### PR TITLE
JP-2071: Added a boolean switch to turn off calculations for one group ramp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.6.1 (unreleased)
+================
+
+ramp_fitting
+------------
+
+- Adding a switch to ramp fitting to suppress ramps with only one
+  good group. [#]
+
 0.6.0 (22-01-14)
 ================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ ramp_fitting
 ------------
 
 - Adding a switch to ramp fitting to suppress ramps with only one
-  good group. [#]
+  good group. [#75]
 
 0.6.0 (22-01-14)
 ================

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -21,17 +21,6 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-# ******************************************************************************
-def print_with_lineo(string):
-    import inspect
-    cf = inspect.currentframe()
-    line_number = cf.f_back.f_lineno
-    print("-" * 80)
-    print(f"[{line_number}] {string}")
-    print("-" * 80)
-# ******************************************************************************
-
-
 def ols_ramp_fit_multi(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, weighting, max_cores):
     """
@@ -1703,15 +1692,6 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
     gdq_sect_r = np.reshape(gdq_sect, (ngroups, npix))
     mask_2d[gdq_sect_r != 0] = False  # saturated or CR-affected
     
-    # XXX JP-2071 - Create a gdq array that has only DO_NOT_USE in group
-    #               locations where a ramp has only one good group.
-    if ramp_data.suppress_one_group_ramps:
-        dnu_mask = calc_one_good_group(mask_2d, ramp_data.flags_do_not_use)
-        gdq_sect_r = gdq_sect_r ^ dnu_mask
-        mask_2d[dnu_mask != 0] = False
-
-    # import sys; sys.exit(1)
-
     mask_2d_init = mask_2d.copy()  # initial flags for entire ramp
 
     wh_f = np.where(np.logical_not(mask_2d))
@@ -1791,8 +1771,6 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
 
     arange_ngroups_col = 0
     all_pix = 0
-
-    # XXX for suppressed one group ramps return GDQ to original.
 
     return gdq_sect, inv_var, opt_res, f_max_seg, num_seg
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1657,7 +1657,7 @@ def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
     # Section of GROUPDQ dq section, excluding bad dq values in mask
     gdq_sect_r = np.reshape(gdq_sect, (ngroups, npix))
     mask_2d[gdq_sect_r != 0] = False  # saturated or CR-affected
-    
+
     mask_2d_init = mask_2d.copy()  # initial flags for entire ramp
 
     wh_f = np.where(np.logical_not(mask_2d))

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1533,40 +1533,6 @@ def interpolate_power(snr):
     return pow_wt.ravel()
 
 
-def calc_one_good_group(mask_2d, dnu):
-    """
-    Computes a DQ mask to turn ramps with one good group into ramps with zero
-    groups.  This will be done by identifying which pixels have only one good
-    group and where that one group is, then creating a DQ array with DO_NOT_USE
-    for those groups.  This will be XOR'd into the group DQ for processing,
-    effectively making these ramps have zero good groups.
-
-    Parameters
-    ----------
-    mask_2d : ndarray
-        This is a 2-D (ngroups, npix) boolean array identifying all good
-        groups.
-
-    Return
-    ------
-    dnu_mask : ndarray
-        This is a 2-D (ngroups, npix) array with DO_NOT_USE at dnu_mask[g, p]
-        where p is a pixel with a ramp having only one good group and g the
-        location of that group.
-    """
-    ngroups, npix = mask_2d.shape
-    one_group = mask_2d.sum(axis=0)
-    dnu_mask = np.zeros((mask_2d.shape), dtype=np.uint32)
-    for pix in range(npix):
-        if one_group[pix] == 1:
-            for group in range(ngroups):
-                if mask_2d[group, pix] == True:
-                    dnu_mask[group, pix] = dnu
-                    break
-
-    return dnu_mask
-
-
 def calc_slope(data_sect, gdq_sect, frame_time, opt_res, save_opt, rn_sect,
                gain_sect, i_max_seg, ngroups, weighting, f_max_seg, ramp_data):
     """

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -144,12 +144,10 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d, algorithm,
         Object containing optional GLS-specific ramp fitting data for the
         exposure
     """
-    if suppress_one_group:
-        log.info("Ramps with one good group suppressed as no good group.")
-        if model.data.shape[1] == 1:
-            # Suppressing one ramp groups and having data with only one group
-            # means there is no work to do.
-            return None, None, None, None
+    if suppress_one_group and model.data.shape[1] == 1:
+        # One group ramp suppression should only be done on data with
+        # ramps having more than one group.
+        suppress_one_group = False
 
     # Create an instance of the internal ramp class, using only values needed
     # for ramp fitting from the to remove further ramp fitting dependence on

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -26,7 +26,6 @@ log.setLevel(logging.DEBUG)
 BUFSIZE = 1024 * 300000  # 300Mb cache size for data section
 
 
-# XXX Possibly change this to add suppressing one group ramps.
 def create_ramp_fit_class(model, dqflags=None):
     """
     Create an internal ramp fit class from a data model.
@@ -142,13 +141,6 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
     # data models.
     ramp_data = create_ramp_fit_class(model, dqflags)
 
-    # XXX 
-    '''
-    ngroups = ramp_data.data.shape[1]
-    if self.suppress_one_group_ramps and ngroups == 1:
-        return all zeros
-    '''
-
     return ramp_fit_data(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,
         algorithm, weighting, max_cores, dqflags)
@@ -225,11 +217,6 @@ def ramp_fit_data(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,
         # Suppress one group ramps, if desired.
         if ramp_data.suppress_one_group_ramps:
             suppress_one_group_ramps(ramp_data)
-
-        print("*" * 80)
-        print(f"ramp_data.groupdq = \n{ramp_data.groupdq[:, :, 0, :]}")
-        print("*" * 80)
-        import sys; sys.exit(1)
 
         # Compute ramp fitting using ordinary least squares.
         image_info, integ_info, opt_info = ols_fit.ols_ramp_fit_multi(

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -146,7 +146,7 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d, algorithm,
     """
     if suppress_one_group:
         log.info("Ramps with one good group suppressed as no good group.")
-        if model.data.shape[2] == 1:
+        if model.data.shape[1] == 1:
             # Suppressing one ramp groups and having data with only one group
             # means there is no work to do.
             return None, None, None, None
@@ -154,7 +154,7 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d, algorithm,
     # Create an instance of the internal ramp class, using only values needed
     # for ramp fitting from the to remove further ramp fitting dependence on
     # data models.
-    ramp_data = create_ramp_fit_class(model, dqflags)
+    ramp_data = create_ramp_fit_class(model, dqflags, suppress_one_group)
 
     return ramp_fit_data(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -253,7 +253,6 @@ def suppress_one_group_ramps(ramp_data):
     """
     dq = ramp_data.groupdq
     nints, ngroups, nrows, ncols = dq.shape
-    npix = nrows * ncols
     for k in range(nints):
         intdq = dq[k, :, :, :]
         good_groups = np.zeros(intdq.shape, dtype=int)

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -272,4 +272,4 @@ def suppress_one_group_ramps(ramp_data):
             c = wh1_cols[n]
             for g in range(ngroups):
                 if intdq[g, r, c] == 0:
-                    intdq[g, r, c] = ramp_data.flags_do_not_use
+                    ramp_data.groupdq[k, g, r, c] = ramp_data.flags_do_not_use

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -244,7 +244,7 @@ def ramp_fit_data(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,
 def suppress_one_group_ramps(ramp_data):
     """
     Finds one group ramps in each integration and suppresses them, i.e. turns
-    the in to zero group ramps.
+    them into zero group ramps.
 
     Parameter
     ---------
@@ -253,6 +253,7 @@ def suppress_one_group_ramps(ramp_data):
     """
     dq = ramp_data.groupdq
     nints, ngroups, nrows, ncols = dq.shape
+
     for k in range(nints):
         intdq = dq[k, :, :, :]
         good_groups = np.zeros(intdq.shape, dtype=int)
@@ -261,14 +262,14 @@ def suppress_one_group_ramps(ramp_data):
         good_groups[intdq == 0] = 1
         ngood_groups = good_groups.sum(axis=0)
 
-        # For each pixel that has only one good group, mark that groups as
+        # For each pixel that has only one good group, mark those groups as
         # DO_NOT_USE, making the ramp effectively zero good groups.
         wh_one = np.where(ngood_groups == 1)
         wh1_rows = wh_one[0]
         wh1_cols = wh_one[1]
-        for k in range(len(wh1_rows)):
-            r = wh1_rows[k]
-            c = wh1_cols[k]
+        for n in range(len(wh1_rows)):
+            r = wh1_rows[n]
+            c = wh1_cols[n]
             for g in range(ngroups):
                 if intdq[g, r, c] == 0:
                     intdq[g, r, c] = ramp_data.flags_do_not_use

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -26,6 +26,7 @@ log.setLevel(logging.DEBUG)
 BUFSIZE = 1024 * 300000  # 300Mb cache size for data section
 
 
+# XXX Possibly change this to add suppressing one group ramps.
 def create_ramp_fit_class(model, dqflags=None):
     """
     Create an internal ramp fit class from a data model.
@@ -69,6 +70,8 @@ def create_ramp_fit_class(model, dqflags=None):
     ramp_data.set_dqflags(dqflags)
     ramp_data.start_row = 0
     ramp_data.num_rows = ramp_data.data.shape[2]
+
+    # XXX self.suppress_one_group_ramps = False
 
     return ramp_data
 
@@ -138,6 +141,13 @@ def ramp_fit(model, buffsize, save_opt, readnoise_2d, gain_2d,
     # for ramp fitting from the to remove further ramp fitting dependence on
     # data models.
     ramp_data = create_ramp_fit_class(model, dqflags)
+
+    # XXX 
+    '''
+    ngroups = ramp_data.data.shape[1]
+    if self.suppress_one_group_ramps and ngroups == 1:
+        return all zeros
+    '''
 
     return ramp_fit_data(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -30,7 +30,6 @@ class RampData:
         self.start_row = None
         self.num_rows = None
 
-        # XXX Optional info
         self.suppress_one_group_ramps = False
 
     def set_arrays(self, data, err, groupdq, pixeldq, int_times):

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -30,6 +30,9 @@ class RampData:
         self.start_row = None
         self.num_rows = None
 
+        # XXX Optional info
+        self.suppress_one_group_ramps = False
+
     def set_arrays(self, data, err, groupdq, pixeldq, int_times):
         """
         Set the arrays needed for ramp fitting.

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -630,6 +630,9 @@ def setup_inputs(dims, var, tm):
 
 # -----------------------------------------------------------------------------
 
+###############################################################################
+# The functions below are only used for DEBUGGING tests and developing tests. #
+###############################################################################
 
 # Main product
 def print_slope_data(slopes):

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -478,8 +478,8 @@ def run_one_group_ramp_suppression(suppress):
     dnu = ramp_data.flags_do_not_use
     dq = [dnu, dnu, 0, dnu, dnu]
 
-    ramp_data.data[0, :, 0, 0] = np.array(arr, dtype=float) * 2
-    ramp_data.data[0, :, 0, 1] = np.array(arr, dtype=float) * 3
+    ramp_data.data[0, :, 0, 0] = np.array(arr, dtype=float)
+    ramp_data.data[0, :, 0, 1] = np.array(arr, dtype=float)
     ramp_data.data[0, :, 0, 2] = np.array(arr, dtype=float)
 
     ramp_data.data[1, :, 0, 0] = np.array(arr, dtype=float)
@@ -525,7 +525,7 @@ def test_one_group_ramp_suppressed():
     np.testing.assert_allclose(sdata, sdata_check, tol)
 
     svp_check = np.zeros((nrows, ncols), dtype=np.float32)
-    svp_check[0, :] = np.array([0.015, 0.02, 0.005])
+    svp_check[0, :] = np.array([0.01, 0.01, 0.005])
     np.testing.assert_allclose(svp, svp_check, tol)
 
     svr_check = np.zeros((nrows, ncols), dtype=np.float32)
@@ -533,7 +533,7 @@ def test_one_group_ramp_suppressed():
     np.testing.assert_allclose(svr, svr_check, tol)
 
     serr_check = np.zeros((nrows, ncols), dtype=np.float32)
-    serr_check[0, :] = np.array([0.46368092, 0.46904156, 0.32403702])
+    serr_check[0, :] = np.array([0.45825756, 0.45825756, 0.32403702])
     np.testing.assert_allclose(serr, serr_check, tol)
 
     # Check slopes per integration
@@ -563,11 +563,11 @@ def test_one_group_ramp_not_suppressed():
 
     # Check slopes information
     sdata_check = np.zeros((nrows, ncols), dtype=np.float32)
-    sdata_check[0, :] = np.array([1.0000001, 0.9488373, 1.0000002])
+    sdata_check[0, :] = np.array([1.0000001, 0.9505884, 1.0000002])
     np.testing.assert_allclose(sdata, sdata_check, tol)
 
     svp_check = np.zeros((nrows, ncols), dtype=np.float32)
-    svp_check[0, :] = np.array([0.015, 0.016, 0.005])
+    svp_check[0, :] = np.array([0.01, 0.008, 0.005])
     np.testing.assert_allclose(svp, svp_check, tol)
 
     svr_check = np.zeros((nrows, ncols), dtype=np.float32)
@@ -575,7 +575,7 @@ def test_one_group_ramp_not_suppressed():
     np.testing.assert_allclose(svr, svr_check, tol)
 
     serr_check = np.zeros((nrows, ncols), dtype=np.float32)
-    serr_check[0, :] = np.array([0.46368092, 0.45439652, 0.32403702])
+    serr_check[0, :] = np.array([0.45825756, 0.44550666, 0.32403702])
     np.testing.assert_allclose(serr, serr_check, tol)
 
     # Check slopes per integration


### PR DESCRIPTION
This PR resolves https://github.com/spacetelescope/jwst/issues/6013

A boolean switch has been added to STCAL ramp fitting to suppress ramps that have only one good group.  These ramps will be treated as having zero good groups.  This is done by finding the one good group in the ramp, then setting the DQ flag for that ramp to DO_NOT_USE.

Two tests have been added to test this new feature.