### PR TITLE
Changes to jump detection 

### DIFF
--- a/tests/test_twopoint_difference.py
+++ b/tests/test_twopoint_difference.py
@@ -756,3 +756,80 @@ def test_first_last_group(setup_cube):
     assert outgdq[0, 0, 100, 100] == DQFLAGS['DO_NOT_USE']
     assert outgdq[0, 6, 100, 100] == DQFLAGS['DO_NOT_USE']
     assert outgdq[0, 3, 100, 100] == DQFLAGS['JUMP_DET']
+
+
+def test_2group(setup_cube):
+    # test should not find a CR, can't do it with only one difference.
+    ngroups = 2
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=25.0)
+
+    data[0, 0, 0, 0] = 10000.0
+    #  set groups 1,2 - to be around 30,000
+    data[0, 1, 0, 0] = 30000.0
+
+    outgdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                    rej_threshold, rej_threshold, nframes,
+                                                    False, 200, 10, DQFLAGS)
+    assert outgdq[0, 1, 0, 0] == 0
+    assert outgdq[0, 0, 0, 0] == 0
+
+
+def test_4group(setup_cube):
+    ngroups = 4
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=25.0)
+
+    data[0, 0, 0, 0] = 10000.0
+    #  set groups 1,2 - to be around 30,000
+    data[0, 1, 0, 0] = 30000.0
+    data[0, 2, 0, 0] = 30020.0
+    data[0, 3, 0, 0] = 30000.0
+
+    outgdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                    rej_threshold, rej_threshold, nframes,
+                                                    False, 200, 10, DQFLAGS)
+    assert outgdq[0, 1, 0, 0] == 4
+
+
+def test_first_last_4group(setup_cube):
+    ngroups = 4
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=25.0)
+
+    #  set up the data so that if the first and last group are used in jump
+    #  detection it would cause a jump to be detected between group 0-1.
+    data[0, 0, 0, 0] = 10000.0
+    #  set groups 1,2 - to be around 30,000
+    data[0, 1, 0, 0] = 30000.0
+    data[0, 2, 0, 0] = 30020.0
+    data[0, 3, 0, 0] = 30000.0
+    # treat as MIRI data with first and last flagged
+    gdq[0, 0, :, :] = DQFLAGS['DO_NOT_USE']
+    gdq[0, 3, :, :] = DQFLAGS['DO_NOT_USE']
+    outgdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                    rej_threshold, rej_threshold, nframes,
+                                                    False, 200, 10, DQFLAGS)
+
+    assert outgdq[0, 0, 0, 0] == DQFLAGS['DO_NOT_USE']
+    assert outgdq[0, 3, 0, 0] == DQFLAGS['DO_NOT_USE']
+    assert outgdq[0, 1, 0, 0] == 0
+
+
+def test_first_last_3group(setup_cube):
+    ngroups = 3
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=25.0)
+
+    #  set up the data so that if the first and last group are used in jump
+    #  detection it would cause a jump to be detected between group 1-2
+    #  and group 6-7. Add a jump between 3 and 4 just to make sure jump detection is working
+    #  set group 1 to be 10,000
+    data[0, 0, 0, 0] = 10000.0
+    data[0, 1, 0, 0] = 10100.0
+    data[0, 2, 0, 0] = 30020.0
+
+    gdq[0, 2, 0, 0] = DQFLAGS['DO_NOT_USE']  # only flag the last group
+    outgdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                    rej_threshold, rej_threshold, nframes,
+                                                    False, 200, 10, DQFLAGS)
+
+    assert outgdq[0, 0, 0, 0] == 0
+    assert outgdq[0, 2, 0, 0] == DQFLAGS['DO_NOT_USE']
+    assert outgdq[0, 1, 0, 0] == 0


### PR DESCRIPTION
This PR takes the place of #71 with a more final version on a new branch. I will update this description later. 

Several fixes to jump detection including:
1. fixes to the computation of the median that is used to compute jump thresholds
2. fixing an error that was causing the largest difference ratio to be missed when comparing to the threshold to classify jumps, resulting in many jumps being missed
3. restructuring code and adding comments that describe each step
4. fixes an issue with MIRI 3 & 4 group integrations (link PR / issue here)



