### PR TITLE
JP-2525: jump step flagging saturated groups as jumps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.6.2 (unreleased)
 ==================
 
+jump
+----
+- Neighboring pixels with 'SATURATION' or 'DONOTUSE' flags are no longer flagged as jumps. [#79]
+
 0.6.1 (22-03-04)
 ================
 


### PR DESCRIPTION
This PR fixes an issue where saturated pixels were also being flagged as jumps. While the initial pass to find jumps was correctly ignoring saturated and donotuse pixels, when the flag to set the DQ for neighboring pixels was set, if the neighboring pixels contained these flags the jump flag was simply added to them. Now, if a neighboring pixel is saturated or donotuse, it will not also be flagged as a jump.

Fixes [JP-2525](https://jira.stsci.edu/browse/JP-2525)