### PR TITLE
updating change log for 0.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
-0.4.0(unreleased)
+0.4.0(2021-10-13)
 ==================
+
+jump_detection
+--------------
+
+- Fix issue with flagging for MIRI three and four group integrations. (#44)
 
 linearity
 ---------
@@ -27,11 +32,6 @@ ramp_fitting
 ==================
 
 Workaround for setuptools_scm issues with recent versions of pip. [#45]
-
-
-jump_detection
---------------
-- Fix issue with flagging for MIRI three and four group integrations. (#44)
 
 
 0.2.3 (2021-08-06)


### PR DESCRIPTION
updated current section to 0.4.0, and moved an item to the current release that was mistakenly in the wrong section. 