### PR TITLE
Check linearity coefficients for zero linear terms JP-2311

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,6 @@ linearity
 ---------
 - Let software set the pixel dq flag to NO_LIN_CORR if linear term of linearity coefficient is zero. [#65]
 
-
 ramp_fitting
 ------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
+
 0.4.3 (unreleased)
 ==================
+
+linearity
+---------
+- Let software set the pixel dq flag to NO_LIN_CORR if linear term of linearity coefficient is zero. [#65]
+
 
 ramp_fitting
 ------------
@@ -8,6 +14,7 @@ ramp_fitting
 
 - Fix issue with inappropriately including a flagged group at the beginning
   of a ramp segment. [#68]
+
 
 0.4.2 (2021-10-28)
 ==================

--- a/src/stcal/linearity/linearity.py
+++ b/src/stcal/linearity/linearity.py
@@ -164,7 +164,7 @@ def correct_for_zero(lin_coeffs, pixeldq, dqflags):
     lin_dq_array = np.zeros((lin_coeffs.shape[1], lin_coeffs.shape[2]),
                             dtype=np.uint32)
 
-    # If there are linearity linear term equal to  zero all th as the correction coefficients, update those
+    # If there are linearity linear term equal to zero all th as the correction coefficients, update those
     # coefficients so that those SCI values will be unchanged.
     if len(yzero) > 0:
         ben_cor = ben_coeffs(lin_coeffs)  # get benign coefficients

--- a/src/stcal/linearity/linearity.py
+++ b/src/stcal/linearity/linearity.py
@@ -86,7 +86,6 @@ def linearity_correction(data, gdq, pdq, lin_coeffs, lin_dq, dqflags):
             data[ints, plane, :, :] = \
                 np.where(np.bitwise_and(gdq[ints, plane, :, :], dqflags['SATURATED']),
                          data[ints, plane, :, :], scorr)
-    
     return data, new_pdq
 
 
@@ -159,13 +158,11 @@ def correct_for_zero(lin_coeffs, pixeldq, dqflags):
 
     # The critcal coefficient that should not be zero is the linear term other terms are fine to be zero
     linear_term = lin_coeffs[1,:,:]
-    
     wh_zero = np.where(linear_term == 0)
     yzero, xzero = wh_zero[0], wh_zero[1]
     num_zero = 0
-
     lin_dq_array = np.zeros((lin_coeffs.shape[1], lin_coeffs.shape[2]),
-                         dtype=np.uint32)
+                            dtype=np.uint32)
 
     # If there are linearity linear term equal to  zero all th as the correction coefficients, update those
     # coefficients so that those SCI values will be unchanged.

--- a/src/stcal/linearity/linearity.py
+++ b/src/stcal/linearity/linearity.py
@@ -164,8 +164,7 @@ def correct_for_zero(lin_coeffs, pixeldq, dqflags):
     lin_dq_array = np.zeros((lin_coeffs.shape[1], lin_coeffs.shape[2]),
                             dtype=np.uint32)
 
-    # If there are linearity linear term equal to zero all th as the correction coefficients, update those
-    # coefficients so that those SCI values will be unchanged.
+    # If there are linearity linear term equal to zero, update the coefficients so the SCI values will be unchanged.
     if len(yzero) > 0:
         ben_cor = ben_coeffs(lin_coeffs)  # get benign coefficients
         num_zero = len(yzero)

--- a/src/stcal/linearity/linearity.py
+++ b/src/stcal/linearity/linearity.py
@@ -164,7 +164,8 @@ def correct_for_zero(lin_coeffs, pixeldq, dqflags):
     lin_dq_array = np.zeros((lin_coeffs.shape[1], lin_coeffs.shape[2]),
                             dtype=np.uint32)
 
-    # If there are linearity linear term equal to zero, update the coefficients so the SCI values will be unchanged.
+    # If there are linearity linear term equal to zero,
+    # update the coefficients so the SCI values will be unchanged.
     if len(yzero) > 0:
         ben_cor = ben_coeffs(lin_coeffs)  # get benign coefficients
         num_zero = len(yzero)

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -46,7 +46,7 @@ def test_coeff_dq():
     lin_coeffs[:, 30, 50] = coeffs
     lin_coeffs[:, 35, 36] = coeffs
     lin_coeffs[:, 35, 35] = coeffs
-    
+
     lin_dq = np.zeros((ysize, xsize), dtype=np.uint32)
 
     # check behavior with NaN coefficients: should not alter pixel values

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -41,8 +41,8 @@ def test_coeff_dq():
     L4 = 7.23E-16
 
     coeffs = np.asfarray([L0, L1, L2, L3, L4])
-    lin_coeffs[1, :, :] = 1 # linearity term should not be zero
-    
+    lin_coeffs[1, :, :] = 1  # linearity term should not be zero
+
     lin_coeffs[:, 30, 50] = coeffs
     lin_dq = np.zeros((ysize, xsize), dtype=np.uint32)
 
@@ -53,9 +53,9 @@ def test_coeff_dq():
     data[0, 50, 20, 50] = 500.0
 
     # test case where all coefficients are zero
-    lin_coeffs[:, 25, 25] = 0 
+    lin_coeffs[:, 25, 25] = 0.0
     data[0, 50, 25, 25] = 600.0
-    
+
     tgroup = 2.775
 
     # set pixel values (DN) for specific pixels up the ramp
@@ -86,7 +86,7 @@ def test_coeff_dq():
     assert(np.isclose(output_data[0, 45, 30, 50], outval, rtol=0.00001))
 
     # check that dq value was handled correctly
-    
+
     assert output_pdq[35, 35] == DQFLAGS['DO_NOT_USE']
     assert output_pdq[35, 36] == DQFLAGS['NO_LIN_CORR']
     # NO_LIN_CORR, sci value should not change

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -41,9 +41,12 @@ def test_coeff_dq():
     L4 = 7.23E-16
 
     coeffs = np.asfarray([L0, L1, L2, L3, L4])
-    lin_coeffs[1, :, :] = 1  # linearity term should not be zero
 
+    # pixels we are testing using above coefficients
     lin_coeffs[:, 30, 50] = coeffs
+    lin_coeffs[:, 35, 36] = coeffs
+    lin_coeffs[:, 35, 35] = coeffs
+    
     lin_dq = np.zeros((ysize, xsize), dtype=np.uint32)
 
     # check behavior with NaN coefficients: should not alter pixel values

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -41,14 +41,21 @@ def test_coeff_dq():
     L4 = 7.23E-16
 
     coeffs = np.asfarray([L0, L1, L2, L3, L4])
+    lin_coeffs[1, :, :] = 1 # linearity term should not be zero
+    
     lin_coeffs[:, 30, 50] = coeffs
     lin_dq = np.zeros((ysize, xsize), dtype=np.uint32)
 
     # check behavior with NaN coefficients: should not alter pixel values
     coeffs2 = np.asfarray([L0, np.nan, L2, L3, L4])
+
     lin_coeffs[:, 20, 50] = coeffs2
     data[0, 50, 20, 50] = 500.0
 
+    # test case where all coefficients are zero
+    lin_coeffs[:, 25, 25] = 0 
+    data[0, 50, 25, 25] = 600.0
+    
     tgroup = 2.775
 
     # set pixel values (DN) for specific pixels up the ramp
@@ -79,9 +86,12 @@ def test_coeff_dq():
     assert(np.isclose(output_data[0, 45, 30, 50], outval, rtol=0.00001))
 
     # check that dq value was handled correctly
+    
     assert output_pdq[35, 35] == DQFLAGS['DO_NOT_USE']
     assert output_pdq[35, 36] == DQFLAGS['NO_LIN_CORR']
     # NO_LIN_CORR, sci value should not change
     assert output_data[0, 30, 35, 36] == 35
     # NaN coefficient should not change data value
     assert output_data[0, 50, 20, 50] == 500.0
+    # dq for pixel with all zero lin coeffs should be NO_LIN_CORR
+    assert output_pdq[25, 25] == DQFLAGS['NO_LIN_CORR']


### PR DESCRIPTION
If the linear term of the linearity coefficients = 0, then the correction wipes out the linearity corrected data. This PR puts in a check if the linear term = 0 (usually all the linearity coefficients = 0  in this case, but the most important one to check is the linear term) and sets the linearity corrections to values that do not change the data linear term = 1 all other terms = 0 and the DQ flag is set to NO_LIN_CORR.

Fixes [JP-2311](https://jira.stsci.edu/browse/JP-2311)