### PR TITLE
JP-2623: Fixing multiprocessing failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ ramp_fitting
 
 - Adding special case handler for GLS to handle one group ramps. [#97]
 
+- Updating how one group suppression and ZEROFRAME processing works with
+  multiprocessing, as well as fixing the multiprocessing failure. [#99]
+
 Changes to API
 --------------
 

--- a/src/stcal/ramp_fitting/gls_fit.py
+++ b/src/stcal/ramp_fitting/gls_fit.py
@@ -461,8 +461,7 @@ def slice_ramp_data(ramp_data, start_row, nrows):
     groupdq = ramp_data.groupdq[:, :, start_row:start_row + nrows, :].copy()
     pixeldq = ramp_data.pixeldq[start_row:start_row + nrows, :].copy()
 
-    ramp_data_slice.set_arrays(
-        data, err, groupdq, pixeldq, ramp_data.int_times)
+    ramp_data_slice.set_arrays(data, err, groupdq, pixeldq)
 
     # Carry over meta data.
     ramp_data_slice.set_meta(

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -49,20 +49,8 @@ def create_ramp_fit_class(model, dqflags=None, suppress_one_group=False):
     """
     ramp_data = ramp_fit_class.RampData()
 
-    if not suppress_one_group and hasattr(model.meta.exposure, 'zero_frame'):
-        if model.meta.exposure.zero_frame:
-            # ZEROFRAME processing here
-            zframe_locs, cnt = use_zeroframe_for_saturated_ramps(model, dqflags)
-            ramp_data.zframe_locs = zframe_locs
-            ramp_data.zframe_cnt = cnt
-
-    # Attribute may not be supported by all pipelines.  Default is NoneType.
-    if hasattr(model, 'int_times'):
-        int_times = model.int_times
-    else:
-        int_times = None
     ramp_data.set_arrays(
-        model.data, model.err, model.groupdq, model.pixeldq, int_times)
+        model.data, model.err, model.groupdq, model.pixeldq)
 
     # Attribute may not be supported by all pipelines.  Default is NoneType.
     if hasattr(model, 'drop_frames1'):
@@ -76,6 +64,9 @@ def create_ramp_fit_class(model, dqflags=None, suppress_one_group=False):
         groupgap=model.meta.exposure.groupgap,
         nframes=model.meta.exposure.nframes,
         drop_frames1=drop_frames1)
+
+    if "zero_frame" in model.meta.exposure and model.meta.exposure.zero_frame:
+        ramp_data.zeroframe = model.zeroframe
 
     ramp_data.set_dqflags(dqflags)
     ramp_data.start_row = 0
@@ -236,7 +227,7 @@ def ramp_fit_data(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,
 
         # Suppress one group ramps, if desired.
         if ramp_data.suppress_one_group_ramps:
-            suppress_one_group_saturated_or_jump_ramps(ramp_data)
+            suppress_one_good_group_ramps(ramp_data)
 
         # Compute ramp fitting using ordinary least squares.
         image_info, integ_info, opt_info = ols_fit.ols_ramp_fit_multi(
@@ -246,7 +237,7 @@ def ramp_fit_data(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d,
     return image_info, integ_info, opt_info, gls_opt_info
 
 
-def suppress_one_group_saturated_or_jump_ramps(ramp_data):
+def suppress_one_good_group_ramps(ramp_data):
     """
     Finds one group ramps in each integration and suppresses them, i.e. turns
     them into zero group ramps.
@@ -258,23 +249,17 @@ def suppress_one_group_saturated_or_jump_ramps(ramp_data):
     """
     dq = ramp_data.groupdq
     nints, ngroups, nrows, ncols = dq.shape
-    sat_flag = ramp_data.flags_saturated
-    jump_flag = ramp_data.flags_jump_det
-
-    ramp_data.one_groups = [None] * nints
+    dnu_flag = ramp_data.flags_do_not_use
 
     for integ in range(nints):
-        ramp_data.one_groups[integ] = []
+        # In the current integration find ramps with only one group.
         intdq = dq[integ, :, :, :]
+        good_groups = np.zeros(intdq.shape, dtype=int)
+        good_groups[intdq == 0] = 1
+        ngood_groups = good_groups.sum(axis=0)
+        wh_one = np.where(ngood_groups == 1)
 
-        # Find ramps with only one group that is not saturated and
-        # not jump (i.e., only one good group).
-        bad_flags = np.bitwise_or(sat_flag, jump_flag)
-        bad_groups = np.zeros(intdq.shape, dtype=int)
-        bad_groups[np.where(np.bitwise_and(intdq, bad_flags))] = 1
-        nbad_groups = bad_groups.sum(axis=0)
-        wh_one = np.where(nbad_groups == (ngroups - 1))
-
+        # Suppress the ramps with only one good group by flagg
         wh1_rows = wh_one[0]
         wh1_cols = wh_one[1]
         for n in range(len(wh1_rows)):
@@ -282,85 +267,6 @@ def suppress_one_group_saturated_or_jump_ramps(ramp_data):
             col = wh1_cols[n]
             # For ramps that have good 0th group, but the rest of the
             # ramp saturated, mark the 0th groups as saturated, too.
-
-            if ramp_data.groupdq[integ, 0, row, col] == 0:
-                ramp_data.groupdq[integ, 0, row, col] = sat_flag
-                sat_pix = (row, col)
-                ramp_data.one_groups[integ].append(sat_pix)
-
-
-def use_zeroframe_for_saturated_ramps(model, dqflags):
-    """
-    For saturated ramps, if there is good data in the ZEROFRAME, replace
-    group zero with the data in ZEROFRAME to use the ramp as a one group
-    ramp.
-
-    Parameters
-    ----------
-    model : data model
-        input data model, assumed to be of type RampModel
-
-    dqflags : dict
-        The data quality flags needed for ramp fitting.
-
-    Return
-    ------
-    zframe_locs : list
-        A 2D list for the location of the ramps using ZEROFRAME data.
-        zframe_locs[k] is the list of pixels in the kth integration.
-    """
-    nints, ngroups, nrows, ncols = model.data.shape
-    sat_flag = dqflags["SATURATED"]
-    good_flag = dqflags["GOOD"]
-    dq = model.groupdq
-
-    zframe_locs = [None] * nints
-
-    cnt = 0
-    for integ in range(nints):
-        zframe_locs[integ] = []
-        intdq = dq[integ, :, :, :]
-
-        # Find ramps with a good zeroeth group, but saturated in
-        # the remainder of the ramp.
-        wh_sat = groups_saturated_in_integration(intdq, sat_flag, ngroups)
-
-        whs_rows = wh_sat[0]
-        whs_cols = wh_sat[1]
-        for n in range(len(whs_rows)):
-            row = whs_rows[n]
-            col = whs_cols[n]
-
-            # For ramps completely saturated look for data in the ZEROFRAME
-            # that is non-zero.  If it is non-zero, replace group zero in the
-            # ramp with the data in ZEROFRAME.
-            if model.zeroframe[integ, row, col] != 0:
-                zframe_locs[integ].append((row, col))
-                model.data[integ, 0, row, col] = model.zeroframe[integ, row, col]
-                model.groupdq[integ, 0, row, col] = good_flag
-                cnt = cnt + 1
-
-    return zframe_locs, cnt
-
-
-def groups_saturated_in_integration(intdq, sat_flag, num_sat_groups):
-    """
-    Find the ramps in an integration that have num_sat_groups saturated.
-
-    Parameters
-    ----------
-    intdq : ndarray
-        DQ flags for an integration
-
-    sat_flag : uint
-        The data quality flag for SATURATED
-
-    num_sat_groups : int
-        The number of saturated groups in an integration of interest.
-    """
-    sat_groups = np.zeros(intdq.shape, dtype=int)
-    sat_groups[np.where(np.bitwise_and(intdq, sat_flag))] = 1
-    nsat_groups = sat_groups.sum(axis=0)
-    wh_nsat_groups = np.where(nsat_groups == num_sat_groups)
-
-    return wh_nsat_groups
+            good_index = np.where(ramp_data.groupdq[integ, :, row, col] == 0)
+            if ramp_data.groupdq[integ, good_index, row, col] == 0:
+                ramp_data.groupdq[integ, good_index, row, col] = dnu_flag

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -8,7 +8,6 @@ class RampData:
         self.err = None
         self.groupdq = None
         self.pixeldq = None
-        self.int_times = None
 
         # Meta information
         self.instrument_name = None
@@ -29,6 +28,7 @@ class RampData:
         # ZEROFRAME
         self.zframe_locs = None
         self.zframe_cnt = 0
+        self.zeroframe = None
 
         # Slice info
         self.start_row = None
@@ -36,11 +36,10 @@ class RampData:
 
         # One group ramp suppression for saturated ramps after 0th group.
         self.suppress_one_group_ramps = False
-        self.one_groups = None
 
         self.current_integ = -1
 
-    def set_arrays(self, data, err, groupdq, pixeldq, int_times):
+    def set_arrays(self, data, err, groupdq, pixeldq):
         """
         Set the arrays needed for ramp fitting.
 
@@ -61,16 +60,12 @@ class RampData:
         pixeldq : ndarray (uint32)
             4-D array containing the pixel data quality information.  It has dimensions
             (nintegrations, ngroups, nrows, ncols)
-
-        int_times : list
-            Time information for each integration.
         """
         # Get arrays from the data model
         self.data = data
         self.err = err
         self.groupdq = groupdq
         self.pixeldq = pixeldq
-        self.int_times = int_times
 
     def set_meta(self, name, frame_time, group_time, groupgap,
                  nframes, drop_frames1=None):
@@ -125,3 +120,39 @@ class RampData:
         self.flags_saturated = dqflags["SATURATED"]
         self.flags_no_gain_val = dqflags["NO_GAIN_VALUE"]
         self.flags_unreliable_slope = dqflags["UNRELIABLE_SLOPE"]
+
+    def dbg_print_types(self):
+        # Arrays from the data model
+        print("-" * 80)
+        print("    Array Types:")
+        print(f"data : {type(self.data)}")
+        print(f"err : {type(self.err)}")
+        print(f"groupdq : {type(self.groupdq)}")
+        print(f"pixeldq : {type(self.pixeldq)}")
+
+        # Meta information
+        print("-" * 80)
+        print("    Meta:")
+        print(f"Instumet: {self.instrument_name}")
+
+        print(f"Frame time : {self.frame_time}")
+        print(f"Group time : {self.group_time}")
+        print(f"Group Gap : {self.groupgap}")
+        print(f"Nframes : {self.nframes}")
+        print(f"Drop Frames : {self.drop_frames1}")
+
+        # Multiprocessing
+        print("-" * 80)
+        print(f"Start row : {self.start_row}")
+        print(f"Number of rows : {self.num_rows}")
+
+        # ZEROFRAME
+        print("-" * 80)
+        print("    ZEROFRAME:")
+        print(f"zframe_locs : {type(self.zframe_locs)}")
+        print(f"zeroframe : {type(self.zeroframe)}")
+
+        # One group ramp suppression for saturated ramps after 0th group.
+        print("-" * 80)
+        print("    One Group Suppression:")
+        print(f"suppress_one_group_ramps : {type(self.suppress_one_group_ramps)}")

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -667,8 +667,7 @@ def calc_pedestal(ramp_data, num_int, slope_int, firstf_int, dq_first, nframes,
     return ped
 
 
-def output_integ(slope_int, dq_int, effintim, var_p3, var_r3, var_both3,
-                 int_times):
+def output_integ(slope_int, dq_int, effintim, var_p3, var_r3, var_both3):
     """
     For the OLS algorithm, construct the output integration-specific results.
     Any variance values that are a large fraction of the default value
@@ -701,9 +700,6 @@ def output_integ(slope_int, dq_int, effintim, var_p3, var_r3, var_both3,
         Cube of integration-specific values for the slope variance due to
         read noise and Poisson noise, 3-D float
 
-    int_times : bintable, or None
-        The INT_TIMES table, if it exists in the input, else None
-
     Returns
     -------
     integ_info : tuple
@@ -723,8 +719,7 @@ def output_integ(slope_int, dq_int, effintim, var_p3, var_r3, var_both3,
     dq = dq_int
     var_poisson = var_p3
     var_rnoise = var_r3
-    int_times = int_times
-    integ_info = (data, dq, var_poisson, var_rnoise, int_times, err)
+    integ_info = (data, dq, var_poisson, var_rnoise, err)
 
     # Reset the warnings filter to its original state
     warnings.resetwarnings()
@@ -1206,10 +1201,9 @@ def do_all_sat(ramp_data, pixeldq, groupdq, imshape, n_int, save_opt):
         dq = groupdq_3d
         var_poisson = np.zeros((n_int,) + imshape, dtype=np.float32)
         var_rnoise = np.zeros((n_int,) + imshape, dtype=np.float32)
-        int_times = None
         err = np.zeros((n_int,) + imshape, dtype=np.float32)
 
-        integ_info = (data, dq, var_poisson, var_rnoise, int_times, err)
+        integ_info = (data, dq, var_poisson, var_rnoise, err)
     else:
         integ_info = None
 
@@ -1474,3 +1468,77 @@ def compute_median_rates(ramp_data):
     del data_sect
 
     return median_rates
+
+
+def use_zeroframe_for_saturated_ramps(ramp_data):
+    """
+    For saturated ramps, if there is good data in the ZEROFRAME, replace
+    group zero with the data in ZEROFRAME to use the ramp as a one group
+    ramp.
+
+    Parameters
+    ----------
+    model : data model
+        input data model, assumed to be of type RampModel
+
+    Return
+    ------
+    zframe_locs : list
+        A 2D list for the location of the ramps using ZEROFRAME data.
+        zframe_locs[k] is the list of pixels in the kth integration.
+    """
+    nints, ngroups, nrows, ncols = ramp_data.data.shape
+    sat_flag = ramp_data.flags_saturated
+    good_flag = 0
+    dq = ramp_data.groupdq
+
+    zframe_locs = [None] * nints
+
+    cnt = 0
+    for integ in range(nints):
+        zframe_locs[integ] = []
+        intdq = dq[integ, :, :, :]
+
+        # Find ramps with a good zeroeth group, but saturated in
+        # the remainder of the ramp.
+        wh_sat = groups_saturated_in_integration(intdq, sat_flag, ngroups)
+
+        whs_rows = wh_sat[0]
+        whs_cols = wh_sat[1]
+        for n in range(len(whs_rows)):
+            row = whs_rows[n]
+            col = whs_cols[n]
+
+            # For ramps completely saturated look for data in the ZEROFRAME
+            # that is non-zero.  If it is non-zero, replace group zero in the
+            # ramp with the data in ZEROFRAME.
+            if ramp_data.zeroframe[integ, row, col] != 0:
+                zframe_locs[integ].append((row, col))
+                ramp_data.data[integ, 0, row, col] = ramp_data.zeroframe[integ, row, col]
+                ramp_data.groupdq[integ, 0, row, col] = good_flag
+                cnt = cnt + 1
+
+    return zframe_locs, cnt
+
+
+def groups_saturated_in_integration(intdq, sat_flag, num_sat_groups):
+    """
+    Find the ramps in an integration that have num_sat_groups saturated.
+
+    Parameters
+    ----------
+    intdq : ndarray
+        DQ flags for an integration
+
+    sat_flag : uint
+        The data quality flag for SATURATED
+
+    num_sat_groups : int
+        The number of saturated groups in an integration of interest.
+    """
+    sat_groups = np.zeros(intdq.shape, dtype=int)
+    sat_groups[np.where(np.bitwise_and(intdq, sat_flag))] = 1
+    nsat_groups = sat_groups.sum(axis=0)
+    wh_nsat_groups = np.where(nsat_groups == num_sat_groups)
+
+    return wh_nsat_groups

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -74,7 +74,7 @@ def test_neg_med_rates_single_integration_integ():
         base_neg_med_rates_single_integration()
 
     sdata, sdq, svp, svr, serr = slopes
-    idata, idq, ivp, ivr, int_times, ierr = cube
+    idata, idq, ivp, ivr, ierr = cube
     tol = 1e-6
 
     np.testing.assert_allclose(idata[0, :, :], sdata, tol)
@@ -154,11 +154,11 @@ def test_neg_med_rates_multi_integration_integ():
         base_neg_med_rates_multi_integrations()
 
     sdata, sdq, svp, svr, serr = slopes
-    idata, idq, ivp, ivr, int_times, ierr = cube
+    idata, idq, ivp, ivr, ierr = cube
     tol = 1e-6
 
     sdata, sdq, svp, svr, serr = slopes
-    idata, idq, ivp, ivr, int_times, ierr = cube
+    idata, idq, ivp, ivr, ierr = cube
 
     np.testing.assert_allclose(ivp[:, 0, 0], np.array([0., 0., 0.]), tol)
     np.testing.assert_allclose(ierr, np.sqrt(ivr), tol)
@@ -303,14 +303,13 @@ def jp_2326_test_setup():
     gdq = np.zeros((nints, ngroups, nrows, ncols), dtype=np.uint8)
     err = np.zeros((nints, ngroups, nrows, ncols))
     pdq = np.zeros((nrows, ncols), dtype=np.uint32)
-    int_times = np.zeros((nints,))
 
     data[0, :, 0, 0] = ramp.copy()
     gdq[0, :, 0, 0] = dq.copy()
 
     ramp_data = RampData()
     ramp_data.set_arrays(
-        data=data, err=err, groupdq=gdq, pixeldq=pdq, int_times=int_times)
+        data=data, err=err, groupdq=gdq, pixeldq=pdq)
     ramp_data.set_meta(
         name="MIRI", frame_time=2.77504, group_time=2.77504, groupgap=0,
         nframes=1, drop_frames1=None)
@@ -402,7 +401,6 @@ def test_2_group_cases():
     rnoise = np.ones((1, npix)) * rnoise_val
     gain = np.ones((1, npix)) * gain_val
     pixeldq = np.zeros((1, npix), dtype=np.uint32)
-    int_times = [(1, 59005.2477, 59005.2479, 59005.2482, 59005.2491, 59005.2494, 59005.2496)]
 
     data = np.zeros(dims, dtype=np.float32)  # Science data
     for k in range(npix):
@@ -419,8 +417,7 @@ def test_2_group_cases():
     # Setup the RampData class to run ramp fitting on.
     ramp_data = RampData()
 
-    ramp_data.set_arrays(
-        data, err, groupdq, pixeldq, int_times)
+    ramp_data.set_arrays(data, err, groupdq, pixeldq)
 
     ramp_data.set_meta(
         name="NIRSPEC",
@@ -521,7 +518,7 @@ def test_one_group_ramp_suppressed_one_integration():
     check = np.array([[0., 0., 1.0000002]])
     np.testing.assert_allclose(sdata, check, tol)
 
-    check = np.array([[3, 3, 0]])
+    check = np.array([[3, 2, 0]])
     np.testing.assert_allclose(sdq, check, tol)
 
     check = np.array([[0., 0., 0.01]])
@@ -534,12 +531,12 @@ def test_one_group_ramp_suppressed_one_integration():
     np.testing.assert_allclose(serr, check, tol)
 
     # Check slopes information
-    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+    cdata, cdq, cvp, cvr, cerr = cube
 
-    check = np.array([[[0., 0., 1.0000001]]])
+    check = np.array([[[0., np.nan, 1.0000001]]])
     np.testing.assert_allclose(cdata, check, tol)
 
-    check = np.array([[[3, 3, 0]]])
+    check = np.array([[[3, 2, 0]]])
     np.testing.assert_allclose(cdq, check, tol)
 
     check = np.array([[[0., 0., 0.01]]])
@@ -576,7 +573,7 @@ def test_one_group_ramp_not_suppressed_one_integration():
     np.testing.assert_allclose(serr, check, tol)
 
     # Check slopes information
-    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+    cdata, cdq, cvp, cvr, cerr = cube
 
     check = np.array([[[0., 1., 1.0000001]]])
     np.testing.assert_allclose(cdata, check, tol)
@@ -608,28 +605,28 @@ def test_one_group_ramp_suppressed_two_integrations():
     check = np.array([[2, 2, 0]])
     np.testing.assert_allclose(sdq, check, tol)
 
-    check = np.array([[0.005, 0.005, 0.005]])
+    check = np.array([[0.005, 0.01, 0.005]])
     np.testing.assert_allclose(svp, check, tol)
 
     check = np.array([[0.19999999, 0.19999999, 0.09999999]])
     np.testing.assert_allclose(svr, check, tol)
 
-    check = np.array([[0.45276925, 0.45276925, 0.32403702]])
+    check = np.array([[0.45276925, 0.45825756, 0.32403702]])
     np.testing.assert_allclose(serr, check, tol)
 
     # Check slopes information
-    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+    cdata, cdq, cvp, cvr, cerr = cube
 
-    check = np.array([[[0.,        0.,        1.0000001]],
+    check = np.array([[[0.,        np.nan,        1.0000001]],
                       [[1.0000001, 1.0000001, 1.0000001]]])
     np.testing.assert_allclose(cdata, check, tol)
 
-    check = np.array([[[3, 3, 0]],
+    check = np.array([[[3, 2, 0]],
                       [[0, 0, 0]]])
     np.testing.assert_allclose(cdq, check, tol)
 
     check = np.array([[[0.,    0.,    0.01]],
-                      [[0.005, 0.005, 0.01]]])
+                      [[0.005, 0.01, 0.01]]])
     np.testing.assert_allclose(cvp, check, tol)
 
     check = np.array([[[0.,         0.,         0.19999999]],
@@ -637,7 +634,7 @@ def test_one_group_ramp_suppressed_two_integrations():
     np.testing.assert_allclose(cvr, check, tol)
 
     check = np.array([[[0.,         0.,         0.4582576]],
-                      [[0.45276922, 0.45276922, 0.4582576]]])
+                      [[0.45276922, 0.4582576, 0.4582576]]])
     np.testing.assert_allclose(cerr, check, tol)
 
 
@@ -665,7 +662,7 @@ def test_one_group_ramp_not_suppressed_two_integrations():
     np.testing.assert_allclose(serr, check, tol)
 
     # Check slopes information
-    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+    cdata, cdq, cvp, cvr, cerr = cube
 
     check = np.array([[[0.,        1.,        1.0000001]],
                       [[1.0000001, 1.0000001, 1.0000001]]])
@@ -710,7 +707,7 @@ def create_zero_frame_data():
     err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
-    int_times = np.zeros((nints,))
+    zframe = np.ones(shape=(nints, nrows, ncols), dtype=np.float32)
 
     # Create base ramps for each pixel in each integration.
     base_slope = 2000.0
@@ -722,32 +719,30 @@ def create_zero_frame_data():
     data[0, :, 0, 2] = base_ramp
     data[1, :, :, :] = data[0, :, :, :] / 2.
 
-    # Compute dummy ZEROFRAME data.
+    # ZEROFRAME data.
     fdn = (data[0, 1, 0, 0] - data[0, 0, 0, 0]) / (nframes + groupgap)
-    data[0, 0, 0, 2] = data[0, 0, 0, 2] - (fdn * 2.5)
+    dummy = data[0, 0, 0, 2] - (fdn * 2.5)
+    zframe[0, 0, :] *= dummy
+    zframe[0, 0, 1] = 0.  # ZEROFRAME is saturated too.
+    fdn = (data[1, 1, 0, 0] - data[1, 0, 0, 0]) / (nframes + groupgap)
+    dummy = data[1, 0, 0, 2] - (fdn * 2.5)
+    zframe[1, 0, :] *= dummy
 
     # Set up group DQ array.
     gdq[0, :, :, :] = dqflags["SATURATED"]
     gdq[0, 0, 0, 0] = dqflags["GOOD"]
-    gdq[0, 0, 0, 2] = dqflags["GOOD"]
 
     # Create RampData for testing.
     ramp_data = RampData()
     ramp_data.set_arrays(
-        data=data, err=err, groupdq=gdq, pixeldq=pixdq, int_times=int_times)
+        data=data, err=err, groupdq=gdq, pixeldq=pixdq)
     ramp_data.set_meta(
-        name="MIRI", frame_time=frame_time, group_time=group_time,
+        name="NIRCam", frame_time=frame_time, group_time=group_time,
         groupgap=groupgap, nframes=nframes, drop_frames1=None)
     ramp_data.set_dqflags(dqflags)
 
-    # Create ZEROFRAME information
-    # ramp_data.zframe_locs = [[], [(0, 2)]]
-    ramp_data.zframe_locs = [None] * nints
-    ramp_data.zframe_locs[0] = []
-    ramp_data.zframe_locs[0].append((0, 2))
-    ramp_data.zframe_locs[1] = []
-
-    ramp_data.zframe_cnt = 1
+    ramp_data.suppress_one_group_ramps = False
+    ramp_data.zeroframe = zframe
 
     # Create variance arrays
     gain = np.ones((nrows, ncols), np.float32) * gval
@@ -774,6 +769,8 @@ def test_zeroframe():
         ramp_data, bufsize, save_opt, rnoise, gain, algo,
         "optimal", ncores, dqflags)
 
+    # return
+
     tol = 1.e-5
 
     # Check slopes information
@@ -795,7 +792,7 @@ def test_zeroframe():
     np.testing.assert_allclose(serr, check, tol, tol)
 
     # Check slopes information
-    cdata, cdq, cvp, cvr, cint_times, cerr = cube
+    cdata, cdq, cvp, cvr, cerr = cube
 
     check = np.array([[[149.0313, 0., 130.40239]],
                       [[18.62891, 18.62891, 18.62891]]])
@@ -834,7 +831,6 @@ def setup_inputs(dims, var, tm):
     err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
-    int_times = np.zeros((nints,))
 
     base_array = np.array([k + 1 for k in range(ngroups)])
     base, inc = 1.5, 1.5
@@ -848,7 +844,7 @@ def setup_inputs(dims, var, tm):
 
     ramp_data = RampData()
     ramp_data.set_arrays(
-        data=data, err=err, groupdq=gdq, pixeldq=pixdq, int_times=int_times)
+        data=data, err=err, groupdq=gdq, pixeldq=pixdq)
     ramp_data.set_meta(
         name="MIRI", frame_time=dtime, group_time=gtime, groupgap=0,
         nframes=nframes, drop_frames1=None)
@@ -919,27 +915,27 @@ def print_slopes(slopes):
 
 
 def print_integ_data(integ_info):
-    idata, idq, ivp, ivr, int_times, ierr = integ_info
+    idata, idq, ivp, ivr, ierr = integ_info
     base_print("Integration data:", idata)
 
 
 def print_integ_gdq(integ_info):
-    idata, idq, ivp, ivr, int_times, ierr = integ_info
+    idata, idq, ivp, ivr, ierr = integ_info
     base_print("Integration DQ:", idq)
 
 
 def print_integ_poisson(integ_info):
-    idata, idq, ivp, ivr, int_times, ierr = integ_info
+    idata, idq, ivp, ivr, ierr = integ_info
     base_print("Integration Poisson:", ivp)
 
 
 def print_integ_rnoise(integ_info):
-    idata, idq, ivp, ivr, int_times, ierr = integ_info
+    idata, idq, ivp, ivr, ierr = integ_info
     base_print("Integration read noise:", ivr)
 
 
 def print_integ_err(integ_info):
-    idata, idq, ivp, ivr, int_times, ierr = integ_info
+    idata, idq, ivp, ivr, ierr = integ_info
     base_print("Integration err:", ierr)
 
 
@@ -1006,7 +1002,7 @@ def print_optional(optional):
 def print_all_info(slopes, cube, optional):
     """
     sdata, sdq, svp, svr, serr = slopes
-    idata, idq, ivp, ivr, int_times, ierr = cube
+    idata, idq, ivp, ivr, ierr = cube
     oslope, osigslope, ovp, ovr, \
         oyint, osigyint, opedestal, oweights, ocrmag = optional
     """

--- a/tests/test_ramp_fitting_gls_fit.py
+++ b/tests/test_ramp_fitting_gls_fit.py
@@ -65,10 +65,9 @@ def setup_inputs(dims, gain, rnoise, group_time, frame_time):
     err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     groupdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     pixeldq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
-    int_times = np.zeros((nints,))
 
     # Set clas arrays
-    ramp_class.set_arrays(data, err, groupdq, pixeldq, int_times)
+    ramp_class.set_arrays(data, err, groupdq, pixeldq)
 
     # Set class meta
     ramp_class.set_meta(


### PR DESCRIPTION
The multiprocessing feature of ramp fitting was failing.  To ensure new features worked properly with multiprocessing the unneeded one group suppression list got removed and the `ZEROFRAME` handling got moved to after multiprocessing to ensure proper usage.

The primary cause of the multiprocessing failure was the `int_times` object, which is an `astropy.io` object that cannot be properly pickled.  Since it is not used in ramp fitting, it is no longer passed to `STCAL` ramp fitting.