### PR TITLE
JP-2611: Update handling of NO_SAT_CHECK in saturation step

### DIFF
--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -67,13 +67,14 @@ def flag_saturated_pixels(
     no_sat_check = dqflags['NO_SAT_CHECK']
 
     # For pixels flagged in reference file as NO_SAT_CHECK,
-    # set the saturation check threshold to the A-to-D converter limit.
-    sat_thresh[np.bitwise_and(sat_dq, no_sat_check) == no_sat_check] = atod_limit
+    # set the saturation check threshold above the A-to-D converter limit,
+    # so that they don't get flagged as saturated.
+    sat_thresh[np.bitwise_and(sat_dq, no_sat_check) == no_sat_check] = atod_limit + 1
 
-    # Also reset NaN values in the saturation threshold array to the
+    # Also reset NaN values in the saturation threshold array above the
     # A-to-D limit and flag them with NO_SAT_CHECK
     sat_dq[np.isnan(sat_thresh)] |= no_sat_check
-    sat_thresh[np.isnan(sat_thresh)] = atod_limit
+    sat_thresh[np.isnan(sat_thresh)] = atod_limit + 1
 
     for ints in range(nints):
         for group in range(ngroups):
@@ -171,6 +172,10 @@ def plane_saturation(plane, sat_thresh, dqflags):
     # Update the 4D gdq array with the saturation flag.
     # check for saturation
     flagarray[:, :] = np.where(plane[:, :] >= sat_thresh, saturated, 0)
+
+    log.debug(' plane[44,962]=%g', plane[44,962])
+    log.debug(' sat_thresh[44,962]=%g', sat_thresh[44,962])
+    log.debug(' flagarray[44,962]=%g', flagarray[44,962])
 
     # check for A/D floor
     flaglowarray[:, :] = np.where(plane[:, :] <= 0, ad_floor | donotuse, 0)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2611](https://jira.stsci.edu/browse/JP-2611)

<!-- describe the changes comprising this PR here -->
This PR makes a minor modification to the way pixels flagged with NO_SAT_CHECK or having thresholds of NaN are treated in terms of flagging as saturated. Previously, these pixels had their internal thresholds set to 65535 (the 16-bit A-to-D converter limit), but because the comparison is done as >= threshold, they would still get flagged as saturated in their raw values were 65535. JP-2611 requested that pixels flagged with NO_SAT_CHECK should never get flagged, regardless of their values. So this change simply sets the internal threshold for NO_SAT_CHECK and NaN pixels to 65535+1, which means they will never have values >= threshold and hence will never get flagged as saturated.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
