### PR TITLE
WIP fixes to twopoint difference

### DIFF
--- a/src/stcal/jump/new_twopoint_difference.py
+++ b/src/stcal/jump/new_twopoint_difference.py
@@ -19,8 +19,7 @@ HUGE_NUM = np.finfo(np.float32).max
 
 import matplotlib.pyplot as plt
 
-
-def find_crs(data, group_dq, read_noise, normal_rej_thresh,
+def new_find_crs(data, group_dq, read_noise, normal_rej_thresh,
              two_diff_rej_thresh, three_diff_rej_thresh, nframes,
              flag_4_neighbors, max_jump_to_flag_neighbors,
              min_jump_to_flag_neighbors, dqflags):
@@ -157,6 +156,7 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
         ratio = np.abs(first_diffs - median_diffs[:, :, np.newaxis]) /\
             sigma[:, :, np.newaxis]
         ratio3d = np.reshape(ratio, (nrows, ncols, ndiffs))
+        sort_index_ratio = np.argsort(ratio3d)
 
         # Get the group index for each pixel of the largest non-saturated
         # group, assuming the indices are sorted. 2 is subtracted from ngroups
@@ -167,7 +167,7 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
         # Extract from the sorted group indices the index of the largest
         # non-saturated group.
         row, col = np.where(number_sat_groups >= 0)
-        max_index1d = sort_index[row, col, max_value_index[row, col]]
+        max_index1d = sort_index_ratio[row, col, max_value_index[row, col]]
 
         # reshape to a 2-D array :
         max_index1 = np.reshape(max_index1d, (nrows, ncols))
@@ -208,7 +208,7 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
         plt.title(f'first pass, at least one CR found = {is_cr}')
         plt.scatter(range(len(ratio3d.flatten())), ratio3d.flatten())
         plt.ylabel('ratio')
-        plt.scatter(max_index1, max_ratio2d, facecolor='None', edgecolor='r', s=200, label='max ratio, group{max_index1}')
+        plt.scatter(max_index1, max_ratio2d, facecolor='None', edgecolor='r', s=200, label=f'max ratio, group {max_index1}')
         plt.legend()
         plt.axhline(normal_rej_thresh)
         plt.show()
@@ -230,15 +230,16 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
             # cr_mask=0 designates a CR
             pix_cr_mask = np.ones(pix_masked_diffs.shape, dtype=bool)
             number_CRs_found = 1
-            pix_sorted_index = sort_index[all_crs_row[j], all_crs_col[j], :]
+            pix_sorted_index_first_diffs = sort_index[all_crs_row[j], all_crs_col[j], :]
+            pix_sorted_index_ratio = sort_index_ratio[all_crs_row[j], all_crs_col[j], :]
 
             # setting largest diff to be a CR
-            pix_cr_mask[pix_sorted_index[ndiffs - pix_sat_groups - 1]] = 0
+            pix_cr_mask[pix_sorted_index_ratio[ndiffs - pix_sat_groups - 1]] = 0
             new_CR_found = True
 
             plt.title('first CR clipped')
             plt.scatter(range(len(ratio3d.flatten())), ratio3d.flatten())
-            next_idx = pix_sorted_index[ndiffs - pix_sat_groups - 1]
+            next_idx = pix_sorted_index_ratio[ndiffs - pix_sat_groups - 1]
             next_ratio = ratio3d[all_crs_row[j], all_crs_col[j]][next_idx]
             plt.scatter(next_idx, next_ratio, facecolor='None', edgecolor='r', s=200, label=f'max ratio, group {next_idx}')
             plt.legend()
@@ -250,48 +251,52 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
             # you go, stop when only 1 diffs is left.
             last_cr_groups = []
             last_cr_groups.append(next_idx)
-            while new_CR_found and ((ndiffs - number_CRs_found -
-                                    pix_sat_groups) > 1):
+
+            #indicies in original list of first diffs of pixels flagged as CRs, starting with first one clipped
+            indicies_of_CRs = [pix_sorted_index_ratio[ndiffs - pix_sat_groups - 1]] 
+
+            while new_CR_found and ((ndiffs - number_CRs_found - pix_sat_groups) > 1):
                 new_CR_found = False
-                largest_diff = ndiffs - number_CRs_found - pix_sat_groups
+                num_usable_diffs = ndiffs - number_CRs_found - pix_sat_groups
 
-                # For this pixel get a new median difference excluding the
-                # number of CRs found and the number of saturated groups
-                pix_med_diff = get_clipped_median_vector(
-                    ndiffs, number_CRs_found + pix_sat_groups,
-                    pix_masked_diffs, pix_sorted_index)
-
-                # Recalculate the noise and ratio for this pixel now that we
-                # have rejected a CR
+                # create new array of diffs by masking pixels flagged as crs
+                # also this is a bad way to do this so think of a better way
+                new_diffs = pix_masked_diffs[pix_cr_mask]
+                print(len(new_diffs))
+                
+                # For this pixel get a new median difference excluding the number of CRs found and the number of saturated groups
+                pix_med_diff = np.nanmedian(new_diffs)
+                # Recalculate the noise and ratio for this pixel now that we have rejected a CR
                 pix_poisson_noise = np.sqrt(np.abs(pix_med_diff))
-                pix_sigma = np.sqrt(pix_poisson_noise * pix_poisson_noise +
-                                    pix_rn2 / nframes)
-                pix_ratio = np.abs(pix_masked_diffs - pix_med_diff) / pix_sigma
+                pix_sigma = np.sqrt(pix_poisson_noise * pix_poisson_noise + pix_rn2 / nframes)
+                new_pix_ratio = np.abs(new_diffs - pix_med_diff) / pix_sigma
+                new_pix_ratio = new_pix_ratio
+                new_pix_ratio_sort_index = np.argsort(new_pix_ratio)
 
-                rej_thresh = get_rej_thresh(
-                    largest_diff, two_diff_rej_thresh, three_diff_rej_thresh,
-                    normal_rej_thresh)
+                rej_thresh = get_rej_thresh(num_usable_diffs, two_diff_rej_thresh, three_diff_rej_thresh, normal_rej_thresh)
 
                 # Check if largest remaining difference is above threshold
-                if pix_ratio[pix_sorted_index[largest_diff - 1]] > rej_thresh:
+                new_max_ratio = new_pix_ratio[new_pix_ratio_sort_index[num_usable_diffs - 1]]
+
+                if new_max_ratio > rej_thresh:
                     new_CR_found = True
-                    pix_cr_mask[pix_sorted_index[largest_diff - 1]] = 0
+                    pix_cr_mask[new_pix_ratio_sort_index[num_usable_diffs - 1]] = 0
                     number_CRs_found += 1
                     
 
                 plt.title(f'next CR, ratio recomputed. CR found = {new_CR_found}')
-                plt.scatter(range(len(pix_ratio)), pix_ratio)
-                print(len(pix_ratio))
-                plt.scatter(pix_sorted_index[largest_diff - 1], pix_ratio[pix_sorted_index[largest_diff - 1]], facecolor='None', edgecolor='r', s=200, label=f'new max ratio, group {pix_sorted_index[largest_diff - 1]}')
+                plt.scatter(range(len(new_pix_ratio)), new_pix_ratio)
+                
+                plt.scatter(new_pix_ratio_sort_index[num_usable_diffs - 1], new_max_ratio, facecolor='None', edgecolor='r', s=200, label=f'new max ratio, group {new_pix_ratio_sort_index[num_usable_diffs - 1]}')
 
                 for g in last_cr_groups:
-                    plt.scatter(g, pix_ratio[g], c='orange', s=200, marker='x')
+                    plt.scatter(g, new_pix_ratio[g], c='orange', s=200, marker='x')
 
                 plt.axhline(rej_thresh)
                 plt.legend()
                 plt.show()
 
-                last_cr_groups.append(pix_sorted_index[largest_diff - 1])
+                last_cr_groups.append(pix_sorted_index_ratio[num_usable_diffs - 1])
 
             # Found all CRs for this pixel. Set CR flags in input DQ array for
             # this pixel
@@ -410,7 +415,7 @@ def get_clipped_median_array(num_diffs, diffs_to_ignore, input_array,
     pix_med_diff : int, 2D array
         clipped median for the array of first differences
     """
-    pix_med_diff = np.zeros_like(diffs_to_ignore)
+    pix_med_diff = np.zeros_like(diffs_to_ignore, np.float64)
     pix_med_index = np.zeros_like(diffs_to_ignore)
 
     # Process pixels with four or more good differences
@@ -433,7 +438,7 @@ def get_clipped_median_array(num_diffs, diffs_to_ignore, input_array,
     # the two central values.  So we need to get the value the other central
     # difference one lower in the sorted index that the one found above.
     even_group_rows, even_group_cols = \
-        np.where(np.logical_and(num_diffs - diffs_to_ignore - 1 % 2 == 0,
+        np.where(np.logical_and((num_diffs - diffs_to_ignore - 1)% 2 == 0,
                  num_diffs - diffs_to_ignore >= 4))
 
     pix_med_index2 = np.zeros_like(pix_med_index)

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -19,8 +19,7 @@ HUGE_NUM = np.finfo(np.float32).max
 
 import matplotlib.pyplot as plt
 
-
-def find_crs(data, group_dq, read_noise, normal_rej_thresh,
+def new_find_crs(data, group_dq, read_noise, normal_rej_thresh,
              two_diff_rej_thresh, three_diff_rej_thresh, nframes,
              flag_4_neighbors, max_jump_to_flag_neighbors,
              min_jump_to_flag_neighbors, dqflags):
@@ -157,6 +156,7 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
         ratio = np.abs(first_diffs - median_diffs[:, :, np.newaxis]) /\
             sigma[:, :, np.newaxis]
         ratio3d = np.reshape(ratio, (nrows, ncols, ndiffs))
+        sort_index_ratio = np.argsort(ratio3d)
 
         # Get the group index for each pixel of the largest non-saturated
         # group, assuming the indices are sorted. 2 is subtracted from ngroups
@@ -167,7 +167,7 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
         # Extract from the sorted group indices the index of the largest
         # non-saturated group.
         row, col = np.where(number_sat_groups >= 0)
-        max_index1d = sort_index[row, col, max_value_index[row, col]]
+        max_index1d = sort_index_ratio[row, col, max_value_index[row, col]]
 
         # reshape to a 2-D array :
         max_index1 = np.reshape(max_index1d, (nrows, ncols))
@@ -208,7 +208,7 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
         plt.title(f'first pass, at least one CR found = {is_cr}')
         plt.scatter(range(len(ratio3d.flatten())), ratio3d.flatten())
         plt.ylabel('ratio')
-        plt.scatter(max_index1, max_ratio2d, facecolor='None', edgecolor='r', s=200, label='max ratio, group{max_index1}')
+        plt.scatter(max_index1, max_ratio2d, facecolor='None', edgecolor='r', s=200, label=f'max ratio, group {max_index1}')
         plt.legend()
         plt.axhline(normal_rej_thresh)
         plt.show()
@@ -230,15 +230,16 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
             # cr_mask=0 designates a CR
             pix_cr_mask = np.ones(pix_masked_diffs.shape, dtype=bool)
             number_CRs_found = 1
-            pix_sorted_index = sort_index[all_crs_row[j], all_crs_col[j], :]
+            pix_sorted_index_first_diffs = sort_index[all_crs_row[j], all_crs_col[j], :]
+            pix_sorted_index_ratio = sort_index_ratio[all_crs_row[j], all_crs_col[j], :]
 
             # setting largest diff to be a CR
-            pix_cr_mask[pix_sorted_index[ndiffs - pix_sat_groups - 1]] = 0
+            pix_cr_mask[pix_sorted_index_ratio[ndiffs - pix_sat_groups - 1]] = 0
             new_CR_found = True
 
             plt.title('first CR clipped')
             plt.scatter(range(len(ratio3d.flatten())), ratio3d.flatten())
-            next_idx = pix_sorted_index[ndiffs - pix_sat_groups - 1]
+            next_idx = pix_sorted_index_ratio[ndiffs - pix_sat_groups - 1]
             next_ratio = ratio3d[all_crs_row[j], all_crs_col[j]][next_idx]
             plt.scatter(next_idx, next_ratio, facecolor='None', edgecolor='r', s=200, label=f'max ratio, group {next_idx}')
             plt.legend()
@@ -250,48 +251,52 @@ def find_crs(data, group_dq, read_noise, normal_rej_thresh,
             # you go, stop when only 1 diffs is left.
             last_cr_groups = []
             last_cr_groups.append(next_idx)
-            while new_CR_found and ((ndiffs - number_CRs_found -
-                                    pix_sat_groups) > 1):
+
+            #indicies in original list of first diffs of pixels flagged as CRs, starting with first one clipped
+            indicies_of_CRs = [pix_sorted_index_ratio[ndiffs - pix_sat_groups - 1]] 
+
+            while new_CR_found and ((ndiffs - number_CRs_found - pix_sat_groups) > 1):
                 new_CR_found = False
-                largest_diff = ndiffs - number_CRs_found - pix_sat_groups
+                num_usable_diffs = ndiffs - number_CRs_found - pix_sat_groups
 
-                # For this pixel get a new median difference excluding the
-                # number of CRs found and the number of saturated groups
-                pix_med_diff = get_clipped_median_vector(
-                    ndiffs, number_CRs_found + pix_sat_groups,
-                    pix_masked_diffs, pix_sorted_index)
-
-                # Recalculate the noise and ratio for this pixel now that we
-                # have rejected a CR
+                # create new array of diffs by masking pixels flagged as crs
+                # also this is a bad way to do this so think of a better way
+                new_diffs = pix_masked_diffs[pix_cr_mask]
+                print(len(new_diffs))
+                
+                # For this pixel get a new median difference excluding the number of CRs found and the number of saturated groups
+                pix_med_diff = np.nanmedian(new_diffs)
+                # Recalculate the noise and ratio for this pixel now that we have rejected a CR
                 pix_poisson_noise = np.sqrt(np.abs(pix_med_diff))
-                pix_sigma = np.sqrt(pix_poisson_noise * pix_poisson_noise +
-                                    pix_rn2 / nframes)
-                pix_ratio = np.abs(pix_masked_diffs - pix_med_diff) / pix_sigma
+                pix_sigma = np.sqrt(pix_poisson_noise * pix_poisson_noise + pix_rn2 / nframes)
+                new_pix_ratio = np.abs(new_diffs - pix_med_diff) / pix_sigma
+                new_pix_ratio = new_pix_ratio
+                new_pix_ratio_sort_index = np.argsort(new_pix_ratio)
 
-                rej_thresh = get_rej_thresh(
-                    largest_diff, two_diff_rej_thresh, three_diff_rej_thresh,
-                    normal_rej_thresh)
+                rej_thresh = get_rej_thresh(num_usable_diffs, two_diff_rej_thresh, three_diff_rej_thresh, normal_rej_thresh)
 
                 # Check if largest remaining difference is above threshold
-                if pix_ratio[pix_sorted_index[largest_diff - 1]] > rej_thresh:
+                new_max_ratio = new_pix_ratio[new_pix_ratio_sort_index[num_usable_diffs - 1]]
+
+                if new_max_ratio > rej_thresh:
                     new_CR_found = True
-                    pix_cr_mask[pix_sorted_index[largest_diff - 1]] = 0
+                    pix_cr_mask[new_pix_ratio_sort_index[num_usable_diffs - 1]] = 0
                     number_CRs_found += 1
                     
 
                 plt.title(f'next CR, ratio recomputed. CR found = {new_CR_found}')
-                plt.scatter(range(len(pix_ratio)), pix_ratio)
-                print(len(pix_ratio))
-                plt.scatter(pix_sorted_index[largest_diff - 1], pix_ratio[pix_sorted_index[largest_diff - 1]], facecolor='None', edgecolor='r', s=200, label=f'new max ratio, group {pix_sorted_index[largest_diff - 1]}')
+                plt.scatter(range(len(new_pix_ratio)), new_pix_ratio)
+                
+                plt.scatter(new_pix_ratio_sort_index[num_usable_diffs - 1], new_max_ratio, facecolor='None', edgecolor='r', s=200, label=f'new max ratio, group {new_pix_ratio_sort_index[num_usable_diffs - 1]}')
 
                 for g in last_cr_groups:
-                    plt.scatter(g, pix_ratio[g], c='orange', s=200, marker='x')
+                    plt.scatter(g, new_pix_ratio[g], c='orange', s=200, marker='x')
 
                 plt.axhline(rej_thresh)
                 plt.legend()
                 plt.show()
 
-                last_cr_groups.append(pix_sorted_index[largest_diff - 1])
+                last_cr_groups.append(pix_sorted_index_ratio[num_usable_diffs - 1])
 
             # Found all CRs for this pixel. Set CR flags in input DQ array for
             # this pixel
@@ -410,7 +415,7 @@ def get_clipped_median_array(num_diffs, diffs_to_ignore, input_array,
     pix_med_diff : int, 2D array
         clipped median for the array of first differences
     """
-    pix_med_diff = np.zeros_like(diffs_to_ignore)
+    pix_med_diff = np.zeros_like(diffs_to_ignore, np.float64)
     pix_med_index = np.zeros_like(diffs_to_ignore)
 
     # Process pixels with four or more good differences
@@ -433,7 +438,7 @@ def get_clipped_median_array(num_diffs, diffs_to_ignore, input_array,
     # the two central values.  So we need to get the value the other central
     # difference one lower in the sorted index that the one found above.
     even_group_rows, even_group_cols = \
-        np.where(np.logical_and(num_diffs - diffs_to_ignore - 1 % 2 == 0,
+        np.where(np.logical_and((num_diffs - diffs_to_ignore - 1)% 2 == 0,
                  num_diffs - diffs_to_ignore >= 4))
 
     pix_med_index2 = np.zeros_like(pix_med_index)


### PR DESCRIPTION
Several major fixes to the twopoint difference routine in jump detection.

1: According to the description of the algorithm, groups that have a 'difference ratio' larger than the 'threshold' are considered a jump. The code was incorrectly using the 'difference ratio' of the group with the largest positive first difference, rather than just the largest ratio. The largest positive first difference often, but not always, has the largest ratio as well. With this fix, the check for 'is the largest ratio above the threshold?' is now being done as intended.

A note: after the first CR is found and clipped, the same process is applied to all groups in a pixel where another CR is found, clipped, and 'ratio' is recomputed. Previously, even though 'ratio' is recomputed during each iteration, the array that sorts 'positive first diffs' was only computed once before the clipping and the 'ratio' values corresponding to the largest / next largest / so on values in this array were being chosen to look for subsequent CRs. What really should be done is: ratio is recomputed, the largest ratio of this new array is selected for the threshold comparison, and if it's above the threshold the original group corresponding to the index of this largest ratio should be flagged. Figuring out how to do this is what is holding me up right now with this - I am clipping pixels during each iteration, but I need to keep track of what index this corresponds to in the original non-clipped array. 

2. There are two functions that compute the median of first differences (which is used in the calculation of the 'difference ratio' therefore impacts what groups are flagged as jumps). The function 'get_clipped_median_array' is used in the initial check for a jump before iterating to find subsequent jumps. In this function, two issues were fixed. First, the median was incorrectly being rounded to the nearest integer value (e.g a median of -5.25542 became -5), which is now fixed. Second, when there were an even number of elements in the array, the two middle values were not being averaged correctly.

3. There was another issue in both clipped median calculating functions -'get_clipped_median_array' which is used in the initial check for jumps and then 'get_clipped_median_vector' which is used on each pixel after the initial jump is found. Both of these functions claim to calculate the clipped median of 'first differences'. In what I assume is a measure to increase efficiency, np.median is not used but rather since the array that sorts the first differences was already computed before these functions were called, the middle element(s) of this array of indexes is selected and then the 'first differences' array is indexed using these to find the median. There was an error in this - while 'first differences' was being passed to these function as the array to get the median of, the sorting array wasn't actually sorting 'first differences', it was sorting the absolute value of first differences (i.e 'positive first differences'). So, the middle element of this sorting array corresponds to the index containing the median of 'positive first differences', but then it was being used to index 'first differences'. I'm still not actually sure reading the description of the algorithm if the median of 'first differences' or 'positive first differences' should be used - it says verbatim 'Compute the clipped (dropping the largest difference) median of the first differences for each pixel.'. Does 'largest' here mean most positive, in which case it would be 'first differences', or largest in magnitude in which case it would be 'positive first differences'. I'm leaning toward the latter, but the former is what is in the current implementation. 


3. I will note that there is an outstanding issue with flagging jumps in 2-group integrations, but I have reverted that back to its original state and will fix that in another PR later since thats not as pressing.  