### PR TITLE
Update twopoint_difference.py

### DIFF
--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -251,8 +251,8 @@ def find_crs(dataa, group_dq, read_noise, normal_rej_thresh,
                                     np.bitwise_or(gdq[integ, group, row, col - 1], jump_flag)
 
                     if cr_col[j] != ncols - 1:
-                        if (gdq[integ, group, row, col - 1] & sat_flag) == 0:
-                            if (gdq[integ, group, row, col - 1] & dnu_flag) == 0:
+                        if (gdq[integ, group, row, col + 1] & sat_flag) == 0:
+                            if (gdq[integ, group, row, col + 1] & dnu_flag) == 0:
                                 gdq[integ, group, row, col + 1] =\
                                     np.bitwise_or(gdq[integ, group, row, col + 1], jump_flag)
     return gdq, row_below_gdq, row_above_gdq


### PR DESCRIPTION
This is a fix for JP-2617 - Incorrect Flagging of saturated groups adjacent to pixels with detected jumps.
The problem was a typo in the section of the code that checks to see if the neighbor pixels already have a DO_NOT_USE or SATURATION flag. This made one of the checks not work correctly, resulting in pixels with both SATURATION and JUMP flags. The ramp_fit step does not behave well when groups have both flags set.