### PR TITLE
JP-1950: Bug fix for DQ flags

### DIFF
--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -861,8 +861,7 @@ def ramp_fit_slopes(input_model, gain_2d, readnoise_2d, save_opt, weighting):
                 rhi = cubeshape[1]
 
             # Skip data section if it is all NaNs
-            # data_sect = np.float32(data[num_int, :, :, :])
-            data_sect = data[num_int, :, :, :]
+            data_sect = np.float32(data[num_int, :, :, :])
             if np.all(np.isnan(data_sect)):
                 log.error('Current data section is all nans, so not processing the section.')
                 continue
@@ -903,7 +902,8 @@ def ramp_fit_slopes(input_model, gain_2d, readnoise_2d, save_opt, weighting):
                 #   to shift all the indices down by 1, so they line up with the
                 #   indices in first_diffs.
                 i_group, i_yy, i_xx, = np.where(np.bitwise_and(gdq_sect[1:, :, :], JUMP_DET))
-                first_diffs_sect[i_group - 1, i_yy, i_xx] = np.NaN
+                # first_diffs_sect[i_group - 1, i_yy, i_xx] = np.NaN
+                first_diffs_sect[i_group, i_yy, i_xx] = np.NaN
 
                 del i_group, i_yy, i_xx
 
@@ -1597,10 +1597,8 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
     err_2d_array = data_sect[0, :, :] * frame_time
 
     # Suppress, then re-enable, harmless arithmetic warnings
-    '''
     warnings.filterwarnings("ignore", ".*invalid value.*", RuntimeWarning)
     warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
-    '''
     err_2d_array[err_2d_array < 0] = 0
     warnings.resetwarnings()
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1101,12 +1101,9 @@ def reset_bad_gain(pdq, gain):
         for pixels in the gain array that are either non-positive or NaN., 2-D
         flag
     """
-    '''
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "invalid value.*", RuntimeWarning)
         wh_g = np.where(gain <= 0.)
-    '''
-    wh_g = np.where(gain <= 0.)
     if len(wh_g[0]) > 0:
         pdq[wh_g] = np.bitwise_or(pdq[wh_g], NO_GAIN_VALUE)
         pdq[wh_g] = np.bitwise_or(pdq[wh_g], DO_NOT_USE)


### PR DESCRIPTION
The primary purpose of this PR is to fix the computation of the median of the first differences of a ramp.  Because there is one less difference than there are groups a "shift" is needed to make sure the correct data quality flag is applied.  This "shifting" was incorrectly done twice, when it should have only been done once.