### PR TITLE
JP-2071: Add feature to turn off calculations for saturated ramps with good 0th group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.6.1 (unreleasd)
+================
+
+ramp_fitting
+------------
+
+- Adding feature to suppress calculations for saturated ramps having only
+  the 0th group be a good group.  [#76]
+
 0.6.0 (22-01-14)
 ================
 

--- a/src/stcal/ramp_fitting/gls_fit.py
+++ b/src/stcal/ramp_fitting/gls_fit.py
@@ -611,7 +611,7 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
         # pixels
         pixeldq_sect = pixeldq[:, :].copy()
         dq_int[num_int, :, :] = utils.dq_compress_sect(
-            ramp_data, gdq_cube[num_int, :, :, :], pixeldq_sect).copy()
+            ramp_data, num_int, gdq_cube[num_int, :, :, :], pixeldq_sect).copy()
 
         dq_int[num_int, :, :] |= temp_dq
         temp_dq[:, :] = 0  # initialize for next integration
@@ -644,7 +644,7 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
     # Compress all integration's dq arrays to create 2D PIXELDDQ array for
     #   primary output
     final_pixeldq = utils.dq_compress_final(
-        dq_int, number_ints, ramp_data.flags_do_not_use)
+        dq_int, ramp_data.flags_do_not_use)
 
     integ_info = (slope_int, dq_int, slope_err_int)
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-
 import logging
 from multiprocessing.pool import Pool as Pool
 import numpy as np
@@ -10,6 +9,7 @@ import warnings
 
 from . import ramp_fit_class
 from . import utils
+
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -983,7 +983,7 @@ def ramp_fit_slopes(ramp_data, gain_2d, readnoise_2d, save_opt, weighting):
 
             pixeldq_sect = pixeldq[rlo:rhi, :].copy()
             dq_int[num_int, rlo:rhi, :] = utils.dq_compress_sect(
-                ramp_data, t_dq_cube, pixeldq_sect).copy()
+                ramp_data, num_int, t_dq_cube, pixeldq_sect).copy()
 
             del t_dq_cube
 
@@ -1426,7 +1426,8 @@ def ramp_fit_overall(
 
     # Compress all integration's dq arrays to create 2D PIXELDDQ array for
     #   primary output
-    final_pixeldq = utils.dq_compress_final(dq_int, n_int, ramp_data.flags_do_not_use)
+    final_pixeldq = utils.dq_compress_final(
+        dq_int, ramp_data.flags_do_not_use)
 
     if dq_int is not None:
         del dq_int

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -272,7 +272,7 @@ def suppress_one_group_saturated_ramps(ramp_data):
             row = wh1_rows[n]
             col = wh1_cols[n]
             # For ramps that have good 0th group, but the rest of the
-            # ramp saturated, mark the 0th groups as saturated (to
+            # ramp saturated, mark the 0th groups as saturated, too.
 
             if ramp_data.groupdq[integ, 0, row, col] == 0:
                 ramp_data.groupdq[integ, 0, row, col] = sat_flag

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -264,7 +264,7 @@ def suppress_one_group_saturated_ramps(ramp_data):
         sat_groups = np.zeros(intdq.shape, dtype=int)
         sat_groups[np.where(np.bitwise_and(intdq, sat_flag))] = 1
         nsat_groups = sat_groups.sum(axis=0)
-        wh_one = np.where(nsat_groups == (ngroups-1))
+        wh_one = np.where(nsat_groups == (ngroups - 1))
 
         wh1_rows = wh_one[0]
         wh1_cols = wh_one[1]

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -30,6 +30,10 @@ class RampData:
         self.start_row = None
         self.num_rows = None
 
+        # One group ramp suppression for saturated ramps after 0th group.
+        self.suppress_one_group_ramps = False
+        self.one_groups = None
+
     def set_arrays(self, data, err, groupdq, pixeldq, int_times):
         """
         Set the arrays needed for ramp fitting.

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1135,14 +1135,6 @@ def fix_sat_ramps(ramp_data, sat_0th_group_int, var_p3, var_both3, slope_int, dq
     dq_int[sat_0th_group_int > 0] = np.bitwise_or(
         dq_int[sat_0th_group_int > 0], ramp_data.flags_do_not_use)
 
-    # Adjust integration DQ for suppressed one groups
-    if ramp_data.suppress_one_group_ramps:
-        nints = dq_int.shape[0]
-        for integ in range(nints):
-            for pix in ramp_data.one_groups[integ]:
-                row, col = pix
-                dq_int[integ, row, col] ^= ramp_data.flags_do_not_use
-
     return var_p3, var_both3, slope_int, dq_int
 
 

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -452,6 +452,241 @@ def test_2_group_cases():
     np.testing.assert_allclose(err, chk_er, tol)
 
 
+def run_one_group_ramp_suppression(nints, suppress):
+    """
+    Forms the base of the one group suppression tests.  Create three ramps
+    using three pixels with two integrations.  In the first integration:
+        The first ramp has no good groups.
+        The second ramp has one good groups.
+        The third ramp has all good groups.
+
+    In the second integration all pixels have all good groups.
+    """
+    # Define the data.
+    ngroups, nrows, ncols = 5, 1, 3
+    dims = (nints, ngroups, nrows, ncols)
+    rnoise, gain = 10, 1
+    nframes, group_time, frame_time = 1, 5.0, 1
+    var = rnoise, gain
+    tm = nframes, group_time, frame_time
+
+    # Using the above create the classes and arrays.
+    ramp_data, rnoise2d, gain2d = setup_inputs(dims, var, tm)
+
+    arr = np.array([k + 1 for k in range(ngroups)], dtype=float)
+
+    sat = ramp_data.flags_saturated
+    sat_dq = np.array([sat] * ngroups, dtype=ramp_data.groupdq.dtype)
+    zdq = np.array([0] * ngroups, dtype=ramp_data.groupdq.dtype)
+
+    ramp_data.data[0, :, 0, 0] = arr
+    ramp_data.data[0, :, 0, 1] = arr
+    ramp_data.data[0, :, 0, 2] = arr
+
+    ramp_data.groupdq[0, :, 0, 0] = sat_dq  # All groups sat
+    ramp_data.groupdq[0, :, 0, 1] = sat_dq  # 0th good, all others sat
+    ramp_data.groupdq[0, 0, 0, 1] = 0
+    ramp_data.groupdq[0, :, 0, 2] = zdq     # All groups good
+
+    if nints > 1:
+        ramp_data.data[1, :, 0, 0] = arr
+        ramp_data.data[1, :, 0, 1] = arr
+        ramp_data.data[1, :, 0, 2] = arr
+
+        # All good ramps
+        ramp_data.groupdq[1, :, 0, 0] = zdq
+        ramp_data.groupdq[1, :, 0, 1] = zdq
+        ramp_data.groupdq[1, :, 0, 2] = zdq
+
+    ramp_data.suppress_one_group_ramps = suppress
+
+    algo = "OLS"
+    save_opt, ncores, bufsize = False, "none", 1024 * 30000
+    slopes, cube, ols_opt, gls_opt = ramp_fit_data(
+        ramp_data, bufsize, save_opt, rnoise2d, gain2d, algo,
+        "optimal", ncores, dqflags)
+
+    return slopes, cube, dims
+
+
+def test_one_group_ramp_suppressed_one_integration():
+    slopes, cube, dims = run_one_group_ramp_suppression(1, True)
+    nints, ngroups, nrows, ncols = dims
+    tol = 1e-5
+
+    # Check slopes information
+    sdata, sdq, svp, svr, serr = slopes
+
+    check = np.array([[0., 0., 1.0000002]])
+    np.testing.assert_allclose(sdata, check, tol)
+
+    check = np.array([[3, 2, 0]])
+    np.testing.assert_allclose(sdq, check, tol)
+
+    check = np.array([[0., 0., 0.01]])
+    np.testing.assert_allclose(svp, check, tol)
+
+    check = np.array([[0., 0., 0.19999999]])
+    np.testing.assert_allclose(svr, check, tol)
+
+    check = np.array([[0., 0., 0.45825756]])
+    np.testing.assert_allclose(serr, check, tol)
+
+    # Check slopes information
+    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+
+    check = np.array([[[0., 0., 1.0000001]]])
+    np.testing.assert_allclose(cdata, check, tol)
+
+    check = np.array([[[3, 2, 0]]])
+    np.testing.assert_allclose(cdq, check, tol)
+
+    check = np.array([[[0., 0., 0.01]]])
+    np.testing.assert_allclose(cvp, check, tol)
+
+    check = np.array([[[0., 0., 0.19999999]]])
+    np.testing.assert_allclose(cvr, check, tol)
+
+    check = np.array([[[0., 0., 0.4582576]]])
+    np.testing.assert_allclose(cerr, check, tol)
+
+
+def test_one_group_ramp_not_suppressed_one_integration():
+    slopes, cube, dims = run_one_group_ramp_suppression(1, False)
+    nints, ngroups, nrows, ncols = dims
+    tol = 1e-5
+
+    # Check slopes information
+    sdata, sdq, svp, svr, serr = slopes
+
+    check = np.array([[0., 1., 1.0000002]])
+    np.testing.assert_allclose(sdata, check, tol)
+
+    check = np.array([[3, 2, 0]])
+    np.testing.assert_allclose(sdq, check, tol)
+
+    check = np.array([[0., 0.04, 0.01]])
+    np.testing.assert_allclose(svp, check, tol)
+
+    check = np.array([[0., 3.9999995, 0.19999999]])
+    np.testing.assert_allclose(svr, check, tol)
+
+    check = np.array([[0., 2.009975, 0.45825756]])
+    np.testing.assert_allclose(serr, check, tol)
+
+    # Check slopes information
+    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+
+    check = np.array([[[0., 1., 1.0000001]]])
+    np.testing.assert_allclose(cdata, check, tol)
+
+    check = np.array([[[3, 2, 0]]])
+    np.testing.assert_allclose(cdq, check, tol)
+
+    check = np.array([[[0., 0.04, 0.01]]])
+    np.testing.assert_allclose(cvp, check, tol)
+
+    check = np.array([[[0., 3.9999995, 0.19999999]]])
+    np.testing.assert_allclose(cvr, check, tol)
+
+    check = np.array([[[0., 2.0099752, 0.4582576]]])
+    np.testing.assert_allclose(cerr, check, tol)
+
+
+def test_one_group_ramp_suppressed_two_integrations():
+    slopes, cube, dims = run_one_group_ramp_suppression(2, True)
+    nints, ngroups, nrows, ncols = dims
+    tol = 1e-5
+
+    # Check slopes information
+    sdata, sdq, svp, svr, serr = slopes
+
+    check = np.array([[1.0000001, 1.0000001, 1.0000002]])
+    np.testing.assert_allclose(sdata, check, tol)
+
+    check = np.array([[2, 2, 0]])
+    np.testing.assert_allclose(sdq, check, tol)
+
+    check = np.array([[0.005, 0.005, 0.005]])
+    np.testing.assert_allclose(svp, check, tol)
+
+    check = np.array([[0.19999999, 0.19999999, 0.09999999]])
+    np.testing.assert_allclose(svr, check, tol)
+
+    check = np.array([[0.45276925, 0.45276925, 0.32403702]])
+    np.testing.assert_allclose(serr, check, tol)
+
+    # Check slopes information
+    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+
+    check = np.array([[[0.,        0.,        1.0000001]],
+                      [[1.0000001, 1.0000001, 1.0000001]]])
+    np.testing.assert_allclose(cdata, check, tol)
+
+    check = np.array([[[3, 2, 0]],
+                      [[0, 0, 0]]])
+    np.testing.assert_allclose(cdq, check, tol)
+
+    check = np.array([[[0.,    0.,    0.01]],
+                      [[0.005, 0.005, 0.01]]])
+    np.testing.assert_allclose(cvp, check, tol)
+
+    check = np.array([[[0.,         0.,         0.19999999]],
+                      [[0.19999999, 0.19999999, 0.19999999]]])
+    np.testing.assert_allclose(cvr, check, tol)
+
+    check = np.array([[[0.,         0.,         0.4582576]],
+                      [[0.45276922, 0.45276922, 0.4582576]]])
+    np.testing.assert_allclose(cerr, check, tol)
+
+
+def test_one_group_ramp_not_suppressed_two_integrations():
+    slopes, cube, dims = run_one_group_ramp_suppression(2, False)
+    nints, ngroups, nrows, ncols = dims
+    tol = 1e-5
+
+    # Check slopes information
+    sdata, sdq, svp, svr, serr = slopes
+
+    check = np.array([[1.0000001, 1.0000002, 1.0000002]])
+    np.testing.assert_allclose(sdata, check, tol)
+
+    check = np.array([[2, 2, 0]])
+    np.testing.assert_allclose(sdq, check, tol)
+
+    check = np.array([[0.005, 0.008, 0.005]])
+    np.testing.assert_allclose(svp, check, tol)
+
+    check = np.array([[0.19999999, 0.19047618, 0.09999999]])
+    np.testing.assert_allclose(svr, check, tol)
+
+    check = np.array([[0.45276925, 0.44550666, 0.32403702]])
+    np.testing.assert_allclose(serr, check, tol)
+
+    # Check slopes information
+    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+
+    check = np.array([[[0.,        1.,        1.0000001]],
+                      [[1.0000001, 1.0000001, 1.0000001]]])
+    np.testing.assert_allclose(cdata, check, tol)
+
+    check = np.array([[[3, 2, 0]],
+                      [[0, 0, 0]]])
+    np.testing.assert_allclose(cdq, check, tol)
+
+    check = np.array([[[0.,    0.04, 0.01]],
+                      [[0.005, 0.01, 0.01]]])
+    np.testing.assert_allclose(cvp, check, tol)
+
+    check = np.array([[[0.,         3.9999995,  0.19999999]],
+                      [[0.19999999, 0.19999999, 0.19999999]]])
+    np.testing.assert_allclose(cvr, check, tol)
+
+    check = np.array([[[0.,         2.0099752, 0.4582576]],
+                      [[0.45276922, 0.4582576, 0.4582576]]])
+    np.testing.assert_allclose(cerr, check, tol)
+
+
 # -----------------------------------------------------------------------------
 #                           Set up functions
 
@@ -495,12 +730,21 @@ def setup_inputs(dims, var, tm):
 
 # -----------------------------------------------------------------------------
 
+###############################################################################
+# The functions below are only used for DEBUGGING tests and developing tests. #
+###############################################################################
 
-# Main product
+
 def print_slope_data(slopes):
     sdata, sdq, svp, svr, serr = slopes
     print("Slope Data:")
     print(sdata)
+
+
+def print_slope_dq(slopes):
+    sdata, sdq, svp, svr, serr = slopes
+    print("Data Quality:")
+    print(sdq)
 
 
 def print_slope_poisson(slopes):
@@ -526,6 +770,9 @@ def print_slopes(slopes):
     print("**** SLOPES")
     print(DELIM)
     print_slope_data(slopes)
+
+    print(DELIM)
+    print_slope_dq(slopes)
 
     print(DELIM)
     print_slope_poisson(slopes)

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -520,7 +520,7 @@ def test_one_group_ramp_suppressed_one_integration():
     check = np.array([[0., 0., 1.0000002]])
     np.testing.assert_allclose(sdata, check, tol)
 
-    check = np.array([[3, 2, 0]])
+    check = np.array([[3, 3, 0]])
     np.testing.assert_allclose(sdq, check, tol)
 
     check = np.array([[0., 0., 0.01]])
@@ -538,7 +538,7 @@ def test_one_group_ramp_suppressed_one_integration():
     check = np.array([[[0., 0., 1.0000001]]])
     np.testing.assert_allclose(cdata, check, tol)
 
-    check = np.array([[[3, 2, 0]]])
+    check = np.array([[[3, 3, 0]]])
     np.testing.assert_allclose(cdq, check, tol)
 
     check = np.array([[[0., 0., 0.01]]])
@@ -623,7 +623,7 @@ def test_one_group_ramp_suppressed_two_integrations():
                       [[1.0000001, 1.0000001, 1.0000001]]])
     np.testing.assert_allclose(cdata, check, tol)
 
-    check = np.array([[[3, 2, 0]],
+    check = np.array([[[3, 3, 0]],
                       [[0, 0, 0]]])
     np.testing.assert_allclose(cdq, check, tol)
 


### PR DESCRIPTION
Resolves [JP-2071](https://jira.stsci.edu/browse/JP-2071)

A `suppress_one_group` boolean variable has been added as a parameter to the `ramp_fit` function.  

When true saturated ramps with only the 0th group being good will be treated as completely saturated ramps.  The calculations will be done as if all calculations are saturated, but the DQ flags will be set as if the first group is good, i.e., the pixel DQ will not have DO_NOT_USE set.

When false saturated ramps with only the 0th group being good will be treated as the normal special case of having only one good group.