### PR TITLE
Add pypi publish workflow and fix jwst CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '*.x'
     tags:
       - '*'
   pull_request:
@@ -30,11 +31,6 @@ jobs:
             runs-on: ubuntu-latest
             python-version: 3.9
             toxenv: py39
-
-          - name: Python 3.8
-            runs-on: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38
 
           - name: Coverage
             runs-on: ubuntu-latest
@@ -73,61 +69,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Upgrade pip
-        run: |
-          python -m pip install --upgrade pip
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}-${{ hashFiles('**/requirements-sdp.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Get CRDS context
-        id: crds-context
-        run: |
-          pip install crds
-          echo "::set-output name=pmap::$(crds list --resolve-contexts --contexts | cut -f 1 -d ".")"
-
-      - name: Restore CRDS cache
-        uses: actions/cache@v2
-        with:
-          path: ~/crds_cache
-          key: crds-${{ matrix.toxenv }}-${{ steps.crds-context.outputs.pmap }}
-
       - name: Install tox
         run: |
           pip install tox
       - name: Run tox
         run: tox -e ${{ matrix.toxenv }}
-
-  # Kept in a separate job because it needs extra system dependencies
-  # that can't be installed by tox.
-  # build-docs:
-  #   name: Build documentation and check warnings
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Install system packages
-  #       run: |
-  #         sudo apt-get install graphviz texlive-latex-extra dvipng
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Set up Python 3.8
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.8
-  #     - name: Install tox
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install tox
-  #     - name: Run tox
-  #       run: tox -e build-docs

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+      name: Publish release to PyPI
+      env:
+        PYPI_USERNAME_STSCI_MAINTAINER: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
+        PYPI_PASSWORD_STSCI_MAINTAINER: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
+        PYPI_USERNAME_OVERRIDE: ${{ secrets.PYPI_USERNAME_OVERRIDE }}
+        PYPI_PASSWORD_OVERRIDE: ${{ secrets.PYPI_PASSWORD_OVERRIDE }}
+        PYPI_TEST: ${{ secrets.PYPI_TEST }}
+        INDEX_URL_OVERRIDE: ${{ secrets.INDEX_URL_OVERRIDE }}
+      runs-on: ubuntu-latest
+      steps:
+
+          # Check out the commit containing this workflow file.
+          - name: checkout repo
+            uses: actions/checkout@v2
+
+          - name: custom action
+            uses: spacetelescope/action-publish_to_pypi@master
+            id: custom_action_0

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,12 @@ usedevelop= true
 extras=
     test
 
-# astropy will complain if the home directory is missing
-passenv= HOME
+passenv =
+    TOXENV
+    CI
+    CODECOV_*
+    HOME
+    CRDS_*
 
 commands=
     pytest
@@ -46,16 +50,13 @@ extras= docs
 commands=
     sphinx-build -W docs/source build/docs
 
-#[testenv:jwst]
-#changedir = {homedir}
-#setenv =
-#    JPL_EPHEMERIS = jwst
-#    CRDS_CONTEXT = jwst-edit
-#deps=
-#    asdf
-#    jwst[test, ephem] @ git+https://github.com/spacetelescope/jwst
-#commands=
-#    pytest --pyargs {posargs:jwst}
+[testenv:jwst]
+changedir = {homedir}
+usedevelop = false
+deps=
+    jwst[test] @ git+https://github.com/spacetelescope/jwst
+commands=
+    pytest --pyargs {posargs:jwst}
 
 [testenv:romancal]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ commands=
     coverage run --source=stcal -m pytest
     coverage report -m
     codecov -e TOXENV
-passenv= TOXENV CI TRAVIS TRAVIS_* CODECOV_* DISPLAY HOME CRDS_*
 
 [testenv:bandit]
 deps=
@@ -62,4 +61,4 @@ commands=
 deps=
     romancal[test] @ git+https://github.com/spacetelescope/romancal
 commands=
-    pytest --pyargs romancal.datamodels
+    pytest --pyargs romancal


### PR DESCRIPTION
Fixes #20 
Fixes #18 
Fixes #3 

The `py38` and `coverage` tests were doing the same thing except one was reporting coverage, so I removed `py38` matrix element in the workflow.  Coverage still needs to be fixed, as we should be checking coverage based on running the `jwst` and `romancal` tests.  Issue filed.