### PR TITLE
JP-2326: Incorrectly includes a DO_NOT_USE flagged group at beginning of segment

### DIFF
--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -961,7 +961,7 @@ def ramp_fit_slopes(ramp_data, gain_2d, readnoise_2d, save_opt, weighting):
             # final slopes, sigmas, etc. for the main (non-optional) products
             t_dq_cube, inv_var, opt_res, f_max_seg, num_seg = \
                 calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
-                           gain_sect, max_seg, ngroups, weighting, f_max_seg)
+                           gain_sect, max_seg, ngroups, weighting, f_max_seg, ramp_data)
 
             del gain_sect
 
@@ -1168,10 +1168,10 @@ def ramp_fit_compute_variances(ramp_data, gain_2d, readnoise_2d, fit_slopes_ans)
         # Huge variances correspond to non-existing segments, so are reset to 0
         #  to nullify their contribution.
         var_p3[var_p3 > 0.1 * utils.LARGE_VARIANCE] = 0.
-        var_p3[:, med_rates <= 0.] = 0.  # XXX JP-2293
+        var_p3[:, med_rates <= 0.] = 0.
         warnings.resetwarnings()
 
-        var_p4[num_int, :, med_rates <= 0.] = 0.  # XXX JP-2293
+        var_p4[num_int, :, med_rates <= 0.] = 0.
         var_both4[num_int, :, :, :] = var_r4[num_int, :, :, :] + var_p4[num_int, :, :, :]
         inv_var_both4[num_int, :, :, :] = 1. / var_both4[num_int, :, :, :]
 
@@ -1330,6 +1330,9 @@ def ramp_fit_overall(
     slope_dataset2[np.isnan(slope_dataset2)] = 0.
 
     # Compute the integration-specific slope
+    print("-" * 80)
+    print(f"opt_res.slope_seg = \n{opt_res.slope_seg[:, :, 0, 0]}")
+    print("-" * 80)
     the_num = (opt_res.slope_seg * inv_var_both4).sum(axis=1)
 
     the_den = (inv_var_both4).sum(axis=1)
@@ -1455,7 +1458,7 @@ def ramp_fit_overall(
     # Some contributions to these vars may be NaN as they are from ramps
     # having PIXELDQ=DO_NOT_USE
     var_p2[np.isnan(var_p2)] = 0.
-    var_p2[med_rates <= 0.0] = 0.  # XXX JP-2293
+    var_p2[med_rates <= 0.0] = 0.
     var_r2[np.isnan(var_r2)] = 0.
 
     # Suppress, then re-enable, harmless arithmetic warning
@@ -1530,7 +1533,7 @@ def interpolate_power(snr):
 
 
 def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
-               gain_sect, i_max_seg, ngroups, weighting, f_max_seg):
+               gain_sect, i_max_seg, ngroups, weighting, f_max_seg, ramp_data):
     """
     Compute the slope of each segment for each pixel in the data cube section
     for the current integration. Each segment has its slope fit in fit_lines();
@@ -1694,6 +1697,18 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
              & (arange_ngroups_col < (end_st[end_heads[all_pix] - 1, all_pix] + 1)))
 
         mask_2d[gdq_sect_r != 0] = False  # RE-exclude bad group dq values
+
+        # Find CRs in the ramp.
+        jump_det = ramp_data.flags_jump_det
+        mask_2d_jump = mask_2d.copy()
+        wh_jump = np.where(gdq_sect_r == jump_det)
+        mask_2d_jump[wh_jump] = True
+
+        # Add back possible CRs at the beginning of a ramp that were excluded
+        # above.
+        wh_mask_2d = np.where(mask_2d)
+        mask_2d[np.maximum(wh_mask_2d[0] - 1, 0), wh_mask_2d[1]] = True
+        mask_2d = mask_2d & mask_2d_jump
 
         # for all pixels, update arrays, summing slope and variance
         f_max_seg, num_seg = \
@@ -2736,10 +2751,6 @@ def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting):
     #   the first channel, and will not propagate beyond this current function
     #   call.
     c_mask_2d = mask_2d.copy()
-    wh_mask_2d = np.where(c_mask_2d)
-    c_mask_2d[np.maximum(wh_mask_2d[0] - 1, 0), wh_mask_2d[1]] = True
-
-    del wh_mask_2d
 
     # num of reads/pixel unmasked
     nreads_1d = c_mask_2d.astype(np.int16).sum(axis=0)

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1701,7 +1701,6 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
 
         mask_2d[gdq_sect_r != 0] = False  # RE-exclude bad group dq values
 
-        # XXX JP-2326
         # Ensure that the first group to be fit is the cosmic-ray-affected
         #   group, the group previous to each group masked as good is
         #   also masked as good.


### PR DESCRIPTION
Groups flagged at the beginning of a segment were incorrectly assumed to be flagged as a JUMP_DET, so were incorrectly included in the segment.  Further checks were added to include only groups flagged as JUMP_DET.

Fixes issue telescope/jwst/#6445