### PR TITLE
Lower numpy version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ setup_requires =
     setuptools_scm
 
 install_requires =
-    numpy>=1.19
+    numpy>=1.17
     astropy
 
 package_dir =


### PR DESCRIPTION
`astropy` requires `numpy>=1.17`. This PR brings `numpy` minimum version requirement to `astropy` level. Of course we cannot do that if the code here is using `numpy` features available in let's say `numpy>=1.18`.

CC: @nden @jdavies-st 