### PR TITLE
JP-2378: A Two Group Saturated Ramp Crashed Due to Incorrect Ndarray Shape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ ramp_fitting
 - Updating multi-integration processing to correctly combine multiple
   integration computations for the final image information. [#108]
 
+- Fixed crash due to two group ramps with saturated groups that used
+  an intermediate array with an incorrect shape. [#109]
+
 Changes to API
 --------------
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2378](https://jira.stsci.edu/browse/JP-2378)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a skipped test that crashed due to having an incorrect shape.  A saturated two group ramp caused an intermediate DQ array to have an incorrect shape.  Troubleshooting this I found small errors in computation due to bad variable names, like `gdq_cube` for a 4-D array.  The intermediate array shape error has been fixed, as well as the final DQ flags for ramps with saturated groups.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
