### PR TITLE
Adds support for roman ramp data

### DIFF
--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -46,16 +46,8 @@ def create_ramp_fit_class(model, dqflags=None):
     """
     ramp_data = ramp_fit_class.RampData()
 
-    ramp_data.set_arrays(
-        model.data, model.err, model.groupdq, model.pixeldq, model.int_times)
-
-    ramp_data.set_meta(
-        name=model.meta.instrument.name,
-        frame_time=model.meta.exposure.frame_time,
-        group_time=model.meta.exposure.group_time,
-        groupgap=model.meta.exposure.groupgap,
-        nframes=model.meta.exposure.nframes,
-        drop_frames1=model.meta.exposure.drop_frames1)
+    ramp_data.set_arrays(model)
+    ramp_data.set_meta(model)
 
     ramp_data.set_dqflags(dqflags)
 

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -26,75 +26,69 @@ class RampData:
         self.flags_no_gain_val = None
         self.flags_unreliable_slope = None
 
-    def set_arrays(self, data, err, groupdq, pixeldq, int_times):
+    def set_arrays(self, model):
         """
         Set the arrays needed for ramp fitting.
 
-        Parameter
-        ---------
-        data : ndarray
-            4-D array containing the pixel information.  It has dimensions
+        Sets the following arrays:
+        data : 4-D array containing the pixel information.  It has dimensions
             (nintegrations, ngroups, nrows, ncols)
 
-        err : ndarray
-            4-D array containing the error information.  It has dimensions
+        err : 4-D array containing the error information.  It has dimensions
             (nintegrations, ngroups, nrows, ncols)
 
-        groupdq : ndarray (uint16)
-            4-D array containing the data quality flags.  It has dimensions
+        groupdq :4-D array containing the data quality flags.  It has dimensions
             (nintegrations, ngroups, nrows, ncols)
 
-        pixeldq : ndarray (uint32)
-            4-D array containing the pixel data quality information.  It has dimensions
+        pixeldq : 4-D array containing the pixel data quality information.  It has dimensions
             (nintegrations, ngroups, nrows, ncols)
 
         int_times : list
-            Time information for each integration.
+            Time information for each integration (only JWST).
+
+
+        Parameters
+        ----------
+        model : Data model
+            JWST or Roman Ramp Model
+
         """
         # Get arrays from the data model
-        self.data = data
-        self.err = err
-        self.groupdq = groupdq
-        self.pixeldq = pixeldq
-        self.int_times = int_times
+        self.data = model.data
+        self.err = model.err
+        self.groupdq = model.groupdq
+        self.pixeldq = model.pixeldq
+        if hasattr(model, 'int_times'):
+            self.int_times = model.int_times
 
-    def set_meta(self, name, frame_time, group_time, groupgap,
-                 nframes, drop_frames1=None):
+    def set_meta(self, model):
         """
-        Set the metainformation needed for ramp fitting.
+        Set the meta information needed for ramp fitting.
 
-        Parameter
-        ---------
-        name : str
-            The instrument name.
+        name: The instrument name.
+        frame_time: The time to read one frame.
+        group_time: The time to read one group.
+        groupgap: The number of frames that are not included in the group average
+        nframes: The number of frames that are included in the group average
+        drop_frames1: The number of frames dropped at the beginning of every integration.
+                      May not be used in some pipelines, so is defaulted to NoneType.
 
-        frame_time : float32
-            The time to read one frame.
-
-        group_time : float32
-            The time to read one group.
-
-        groupgap : int
-            The number of frames that are not included in the group average
-
-        nframes : int
-            The number of frames that are included in the group average
-
-        drop_frames1 :
-            The number of frames dropped at the beginning of every integration.
-            May not be used in some pipelines, so is defaulted to NoneType.
-        """
-
+        Parameters
+        ----------
+        model : Data model
+            JWST or ROman Ramp Model
+        """       
         # Get meta information
-        self.instrument_name = name
+        self.instrument_name = model.meta.instrument.name
 
-        self.frame_time = frame_time
-        self.group_time = group_time
-        self.groupgap = groupgap
-        self.nframes = nframes
+        self.frame_time = meta.exposure.frame_time
+        self.group_time = meta.exposure.group_time
+        self.groupgap = model.meta.exposure.groupgap
+        self.nframes = model.meta.exposure.nframes
 
         # May not be available for all pipelines, so is defaulted to NoneType.
-        self.drop_frames1 = drop_frames1
+        if hasattr(model, 'drop_frames1'):
+            self.drop_frames1 = drop_frames1
 
     def set_dqflags(self, dqflags):
         """


### PR DESCRIPTION
The Roman `RampModel` is missing `meta.exposure.drop_frames1` and `model.int_times`. 
This adds a check that those attributes exist before attempting to access them.