### PR TITLE
JP-2346: Changed the 2 Group Ramp Special Case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+0.4.3 (unreleased)
+==================
+
+ramp_fitting
+------------
+
+- Fix issue with inappropriately including a flagged group at the beginning
+  of a ramp segment.
+
+
+
 0.4.2 (2021-10-28)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@
 ramp_fitting
 ------------
 
+- Fix special handling for 2 group ramp. [#70]
+
 - Fix issue with inappropriately including a flagged group at the beginning
-  of a ramp segment.
-
-
+  of a ramp segment. [#68]
 
 0.4.2 (2021-10-28)
 ==================

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -21,6 +21,13 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
+# ******************************************************************************
+# XXX - Debugging functions
+import sys; sys.path.insert(0, "/Users/kmacdonald/bin")
+from debug_funcs import *
+# ******************************************************************************
+
+
 def ols_ramp_fit_multi(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, weighting, max_cores):
     """
@@ -1581,7 +1588,7 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
         of all ramps; later used when truncating arrays before output.
 
     remp_data : RampClass
-        The ramp data and metadata, specifically the relevant DQ flags.
+        The ramp data and metadata, specifically the relavent DQ flags.
 
     Returns
     -------
@@ -1722,10 +1729,10 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
         mask_2d = mask_2d & mask_2d_jump
 
         # for all pixels, update arrays, summing slope and variance
-        f_max_seg, num_seg = \
-            fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
-                             mask_2d_init, inv_var, num_seg, opt_res, save_opt, rn_sect,
-                             gain_sect, ngroups, weighting, f_max_seg)
+        f_max_seg, num_seg = fit_next_segment(
+            start, end_st, end_heads, pixel_done, data_sect, mask_2d, mask_2d_init,
+            inv_var, num_seg, opt_res, save_opt, rn_sect, gain_sect, ngroups, weighting,
+            f_max_seg, gdq_sect_r, ramp_data)
 
         if f_max_seg is None:
             f_max_seg = 1
@@ -1738,7 +1745,7 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
 
 def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
                      mask_2d_init, inv_var, num_seg, opt_res, save_opt, rn_sect,
-                     gain_sect, ngroups, weighting, f_max_seg):
+                     gain_sect, ngroups, weighting, f_max_seg, gdq_sect_r, ramp_data):
     """
     Call routine to LS fit masked data for a single segment for all pixels in
     data section. Then categorize each pixel's fitting interval based on
@@ -1821,8 +1828,8 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
 
     # Compute fit quantities for the next segment of all pixels
     # Each returned array below is 1D, for all npix pixels for current segment
-    slope, intercept, variance, sig_intercept, sig_slope = \
-        fit_lines(data_sect, mask_2d, rn_sect, gain_sect, ngroups, weighting)
+    slope, intercept, variance, sig_intercept, sig_slope = fit_lines(
+        data_sect, mask_2d, rn_sect, gain_sect, ngroups, weighting, gdq_sect_r, ramp_data)
 
     end_locs = end_st[end_heads[all_pix] - 1, all_pix]
 
@@ -2707,7 +2714,7 @@ def fit_short_ngroups(
     return 1, num_seg
 
 
-def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting):
+def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting, gdq_sect_r, ramp_data):
     """
     Do linear least squares fit to data cube in this integration for a single
     segment for all pixels.  In addition to applying the mask due to identified
@@ -2779,9 +2786,9 @@ def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting):
 
     if ngroups == 2:  # process all pixels in 2 group/integration dataset
         rn_sect_1d = rn_sect.reshape(npix)
-        slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s = \
-            fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
-                        sig_slope_s, npix, data, c_mask_2d, rn_sect_1d)
+        slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s = fit_2_group(
+            slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s, npix,
+            data, c_mask_2d, rn_sect_1d, gdq_sect_r, ramp_data)
 
         return slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s
 
@@ -3190,8 +3197,101 @@ def fit_1_group(slope_s, intercept_s, variance_s, sig_intercept_s,
     return slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s
 
 
-def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
-                sig_slope_s, npix, data, mask_2d, rn_sect_1d):
+def check_both_groups_good(gdq):
+    """
+    Special case checker for 2 group ramps.  This checks to see if both groups
+    in a two group ramp are good.
+
+    gdq : ndarray
+        The group DQ, 2-D uint8 with dimensions (2, npix), where npix is the
+        number of groups, i.e., npx = nrows * ncols.
+    """
+    # Get each group for every pixel.
+    g0 = gdq[0, :]
+    g1 = gdq[1, :]
+
+    # Mark the pixels with good groups in the zeroth group.
+    group_0_good = np.zeros(g0.shape, dtype=bool)
+    group_0_good[g0 == 0] = True 
+
+    # Mark the pixels with good groups in the first group.
+    group_1_good = np.zeros(g1.shape, dtype=bool)
+    group_1_good[g1 == 0] = True 
+
+    # Mark the pixels with good groups in the both groups.
+    both = group_0_good & group_1_good
+
+    return both
+    
+
+def check_good_0_bad_1(gdq):
+    """
+    Special case checker for 2 group ramps.  This checks to see if group 0 is
+    good, but group 1 is bad, making it effectively a one group ramp.
+
+    gdq : ndarray
+        The group DQ, 2-D uint8 with dimensions (2, npix), where npix is the
+        number of groups, i.e., npx = nrows * ncols.
+    """
+    # Get each group for every pixel.
+    g0 = gdq[0, :]
+    g1 = gdq[1, :]
+
+    # Mark the pixels with good groups in the zeroth group.
+    group_0_good = np.zeros(g0.shape, dtype=bool)
+    group_0_good[g0 == 0] = True 
+
+    # Mark the pixels with bad groups in the first group.
+    group_1_good = np.zeros(g1.shape, dtype=bool)
+    group_1_good[g1 != 0] = True 
+
+    # Mark the pixels with good group 0 and bad group 1.
+    both = group_0_good & group_1_good
+
+    return both
+
+
+def check_bad_0_good_1(gdq, sat):
+    """
+    Special case checker for 2 group ramps.  This checks to see if group 0 is
+    bad, but group 1 is good, making it effectively a one group ramp.
+
+    gdq : ndarray
+        The group DQ, 2-D uint8 with dimensions (2, npix), where npix is the
+        number of groups, i.e., npx = nrows * ncols.
+
+    sat : uint8
+        The group DQ saturation flag.
+    """
+    # Get each group for every pixel.
+    g0 = gdq[0, :]
+    g1 = gdq[1, :]
+
+    # Mark the pixels with bad groups in the zeroeth group.
+    group_0_bad = np.zeros(g0.shape, dtype=bool)
+    group_0_bad[g0 != 0] = True 
+
+    # Mark pixels flagged as saturated in zeroeth group, which means group 1
+    # cannot be a good group.
+    group_0_sat = np.zeros(g0.shape, dtype=np.uint8)
+    group_0_sat = np.bitwise_and(g0, sat)
+    group_0_sat.dtype = bool
+
+    # Mark pixels flagged in the zeroeth group, but not flagged as saturated.
+    group_0_bad_nsat = group_0_bad ^ group_0_sat
+
+    # Mark pixels with good first group.
+    group_1_good = np.zeros(g1.shape, dtype=bool)
+    group_1_good[g1 == 0] = True 
+
+    # Mark the pixels with non-saturated bad zeroeth group and good first group.
+    both = group_0_bad_nsat & group_1_good
+
+    return both
+
+
+def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s,
+                npix, data, mask_2d, rn_sect_1d, gdq_sect_r, ramp_data):
     """
     This function sets the fitting arrays for datasets having only 2 groups
     per integration.
@@ -3217,8 +3317,8 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
     npix : int
         number of pixels in 2d array
 
-    data : float
-        array of values for current data section
+    data : ndarray
+        array of values for current data section, 3-D float
 
     mask_2d : ndarray
         delineates which channels to fit for each pixel, 2-D bool
@@ -3243,45 +3343,19 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
     sig_slope_s : ndarray
         sigma of slopes from fit for data section, 1-D float
     """
-    # For pixels saturated on the first group, overwrite fit values with
-    # benign values to be recalculated later.
-    wh_sat0 = np.where(np.logical_not(mask_2d[0, :]))
+    # XXX JP-2346
+    # There are four cases:
+    # 1. Pixels with two good groups.
+    # 2. Pixels with zero good groups (nothing needs to be done).
+    # 3. Pixels with good 0 group and bad 1 group.
+    # 4. Pixels with bad 0 group and good 1 group.
 
-    if len(wh_sat0[0]) > 0:
-        sat_pix = wh_sat0[0]
-        slope_s[sat_pix] = 0.
-        variance_s[sat_pix] = 0.
-        sig_slope_s[sat_pix] = 0.
-        intercept_s[sat_pix] = 0.
-        sig_intercept_s[sat_pix] = 0.
-    del wh_sat0
+    # Shape data as (ngroups, npix)
+    data_r = data.reshape((2, npix))
 
-    # For pixels saturated on the second group, recalculate the slope as
-    # the value of the SCI data in the first group, which will later be
-    # divided by the group exposure time to give the count rate, and
-    # recalculate the other fit quantities to be benign. Note: these pixels
-    # will already have been handled earlier (for intervals of arbitrary
-    # length) in this function, but are being included here to explicitly
-    # cover all possibilities for pixels in datasets with ngroups=2. Will
-    # later consider refactoring.
-    wh_sat1 = np.where((mask_2d[:, :].sum(axis=0) == 1) & mask_2d[0, :])
-
-    if len(wh_sat1[0]) > 0:
-        data0_slice = data[0, :, :].reshape(npix)
-        slope_s[wh_sat1] = data0_slice[wh_sat1]
-        # set variance non-zero because calling function uses variance=0 to
-        # throw out bad results; this is not bad
-        variance_s[wh_sat1] = 1.
-        sig_slope_s[wh_sat1] = 0.
-        intercept_s[wh_sat1] = 0.
-        sig_intercept_s[wh_sat1] = 0.
-    del wh_sat1
-
-    # For pixels with no saturated values, recalculate the slope as the
-    # difference between the values of the second and first groups (1-based),
-    # which will later be divided by the group exposure time to give the count
-    # rate, and recalculate other fit quantities to be benign.
-    wh_sat_no = np.where(mask_2d[:, :].sum(axis=0) == 2)
+    # Special case 1.  Both groups in ramp are good.
+    both_groups_good = check_both_groups_good(gdq_sect_r)
+    wh_sat_no = np.where(both_groups_good) 
 
     if len(wh_sat_no[0]) > 0:
         data0_slice = data[0, :, :].reshape(npix)
@@ -3294,6 +3368,33 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s,
         variance_s[wh_sat_no] = np.sqrt(2) * rn_sect_1d[wh_sat_no]
 
     del wh_sat_no
+
+    # Special case 3.  Good 0th group, bad 1st group.
+    good_0_bad_1 = check_good_0_bad_1(gdq_sect_r)
+
+    one_group_locs = np.where(good_0_bad_1)
+    if len(one_group_locs[0]) > 0:
+        data0 = data_r[0, :]
+        slope_s[one_group_locs] = data0[one_group_locs]
+
+        # set variance non-zero because calling function uses variance=0 to
+        # throw out bad results; this is not bad
+        variance_s[one_group_locs] = 1.
+    del one_group_locs
+
+    # Special case 4.  Bad 0th group, good 1st group.
+    bad_0_good_1 = check_bad_0_good_1(gdq_sect_r, ramp_data.flags_saturated)
+
+    # one_group_locs = np.where(good_0_bad_1)
+    one_group_locs = np.where(bad_0_good_1)
+    if len(one_group_locs[0]) > 0:
+        data1 = data_r[1, :]
+        slope_s[one_group_locs] = data1[one_group_locs]
+
+        # set variance non-zero because calling function uses variance=0 to
+        # throw out bad results; this is not bad
+        variance_s[one_group_locs] = 1.
+    del one_group_locs
 
     return slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1804,6 +1804,12 @@ def fit_next_segment(start, end_st, end_heads, pixel_done, data_sect, mask_2d,
         fitting ramps in the current data section; later used when truncating
         arrays before output.
 
+    gdq_sect_r : ndarray
+        The section data presented as a 2-D array with dimnsions (ngroups, npix)
+
+    ramp_data : RampData
+        The ramp data needed for processing, specifically flag values.
+
     Returns
     -------
     f_max_seg : int
@@ -2736,6 +2742,12 @@ def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting, gdq_sect_r,
         'optimal' specifies that optimal weighting should be used; currently
         the only weighting supported.
 
+    gdq_sect_r : ndarray
+        The section data presented as a 2-D array with dimnsions (ngroups, npix)
+
+    ramp_data : RampData
+        The ramp data needed for processing, specifically flag values.
+
     Returns
     -------
     Note - all of these pertain to a single segment (hence '_s')
@@ -3339,6 +3351,12 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s,
 
     rn_sect_1d : ndarray
         read noise values for all pixels in data section, 1-D float
+
+    gdq_sect_r : ndarray
+        The section data presented as a 2-D array with dimnsions (ngroups, npix)
+
+    ramp_data : RampData
+        The ramp data needed for processing, specifically flag values.
 
     Returns
     -------

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1581,7 +1581,7 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
         of all ramps; later used when truncating arrays before output.
 
     remp_data : RampClass
-        The ramp data and metadata, specifically the relavent DQ flags.
+        The ramp data and metadata, specifically the relevant DQ flags.
 
     Returns
     -------
@@ -3212,17 +3212,17 @@ def check_both_groups_good(gdq):
 
     # Mark the pixels with good groups in the zeroth group.
     group_0_good = np.zeros(g0.shape, dtype=bool)
-    group_0_good[g0 == 0] = True 
+    group_0_good[g0 == 0] = True
 
     # Mark the pixels with good groups in the first group.
     group_1_good = np.zeros(g1.shape, dtype=bool)
-    group_1_good[g1 == 0] = True 
+    group_1_good[g1 == 0] = True
 
     # Mark the pixels with good groups in the both groups.
     both = group_0_good & group_1_good
 
     return both
-    
+
 
 def check_good_0_bad_1(gdq):
     """
@@ -3246,11 +3246,11 @@ def check_good_0_bad_1(gdq):
 
     # Mark the pixels with good groups in the zeroth group.
     group_0_good = np.zeros(g0.shape, dtype=bool)
-    group_0_good[g0 == 0] = True 
+    group_0_good[g0 == 0] = True
 
     # Mark the pixels with bad groups in the first group.
     group_1_good = np.zeros(g1.shape, dtype=bool)
-    group_1_good[g1 != 0] = True 
+    group_1_good[g1 != 0] = True
 
     # Mark the pixels with good group 0 and bad group 1.
     both = group_0_good & group_1_good
@@ -3283,7 +3283,7 @@ def check_bad_0_good_1(gdq, sat):
 
     # Mark the pixels with bad groups in the zeroeth group.
     group_0_bad = np.zeros(g0.shape, dtype=bool)
-    group_0_bad[g0 != 0] = True 
+    group_0_bad[g0 != 0] = True
 
     # Mark pixels flagged as saturated in zeroeth group, which means group 1
     # cannot be a good group.
@@ -3296,7 +3296,7 @@ def check_bad_0_good_1(gdq, sat):
 
     # Mark pixels with good first group.
     group_1_good = np.zeros(g1.shape, dtype=bool)
-    group_1_good[g1 == 0] = True 
+    group_1_good[g1 == 0] = True
 
     # Mark the pixels with non-saturated bad zeroeth group and good first group.
     both = group_0_bad_nsat & group_1_good
@@ -3362,7 +3362,7 @@ def fit_2_group(slope_s, intercept_s, variance_s, sig_intercept_s, sig_slope_s,
 
     # Special case 1.  Both groups in ramp are good.
     both_groups_good = check_both_groups_good(gdq_sect_r)
-    wh_sat_no = np.where(both_groups_good) 
+    wh_sat_no = np.where(both_groups_good)
     if len(wh_sat_no[0]) > 0:
         data0 = data_r[0, :]
         data1 = data_r[1, :]

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -290,6 +290,79 @@ def test_utils_dq_compress_final():
     assert(not(dq[0, 2] & dqflags["DO_NOT_USE"]))
 
 
+def jp_2326_test_setup():
+    # Set up ramp data
+    ramp = np.array([120.133545, 117.85222, 87.38832, 66.90588,  51.392555,
+                     41.65941,   32.15081,  24.25277, 15.955284, 9.500946])
+    dnu = dqflags["DO_NOT_USE"]
+    dq = np.array([dnu, 0, 0, 0, 0, 0, 0, 0, 0, dnu])
+
+    nints, ngroups, nrows, ncols = 1, len(ramp), 1, 1
+    data = np.zeros((nints, ngroups, nrows, ncols))
+    gdq = np.zeros((nints, ngroups, nrows, ncols), dtype=np.uint8)
+    err = np.zeros((nints, ngroups, nrows, ncols))
+    pdq = np.zeros((nrows, ncols), dtype=np.uint32)
+    int_times = np.zeros((nints,))
+
+    data[0, :, 0, 0] = ramp.copy()
+    gdq[0, :, 0, 0] = dq.copy()
+
+    ramp_data = RampData()
+    ramp_data.set_arrays(
+        data=data, err=err, groupdq=gdq, pixeldq=pdq, int_times=int_times)
+    ramp_data.set_meta(
+        name="MIRI", frame_time=2.77504, group_time=2.77504, groupgap=0,
+        nframes=1, drop_frames1=None)
+    ramp_data.set_dqflags(dqflags)
+
+    # Set up gain and read noise
+    gain = np.ones(shape=(nrows, ncols), dtype=np.float32) * 5.5
+    rnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 1000.
+
+    return ramp_data, gain, rnoise
+
+
+def test_miri_ramp_dnu_at_ramp_beginning():
+    """
+    Tests a MIRI ramp with DO_NOT_USE in the first two groups and last group.
+    This test ensures these groups are properly excluded.
+    """
+    ramp_data, gain, rnoise = jp_2326_test_setup()
+    ramp_data.groupdq[0, 1, 0, 0] = dqflags["DO_NOT_USE"]
+
+    # Run ramp fit on RampData
+    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    slopes1, cube, optional, gls_dummy = ramp_fit_data(
+        ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags)
+
+    s1 = slopes1[0]
+    tol = 1e-6
+    ans = -4.1035075
+
+    assert abs(s1[0, 0] - ans) < tol
+
+
+def test_miri_ramp_dnu_and_jump_at_ramp_beginning():
+    """
+    Tests a MIRI ramp with DO_NOT_USE in the first and last group, with a
+    JUMP_DET in the second group. This test ensures the DO_NOT_USE groups are
+    properly excluded, while the JUMP_DET group is included.
+    """
+    ramp_data, gain, rnoise = jp_2326_test_setup()
+    ramp_data.groupdq[0, 1, 0, 0] = dqflags["JUMP_DET"]
+
+    # Run ramp fit on RampData
+    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    slopes2, cube, optional, gls_dummy = ramp_fit_data(
+        ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags)
+
+    s2 = slopes2[0]
+    tol = 1e-6
+    ans = -4.9032097
+
+    assert abs(s2[0, 0] - ans) < tol
+
+
 # -----------------------------------------------------------------------------
 #                           Set up functions
 

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -438,7 +438,7 @@ def test_2_group_cases():
 
     # Check the outputs
     data, dq, var_poisson, var_rnoise, err = slopes
-    chk_dt = np.array([[ 551.0735, 0., 0., 0., -293.9943, -845.0678, -845.0677]])
+    chk_dt = np.array([[551.0735, 0., 0., 0., -293.9943, -845.0678, -845.0677]])
     chk_dq = np.array([[0, dnu | sat, dnu | sat, sat, 0, 0, sat]])
     chk_vp = np.array([[38.945766, 0., 0., 0., 38.945766, 38.945766, 0.]])
     chk_vr = np.array([[0.420046, 0.420046, 0.420046, 0., 0.420046, 0.420046, 0.420046]])


### PR DESCRIPTION
Changed how `fit_2_group` functions.  It improperly assumed if group 0 was flagged, then the flag was `SATURATED`, which also invalidates group 1.  It is possible for group 0 to be flagged such that group 1 contains valid data to be used during ramp fitting.  Now the function properly uses valid data in group 1, when valid, even if group 0 is flagged with a non-`SATURATED` flag.

A unit test was added to test the various possibilities for a 2 group ramp.  All unit tests in JWST and STCAL pass.

This PR addresses the the following JIRA ticket.
https://jira.stsci.edu/browse/JP-2346