### PR TITLE
Update to handle single good group

### DIFF
--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -261,12 +261,12 @@ def test_utils_dq_compress_final():
     var = (rnoise_val, gain_val)
     tm = (nframes, gtime, dtime)
     ramp_data, rnoise, gain = setup_inputs(dims, var, tm)
+
     ramp_data.groupdq[0, :, 0, 0] = np.array([dqflags["SATURATED"]] * ngroups)
     ramp_data.groupdq[1, :, 0, 0] = np.array([dqflags["SATURATED"]] * ngroups)
 
-    ramp_data.groupdq[0, 1:, 0, 1] = np.array([dqflags["SATURATED"]] * (ngroups - 1))
-    ramp_data.groupdq[1, 1:, 0, 1] = np.array([6] * (ngroups - 1))
-    ramp_data.suppress_one_group_ramps = True
+    ramp_data.groupdq[0, :, 0, 1] = np.array([dqflags["SATURATED"]] * ngroups)
+
     # Run ramp fit on RampData
     buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -261,12 +261,12 @@ def test_utils_dq_compress_final():
     var = (rnoise_val, gain_val)
     tm = (nframes, gtime, dtime)
     ramp_data, rnoise, gain = setup_inputs(dims, var, tm)
-
     ramp_data.groupdq[0, :, 0, 0] = np.array([dqflags["SATURATED"]] * ngroups)
     ramp_data.groupdq[1, :, 0, 0] = np.array([dqflags["SATURATED"]] * ngroups)
 
-    ramp_data.groupdq[0, :, 0, 1] = np.array([dqflags["SATURATED"]] * ngroups)
-
+    ramp_data.groupdq[0, 1:, 0, 1] = np.array([dqflags["SATURATED"]] * (ngroups - 1))
+    ramp_data.groupdq[1, 1:, 0, 1] = np.array([6] * (ngroups - 1))
+    ramp_data.suppress_one_group_ramps = True
     # Run ramp fit on RampData
     buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(


### PR DESCRIPTION
The baseline code assumes that if there is only one group in an integration it must be the first group. This is not true when MIRI is flagging more than one frame like happens in the RSCD step.
Also, there was the assumption that only saturation could create the single good group but with CR neighbor flagging turned on you can have the first group good and the second group have a jump. So, jumps need to be added to the total number of groups that are bad.
This is a fix for JP-2572.