### PR TITLE
Al-522: Adding a DQ flags parameter to `ramp_fit` to make them pipeline indepedent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ ramp_fitting
 ------------
 
 - Added ramp fitting code [#6]
+- Added DQ flag parameter to `ramp_fit` [#25]
 
 
 0.1.0 (2021-03-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.2.2 (Unreleased)
+==================
+
+ramp_fitting
+------------
+
+- Added DQ flag parameter to `ramp_fit` [#25]
+
+
 0.2.1 (2021-05-20)
 ==================
 
@@ -14,7 +23,6 @@ ramp_fitting
 ------------
 
 - Added ramp fitting code [#6]
-- Added DQ flag parameter to `ramp_fit` [#25]
 
 
 0.1.0 (2021-03-19)

--- a/src/stcal/ramp_fitting/constants.py
+++ b/src/stcal/ramp_fitting/constants.py
@@ -5,3 +5,10 @@ dqflags = {
     "NO_GAIN_VALUE": None,
     "UNRELIABLE_SLOPE": None,
 }
+
+def update_dqflags(input_flags):
+    dqflags["DO_NOT_USE"] = input_flags["DO_NOT_USE"]
+    dqflags["SATURATED"] = input_flags["SATURATED"]
+    dqflags["JUMP_DET"] = input_flags["JUMP_DET"]
+    dqflags["NO_GAIN_VALUE"] = input_flags["NO_GAIN_VALUE"]
+    dqflags["UNRELIABLE_SLOPE"] = input_flags["UNRELIABLE_SLOPE"]

--- a/src/stcal/ramp_fitting/constants.py
+++ b/src/stcal/ramp_fitting/constants.py
@@ -1,5 +1,7 @@
-DO_NOT_USE = 2**0           # Bad pixel. Do not use.
-SATURATED = 2**1            # Pixel saturated during exposure.
-JUMP_DET = 2**2             # Jump detected during exposure
-NO_GAIN_VALUE = 2**19       # Gain cannot be measured
-UNRELIABLE_SLOPE = 2**24    # Slope variance large (i.e., noisy pixel)
+dqflags = {
+    "DO_NOT_USE": None,
+    "SATURATED": None,
+    "JUMP_DET": None,
+    "NO_GAIN_VALUE": None,
+    "UNRELIABLE_SLOPE": None,
+}

--- a/src/stcal/ramp_fitting/constants.py
+++ b/src/stcal/ramp_fitting/constants.py
@@ -6,6 +6,7 @@ dqflags = {
     "UNRELIABLE_SLOPE": None,
 }
 
+
 def update_dqflags(input_flags):
     dqflags["DO_NOT_USE"] = input_flags["DO_NOT_USE"]
     dqflags["SATURATED"] = input_flags["SATURATED"]

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -69,7 +69,7 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
         (Hyper Threading for Intel).
 
     dqflags: dict
-        A dictionary with at least the following keywords: 
+        A dictionary with at least the following keywords:
         DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, UNRELIABLE_SLOPE
 
     Returns

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -90,7 +90,7 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
 
     constants.update_dqflags(dqflags)
     if None in constants.dqflags.values():
-        raise ValueError
+        raise ValueError("Some of the DQ flags required for ramp_fitting are None.")
 
     if algorithm.upper() == "GLS":
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -68,6 +68,10 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
         to use for multi-proc. The total number of cores includes the SMT cores
         (Hyper Threading for Intel).
 
+    dqflags: dict
+        A dictionary with at least the following keywords: 
+        DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, UNRELIABLE_SLOPE
+
     Returns
     -------
     image_info: tuple

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -16,6 +16,7 @@
 import numpy as np
 import logging
 
+from . import constants
 # from . import gls_fit           # used only if algorithm is "GLS"
 from . import ols_fit           # used only if algorithm is "OLS"
 
@@ -26,7 +27,7 @@ BUFSIZE = 1024 * 300000  # 300Mb cache size for data section
 
 
 def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
-             algorithm, weighting, max_cores):
+             algorithm, weighting, max_cores, dqflags):
     """
     Calculate the count rate for each pixel in all data cube sections and all
     integrations, equal to the slope for all sections (intervals between
@@ -82,6 +83,12 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
         Object containing optional GLS-specific ramp fitting data for the
         exposure
     """
+    constants.dqflags["DO_NOT_USE"] = dqflags["DO_NOT_USE"]
+    constants.dqflags["SATURATED"] = dqflags["SATURATED"]
+    constants.dqflags["JUMP_DET"] = dqflags["JUMP_DET"]
+    constants.dqflags["NO_GAIN_VALUE"] = dqflags["NO_GAIN_VALUE"]
+    constants.dqflags["UNRELIABLE_SLOPE"] = dqflags["UNRELIABLE_SLOPE"]
+
     if algorithm.upper() == "GLS":
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # !!!!! Reference to ReadModel and GainModel changed to simple ndarrays !!!!!

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -87,11 +87,10 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
         Object containing optional GLS-specific ramp fitting data for the
         exposure
     """
-    constants.dqflags["DO_NOT_USE"] = dqflags["DO_NOT_USE"]
-    constants.dqflags["SATURATED"] = dqflags["SATURATED"]
-    constants.dqflags["JUMP_DET"] = dqflags["JUMP_DET"]
-    constants.dqflags["NO_GAIN_VALUE"] = dqflags["NO_GAIN_VALUE"]
-    constants.dqflags["UNRELIABLE_SLOPE"] = dqflags["UNRELIABLE_SLOPE"]
+
+    constants.update_dqflags(dqflags)
+    if None in constants.dqflags.values():
+        raise ValueError
 
     if algorithm.upper() == "GLS":
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
The DQ flags were originally defined in the JWST pipeline and defined globally.  The move to STCAL for ramp fitting to be used by multiple pipelines, there is a possibility the flags could be different.  To accommodate for this, DQ flags are now passed as a parameter to `ramp_fit` as a dictionary with five required keywords. 