### PR TITLE
JP-2581: fix to allow multiprocessing for jump

### DIFF
--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -64,11 +64,10 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
     four_grp_thresh : float
         cosmic ray sigma rejection threshold for ramps having 4 groups
 
-    max_cores: int or str
+    max_cores: str
         Maximum number of cores to use for multiprocessing. Available choices
-        are 1, 'quarter', 'half', 'all', or an integer. If the integer exceeds
-        the number of available cores, then it will be capped at the max number
-        available.
+        are 'none' (which will create one process), 'quarter', 'half', 'all'
+        (of availble cpu cores).
 
     max_jump_to_flag_neighbors : float
         value in units of sigma that sets the upper limit for flagging of
@@ -135,11 +134,8 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
     # figure out how many slices to make based on 'max_cores'
 
     max_available = multiprocessing.cpu_count()
-    if type(max_cores) == int:
-        if max_cores > max_available:
-            n_slices = max_available
-        else:
-            n_slices = max_cores
+    if max_cores.lower() == 'none':
+        n_slices = 1
     elif max_cores == 'quarter':
         n_slices = max_available // 4 or 1
     elif max_cores == 'half':
@@ -171,7 +167,6 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
         copy_arrs = False   # we dont need to copy arrays again in find_crs
 
         for i in range(n_slices - 1):
-            print('setting up slices')
             slices.insert(i, (data[:, :, i * yinc:(i + 1) * yinc, :],
                               gdq[:, :, i * yinc:(i + 1) * yinc, :],
                               readnoise_2d[i * yinc:(i + 1) * yinc, :],

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -76,7 +76,7 @@ def find_crs(dataa, group_dq, read_noise, normal_rej_thresh,
         dataa = dataa.copy()
         gdq = group_dq.copy()
     else:
-        group_dq = gdq
+        gdq = group_dq
 
     # Get data characteristics
     nints, ngroups, nrows, ncols = dataa.shape

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -75,6 +75,8 @@ def find_crs(dataa, group_dq, read_noise, normal_rej_thresh,
     if copy_arrs:
         dataa = dataa.copy()
         gdq = group_dq.copy()
+    else:
+        group_dq = gdq
 
     # Get data characteristics
     nints, ngroups, nrows, ncols = dataa.shape

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -8,7 +8,7 @@ log.setLevel(logging.DEBUG)
 def find_crs(dataa, group_dq, read_noise, normal_rej_thresh,
              two_diff_rej_thresh, three_diff_rej_thresh, nframes,
              flag_4_neighbors, max_jump_to_flag_neighbors,
-             min_jump_to_flag_neighbors, dqflags):
+             min_jump_to_flag_neighbors, dqflags, copy_arrs=True):
 
     """
     Find CRs/Jumps in each integration within the input data array. The input
@@ -54,6 +54,10 @@ def find_crs(dataa, group_dq, read_noise, normal_rej_thresh,
         neighbors (marginal detections). Any primary jump below this value will
         not have its neighbors flagged.
 
+    copy_arrs : bool
+        Flag for making internal copies of the arrays so the input isn't modified,
+        defaults to True.
+
     Returns
     -------
     gdq : int, 4D array
@@ -68,8 +72,9 @@ def find_crs(dataa, group_dq, read_noise, normal_rej_thresh,
     """
 
     # copy data and group DQ array
-    dataa = dataa.copy()
-    gdq = group_dq.copy()
+    if copy_arrs:
+        dataa = dataa.copy()
+        gdq = group_dq.copy()
 
     # Get data characteristics
     nints, ngroups, nrows, ncols = dataa.shape


### PR DESCRIPTION
Fixes an issue in jump where the input gdq arrays were being modified which was causing tests to fail in JWST when the step was being run in multiprocessing mode. If multiple processes are run, the gdq/data arrays are copied before `find_crs` and not again within the function (which in this mode is running on slices).