### PR TITLE
JP-2572: Updating the handler for the suppression of one good group ramps.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+0.7.3 (unreleased)
+==================
+
+ramp_fitting
+------------
+
+- Updating the one good group ramp suppression handler works. [#92]
+
 0.7.2 (2022-05-19)
 ==================
 

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -236,7 +236,7 @@ def ramp_fit_data(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,
 
         # Suppress one group ramps, if desired.
         if ramp_data.suppress_one_group_ramps:
-            suppress_one_group_saturated_ramps(ramp_data)
+            suppress_one_group_saturated_or_jump_ramps(ramp_data)
 
         # Compute ramp fitting using ordinary least squares.
         image_info, integ_info, opt_info = ols_fit.ols_ramp_fit_multi(
@@ -246,7 +246,7 @@ def ramp_fit_data(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,
     return image_info, integ_info, opt_info, gls_opt_info
 
 
-def suppress_one_group_saturated_ramps(ramp_data):
+def suppress_one_group_saturated_or_jump_ramps(ramp_data):
     """
     Finds one group ramps in each integration and suppresses them, i.e. turns
     them into zero group ramps.

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -259,6 +259,7 @@ def suppress_one_group_saturated_ramps(ramp_data):
     dq = ramp_data.groupdq
     nints, ngroups, nrows, ncols = dq.shape
     sat_flag = ramp_data.flags_saturated
+    jump_flag = ramp_data.flags_jump_det
 
     ramp_data.one_groups = [None] * nints
 
@@ -266,9 +267,13 @@ def suppress_one_group_saturated_ramps(ramp_data):
         ramp_data.one_groups[integ] = []
         intdq = dq[integ, :, :, :]
 
-        # Find ramps with a good zeroeth group, but saturated in
-        # the remainder of the ramp.
-        wh_one = groups_saturated_in_integration(intdq, sat_flag, ngroups - 1)
+        # Find ramps with only one group that is not saturated and
+        # not jump (i.e., only one good group).
+        bad_flags = np.bitwise_or(sat_flag, jump_flag)
+        bad_groups = np.zeros(intdq.shape, dtype=int)
+        bad_groups[np.where(np.bitwise_and(intdq, bad_flags))] = 1
+        nbad_groups = bad_groups.sum(axis=0)
+        wh_one = np.where(nbad_groups == (ngroups - 1))
 
         wh1_rows = wh_one[0]
         wh1_cols = wh_one[1]


### PR DESCRIPTION
Due to the possibility the first groups of a ramp could be flagged as DO_NOT_USE, as well as the way the jump detector works, the one good group suppression handler needed to be modified to handle these cases as well.