### PR TITLE
JP-2693: Flag groups do_not_use after detected ramp jumps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ General
 - Made style changes due to the new 5.0.3 version of flake8, which
   noted many missing white spaces after keywords. [#114]
 
+jump
+~~~~
+
+ - Added flagging after detected ramp jumps based on two DN thresholds and
+   two number of groups to flag [#110]
+
 Bug Fixes
 ---------
 
@@ -139,7 +145,7 @@ saturation
 - Pin astropy min version to 5.0.4. [#82]
 
 - Fix for jumps in first good group after dropping groups [#84]
-  
+
 
 0.6.2 (22-03-29)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,12 +7,6 @@ General
 - Made style changes due to the new 5.0.3 version of flake8, which
   noted many missing white spaces after keywords. [#114]
 
-jump
-~~~~
-
- - Added flagging after detected ramp jumps based on two DN thresholds and
-   two number of groups to flag [#110]
-
 Bug Fixes
 ---------
 
@@ -31,7 +25,11 @@ ramp_fitting
 Changes to API
 --------------
 
+jump
+~~~~
 
+ - Added flagging after detected ramp jumps based on two DN thresholds and
+   two number of groups to flag [#110]
 
 1.0.0 (2022-06-24)
 ==================

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -144,12 +144,13 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
     elif max_cores == 'all':
         n_slices = max_available
 
+    flag_n_after_jump = 5
     if n_slices == 1:
         gdq, row_below_dq, row_above_dq = \
             twopt.find_crs(data, gdq, readnoise_2d, rejection_thresh,
                            three_grp_thresh, four_grp_thresh, frames_per_group,
                            flag_4_neighbors, max_jump_to_flag_neighbors,
-                           min_jump_to_flag_neighbors, dqflags)
+                           min_jump_to_flag_neighbors, flag_n_after_jump, dqflags)
 
         elapsed = time.time() - start
     else:
@@ -174,7 +175,8 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
                               rejection_thresh, three_grp_thresh, four_grp_thresh,
                               frames_per_group, flag_4_neighbors,
                               max_jump_to_flag_neighbors,
-                              min_jump_to_flag_neighbors, dqflags, copy_arrs))
+                              min_jump_to_flag_neighbors, flag_n_after_jump, dqflags,
+                              copy_arrs))
 
         # last slice get the rest
         slices.insert(n_slices - 1, (data[:, :, (n_slices - 1) * yinc:n_rows, :],
@@ -183,7 +185,8 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
                                      rejection_thresh, three_grp_thresh,
                                      four_grp_thresh, frames_per_group,
                                      flag_4_neighbors, max_jump_to_flag_neighbors,
-                                     min_jump_to_flag_neighbors, dqflags, copy_arrs))
+                                     min_jump_to_flag_neighbors, flag_n_after_jump,
+                                     dqflags, copy_arrs))
         log.info("Creating %d processes for jump detection " % n_slices)
         pool = multiprocessing.Pool(processes=n_slices)
         # Starts each slice in its own process. Starmap allows more than one

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -134,6 +134,9 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
     data *= gain_2d
     err *= gain_2d
     readnoise_2d *= gain_2d
+    # also apply to the after_jump thresholds
+    after_jump_flag_e1 = after_jump_flag_dn1 * gain_2d
+    after_jump_flag_e2 = after_jump_flag_dn2 * gain_2d
 
     # Apply the 2-point difference method as a first pass
     log.info('Executing two-point difference method')
@@ -168,9 +171,9 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
                            three_grp_thresh, four_grp_thresh, frames_per_group,
                            flag_4_neighbors, max_jump_to_flag_neighbors,
                            min_jump_to_flag_neighbors, dqflags,
-                           after_jump_flag_dn1=after_jump_flag_dn1,
+                           after_jump_flag_e1=after_jump_flag_e1,
                            after_jump_flag_n1=after_jump_flag_n1,
-                           after_jump_flag_dn2=after_jump_flag_dn2,
+                           after_jump_flag_e2=after_jump_flag_e2,
                            after_jump_flag_n2=after_jump_flag_n2)
 
         elapsed = time.time() - start
@@ -196,10 +199,10 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
                               rejection_thresh, three_grp_thresh, four_grp_thresh,
                               frames_per_group, flag_4_neighbors,
                               max_jump_to_flag_neighbors,
-                              min_jump_to_flag_neighbors,
-                              after_jump_flag_dn1, after_jump_flag_n1,
-                              after_jump_flag_dn2, after_jump_flag_n2,
-                              dqflags, copy_arrs))
+                              min_jump_to_flag_neighbors, dqflags,
+                              after_jump_flag_e1, after_jump_flag_n1,
+                              after_jump_flag_e2, after_jump_flag_n2,
+                              copy_arrs))
 
         # last slice get the rest
         slices.insert(n_slices - 1, (data[:, :, (n_slices - 1) * yinc:n_rows, :],
@@ -208,10 +211,10 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
                                      rejection_thresh, three_grp_thresh,
                                      four_grp_thresh, frames_per_group,
                                      flag_4_neighbors, max_jump_to_flag_neighbors,
-                                     min_jump_to_flag_neighbors,
-                                     after_jump_flag_dn1, after_jump_flag_n1,
-                                     after_jump_flag_dn2, after_jump_flag_n2,
-                                     dqflags, copy_arrs))
+                                     min_jump_to_flag_neighbors, dqflags,
+                                     after_jump_flag_e1, after_jump_flag_n1,
+                                     after_jump_flag_e2, after_jump_flag_n2,
+                                     copy_arrs))
         log.info("Creating %d processes for jump detection " % n_slices)
         pool = multiprocessing.Pool(processes=n_slices)
         # Starts each slice in its own process. Starmap allows more than one

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -14,9 +14,10 @@ log.setLevel(logging.DEBUG)
 def detect_jumps(frames_per_group, data, gdq, pdq, err,
                  gain_2d, readnoise_2d, rejection_thresh,
                  three_grp_thresh, four_grp_thresh, max_cores, max_jump_to_flag_neighbors,
+                 min_jump_to_flag_neighbors, flag_4_neighbors,
                  after_jump_flag_dn1, after_jump_flag_n1,
                  after_jump_flag_dn2, after_jump_flag_n2,
-                 min_jump_to_flag_neighbors, flag_4_neighbors, dqflags):
+                 dqflags):
     """
     This is the high-level controlling routine for the jump detection process.
     It loads and sets the various input data and parameters needed by each of
@@ -165,6 +166,7 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
             twopt.find_crs(data, gdq, readnoise_2d, rejection_thresh,
                            three_grp_thresh, four_grp_thresh, frames_per_group,
                            flag_4_neighbors, max_jump_to_flag_neighbors,
+                           min_jump_to_flag_neighbors,
                            after_jump_flag_dn1, after_jump_flag_n1,
                            after_jump_flag_dn2, after_jump_flag_n2,
                            dqflags)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -93,20 +93,20 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
         DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, GOOD
 
     after_jump_flag_dn1 : float
-        1st flag after jumps with the specified DN jump
-        to remove the transient seen from the slope calculation
+        Jumps with amplitudes above the specified DN value will have subsequent
+        groups flagged with the number determined by the after_jump_flag_n1
 
     after_jump_flag_n1 : int
-        1st flag n groups after companion threshold
-        to remove the transient seen from the slope calculation
+        Gives the number of groups to flag after jumps with DN values above that
+        given by after_jump_flag_dn1
 
     after_jump_flag_dn2 : float
-        2nd flag after jumps with the specified DN jump
-        to remove the transient seen from the slope calculation
+        Jumps with amplitudes above the specified DN value will have subsequent
+        groups flagged with the number determined by the after_jump_flag_n2
 
     after_jump_flag_n2 : int
-        2nd flag n groups after companion threshold
-        to remove the transient seen from the slope calculation
+        Gives the number of groups to flag after jumps with DN values above that
+        given by after_jump_flag_dn2
 
     Returns
     -------

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -14,10 +14,11 @@ log.setLevel(logging.DEBUG)
 def detect_jumps(frames_per_group, data, gdq, pdq, err,
                  gain_2d, readnoise_2d, rejection_thresh,
                  three_grp_thresh, four_grp_thresh, max_cores, max_jump_to_flag_neighbors,
-                 min_jump_to_flag_neighbors, flag_4_neighbors,
-                 after_jump_flag_dn1, after_jump_flag_n1,
-                 after_jump_flag_dn2, after_jump_flag_n2,
-                 dqflags):
+                 min_jump_to_flag_neighbors, flag_4_neighbors, dqflags,
+                 after_jump_flag_dn1=0.0,
+                 after_jump_flag_n1=0,
+                 after_jump_flag_dn2=0.0,
+                 after_jump_flag_n2=0):
     """
     This is the high-level controlling routine for the jump detection process.
     It loads and sets the various input data and parameters needed by each of
@@ -87,6 +88,10 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
         if set to True (default is True), it will cause the four perpendicular
         neighbors of all detected jumps to also be flagged as a jump.
 
+    dqflags: dict
+        A dictionary with at least the following keywords:
+        DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, GOOD
+
     after_jump_flag_dn1 : float
         1st flag after jumps with the specified DN jump
         to remove the transient seen from the slope calculation
@@ -102,10 +107,6 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
     after_jump_flag_n2 : int
         2nd flag n groups after companion threshold
         to remove the transient seen from the slope calculation
-
-    dqflags: dict
-        A dictionary with at least the following keywords:
-        DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, GOOD
 
     Returns
     -------
@@ -166,10 +167,11 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
             twopt.find_crs(data, gdq, readnoise_2d, rejection_thresh,
                            three_grp_thresh, four_grp_thresh, frames_per_group,
                            flag_4_neighbors, max_jump_to_flag_neighbors,
-                           min_jump_to_flag_neighbors,
-                           after_jump_flag_dn1, after_jump_flag_n1,
-                           after_jump_flag_dn2, after_jump_flag_n2,
-                           dqflags)
+                           min_jump_to_flag_neighbors, dqflags,
+                           after_jump_flag_dn1=after_jump_flag_dn1,
+                           after_jump_flag_n1=after_jump_flag_n1,
+                           after_jump_flag_dn2=after_jump_flag_dn2,
+                           after_jump_flag_n2=after_jump_flag_n2)
 
         elapsed = time.time() - start
     else:

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -301,7 +301,8 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
         #                 uplimit = flag_dn_threshold[1]
         #         cdn_jumps = dn_jump[cr_group, cr_row, cr_col]
         #         flagcrs = (cdn_jumps >= flag_dn_threshold[jj]) & (cdn_jumps < uplimit)
-        #         log.info(f"Flagging {flag_groups[jj]} groups after {flag_dn_threshold[jj]} DN jumps for {np.sum(flagcrs)} pixels.")
+        #         log.info(f"Flagging {flag_groups[jj]} groups after {flag_dn_threshold[jj]}
+        #                   DN jumps for {np.sum(flagcrs)} pixels.")
         #         for group, row, col in zip(cr_group[flagcrs], cr_row[flagcrs], cr_col[flagcrs]):
         #             for kk in range(group, min(group + flag_groups[jj], ngroups)):
         #                 if (gdq[integ, kk, row, col] & sat_flag) == 0:

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -63,21 +63,21 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
         A dictionary with at least the following keywords:
         DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, GOOD
 
-    after_jump_flag_e1 : float, 2D array
-        1st flag after jumps with the specified electron jump per pixel
-        to remove the transient seen from the slope calculation
+    after_jump_flag_e1 : float
+        Jumps with amplitudes above the specified e value will have subsequent
+        groups flagged with the number determined by the after_jump_flag_n1
 
     after_jump_flag_n1 : int
-        1st flag n groups after companion threshold
-        to remove the transient seen from the slope calculation
+        Gives the number of groups to flag after jumps with DN values above that
+        given by after_jump_flag_dn1
 
-    after_jump_flag_e2 : float, 2D array
-        2nd flag after jumps with the specified electron jump per pixel
-        to remove the transient seen from the slope calculation
+    after_jump_flag_e2 : float
+        Jumps with amplitudes above the specified e value will have subsequent
+        groups flagged with the number determined by the after_jump_flag_n2
 
     after_jump_flag_n2 : int
-        2nd flag n groups after companion threshold
-        to remove the transient seen from the slope calculation
+        Gives the number of groups to flag after jumps with DN values above that
+        given by after_jump_flag_dn2
 
     copy_arrs : bool
         Flag for making internal copies of the arrays so the input isn't modified,
@@ -282,7 +282,8 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
                                 gdq[integ, group, row, col + 1] =\
                                     np.bitwise_or(gdq[integ, group, row, col + 1], jump_flag)
 
-        # flag n groups after all jumps to account for the transient seen
+        # flag n groups after jumps above the specified thresholds to account for
+        # the transient seen after ramp jumps
         flag_e_threshold = [after_jump_flag_e1, after_jump_flag_e2]
         flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
 

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -263,6 +263,8 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
 
         # flag n groups after all jumps to account for the transient seen
         if flag_n_after_jump > 0:
+            log.info(f"Flagging {flag_n_after_jump} extra groups after all detected jumps.")
+
             cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq[integ], jump_flag))
 
             for j in range(len(cr_group)):
@@ -279,6 +281,8 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
                 # print(gdq[integ, :, row, col])
                 # if j > 10:
                 #     exit()
+        else:
+            log.info("No extra groups flagged after detected jumps.")
 
     return gdq, row_below_gdq, row_above_gdq
 

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -9,9 +9,9 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
              two_diff_rej_thresh, three_diff_rej_thresh, nframes,
              flag_4_neighbors, max_jump_to_flag_neighbors,
              min_jump_to_flag_neighbors, dqflags,
-             after_jump_flag_dn1=0.0,
+             after_jump_flag_e1=0.0,
              after_jump_flag_n1=0,
-             after_jump_flag_dn2=0.0,
+             after_jump_flag_e2=0.0,
              after_jump_flag_n2=0,
              copy_arrs=True):
 
@@ -63,16 +63,16 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
         A dictionary with at least the following keywords:
         DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, GOOD
 
-    after_jump_flag_dn1 : float
-        1st flag after jumps with the specified DN jump
+    after_jump_flag_e1 : float
+        1st flag after jumps with the specified electron jump
         to remove the transient seen from the slope calculation
 
     after_jump_flag_n1 : int
         1st flag n groups after companion threshold
         to remove the transient seen from the slope calculation
 
-    after_jump_flag_dn2 : float
-        2nd flag after jumps with the specified DN jump
+    after_jump_flag_e2 : float
+        2nd flag after jumps with the specified electron jump
         to remove the transient seen from the slope calculation
 
     after_jump_flag_n2 : int
@@ -283,7 +283,7 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
                                     np.bitwise_or(gdq[integ, group, row, col + 1], jump_flag)
 
         # flag n groups after all jumps to account for the transient seen
-        flag_dn_threshold = [after_jump_flag_dn1, after_jump_flag_dn2]
+        flag_dn_threshold = [after_jump_flag_e1, after_jump_flag_e2]
         flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
         # ensure the smallest threshold is 1st
         # if flag_dn_threshold[0] > flag_dn_threshold[1]:
@@ -311,13 +311,15 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
 
         for cthres, cgroup in zip(flag_dn_threshold, flag_groups):
             if cgroup > 0:
-                log.info(f"Flagging {cgroup} groups after detected jumps with DN >= {cthres}.")
+                log.info(f"Flagging {cgroup} groups after detected jumps with e >= {np.mean(cthres)}.")
 
                 for j in range(len(cr_group)):
                     group = cr_group[j]
                     row = cr_row[j]
                     col = cr_col[j]
-                    if dn_jump[group - 1, row, col] >= cthres:
+                    if dn_jump[group - 1, row, col] >= cthres[row, col]:
+                        # print("stcal ", group, group + cgroup + 1,
+                        #       dn_jump[group - 1, row, col], cthres[row, col])
                         for kk in range(group, min(group + cgroup + 1, ngroups)):
                             if (gdq[integ, kk, row, col] & sat_flag) == 0:
                                 if (gdq[integ, kk, row, col] & dnu_flag) == 0:

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -280,6 +280,8 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
                                     np.bitwise_or(gdq[integ, group, row, col + 1], jump_flag)
 
         # flag n groups after all jumps to account for the transient seen
+        dn_diff = first_diffs - median_diffs[np.newaxis, :, :]
+
         flag_dn_threshold = [after_jump_flag_dn1, after_jump_flag_dn2]
         flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
         for cthres, cgroup in zip(flag_dn_threshold, flag_groups):
@@ -292,13 +294,20 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
                     group = cr_group[j]
                     row = cr_row[j]
                     col = cr_col[j]
-                    # print(j)
+                    # print(j, row, col)
                     # print(gdq[integ, :, row, col])
-                    for kk in range(group, min(group + cgroup, ngroups)):
-                        if (gdq[integ, kk, row, col] & sat_flag) == 0:
-                            if (gdq[integ, kk, row, col] & dnu_flag) == 0:
-                                gdq[integ, kk, row, col] =\
-                                    np.bitwise_or(gdq[integ, kk, row, col], jump_flag)
+                    # print(dataa[integ, :, row, col])
+                    # print(group)
+                    # print(dataa[integ, group + 1, row, col] - dataa[integ, group, row, col])
+                    # print(dn_diff[:, row, col])
+                    # print(dn_diff[group-1, row, col], dn_diff[group, row, col], dn_diff[group + 1, row, col])
+                    # exit()
+                    if dn_diff[group - 1, row, col] > cthres:
+                        for kk in range(group, min(group + cgroup, ngroups)):
+                            if (gdq[integ, kk, row, col] & sat_flag) == 0:
+                                if (gdq[integ, kk, row, col] & dnu_flag) == 0:
+                                    gdq[integ, kk, row, col] =\
+                                        np.bitwise_or(gdq[integ, kk, row, col], jump_flag)
                     # print(gdq[integ, :, row, col])
                     # if j > 10:
                     #     exit()

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -8,10 +8,12 @@ log.setLevel(logging.DEBUG)
 def find_crs(dataa, group_dq, read_noise, rejection_thresh,
              two_diff_rej_thresh, three_diff_rej_thresh, nframes,
              flag_4_neighbors, max_jump_to_flag_neighbors,
-             min_jump_to_flag_neighbors,
-             after_jump_flag_dn1, after_jump_flag_n1,
-             after_jump_flag_dn2, after_jump_flag_n2,
-             dqflags, copy_arrs=True):
+             min_jump_to_flag_neighbors, dqflags,
+             after_jump_flag_dn1=0.0,
+             after_jump_flag_n1=0,
+             after_jump_flag_dn2=0.0,
+             after_jump_flag_n2=0,
+             copy_arrs=True):
 
     """
     Find CRs/Jumps in each integration within the input data array. The input
@@ -57,6 +59,10 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
         neighbors (marginal detections). Any primary jump below this value will
         not have its neighbors flagged.
 
+    dqflags: dict
+        A dictionary with at least the following keywords:
+        DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, GOOD
+
     after_jump_flag_dn1 : float
         1st flag after jumps with the specified DN jump
         to remove the transient seen from the slope calculation
@@ -72,10 +78,6 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
     after_jump_flag_n2 : int
         2nd flag n groups after companion threshold
         to remove the transient seen from the slope calculation
-
-    dqflags: dict
-        A dictionary with at least the following keywords:
-        DO_NOT_USE, SATURATED, JUMP_DET, NO_GAIN_VALUE, GOOD
 
     copy_arrs : bool
         Flag for making internal copies of the arrays so the input isn't modified,
@@ -284,9 +286,9 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
         flag_dn_threshold = [after_jump_flag_dn1, after_jump_flag_dn2]
         flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
         # ensure the smallest threshold is 1st
-        if flag_dn_threshold[0] > flag_dn_threshold[1]:
-            flag_dn_threshold = np.flip(flag_dn_threshold)
-            flag_groups = np.flip(flag_groups)
+        # if flag_dn_threshold[0] > flag_dn_threshold[1]:
+        #     flag_dn_threshold = np.flip(flag_dn_threshold)
+        #     flag_groups = np.flip(flag_groups)
 
         cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq[integ], jump_flag))
 
@@ -316,7 +318,7 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
                     row = cr_row[j]
                     col = cr_col[j]
                     if dn_jump[group - 1, row, col] >= cthres:
-                        for kk in range(group, min(group + cgroup, ngroups)):
+                        for kk in range(group, min(group + cgroup + 1, ngroups)):
                             if (gdq[integ, kk, row, col] & sat_flag) == 0:
                                 if (gdq[integ, kk, row, col] & dnu_flag) == 0:
                                     gdq[integ, kk, row, col] =\

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -289,17 +289,16 @@ def find_crs(dataa, group_dq, read_noise, rejection_thresh,
             flag_groups = np.flip(flag_groups)
 
         cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq[integ], jump_flag))
-        #
-        #  **should** work and be faster.  But does not.  Sigh.
-        #
+
+        # **should** work and be faster.  But does not.  Sigh.
         # for jj in range(2):
         #     if flag_groups[jj] > 0:
         #         uplimit = 1e6
         #         if jj == 0:
         #             if flag_groups[1] > 0:
         #                 uplimit = flag_dn_threshold[1]
-        #         print(jj, flag_dn_threshold[jj], uplimit)
-        #         flagcrs = (cr_group >= flag_dn_threshold[jj]) & (cr_group < uplimit)
+        #         cdn_jumps = dn_jump[cr_group, cr_row, cr_col]
+        #         flagcrs = (cdn_jumps >= flag_dn_threshold[jj]) & (cdn_jumps < uplimit)
         #         log.info(f"Flagging {flag_groups[jj]} groups after {flag_dn_threshold[jj]} DN jumps for {np.sum(flagcrs)} pixels.")
         #         for group, row, col in zip(cr_group[flagcrs], cr_row[flagcrs], cr_col[flagcrs]):
         #             for kk in range(group, min(group + flag_groups[jj], ngroups)):

--- a/tests/test_twopoint_difference.py
+++ b/tests/test_twopoint_difference.py
@@ -852,7 +852,7 @@ def test_10grps_1cr_afterjump(setup_cube):
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_dn1=0.0,
+                                                     after_jump_flag_e1=0.0,
                                                      after_jump_flag_n1=10)
     # all groups after CR should be flagged
     for k in range(6, 10):
@@ -876,7 +876,7 @@ def test_10grps_1cr_afterjump_2group(setup_cube):
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_dn1=0.0,
+                                                     after_jump_flag_e1=0.0,
                                                      after_jump_flag_n1=2)
 
     # 2 groups after CR should be flagged
@@ -905,7 +905,7 @@ def test_10grps_1cr_afterjump_toosmall(setup_cube):
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_dn1=10000,
+                                                     after_jump_flag_e1=10000,
                                                      after_jump_flag_n1=10)
     # all groups after CR should be flagged
     for k in range(7, 10):
@@ -929,9 +929,9 @@ def test_10grps_1cr_afterjump_twothresholds(setup_cube):
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_dn1=500,
+                                                     after_jump_flag_e1=500,
                                                      after_jump_flag_n1=10,
-                                                     after_jump_flag_dn2=10,
+                                                     after_jump_flag_e2=10,
                                                      after_jump_flag_n2=2)
     # 2 groups after CR should be flagged
     for k in range(2, 5):

--- a/tests/test_twopoint_difference.py
+++ b/tests/test_twopoint_difference.py
@@ -835,6 +835,113 @@ def test_first_last_3group(setup_cube):
     assert outgdq[0, 1, 0, 0] == 0
 
 
+def test_10grps_1cr_afterjump(setup_cube):
+    ngroups = 10
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 21
+    data[0, 3, 100, 100] = 33
+    data[0, 4, 100, 100] = 46
+    data[0, 5, 100, 100] = 60
+    data[0, 6, 100, 100] = 1160
+    data[0, 7, 100, 100] = 1175
+    data[0, 8, 100, 100] = 1190
+    data[0, 9, 100, 100] = 1209
+    out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                     rej_threshold, rej_threshold, nframes,
+                                                     False, 200, 10, DQFLAGS,
+                                                     after_jump_flag_dn1=0.0,
+                                                     after_jump_flag_n1=10)
+    # all groups after CR should be flagged
+    for k in range(6, 10):
+        assert 4 == out_gdq[0, k, 100, 100], f"after jump flagging failed in group {k}"
+
+
+def test_10grps_1cr_afterjump_2group(setup_cube):
+    ngroups = 10
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 21
+    data[0, 3, 100, 100] = 33
+    data[0, 4, 100, 100] = 46
+    data[0, 5, 100, 100] = 60
+    data[0, 6, 100, 100] = 1160
+    data[0, 7, 100, 100] = 1175
+    data[0, 8, 100, 100] = 1190
+    data[0, 9, 100, 100] = 1209
+    out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                     rej_threshold, rej_threshold, nframes,
+                                                     False, 200, 10, DQFLAGS,
+                                                     after_jump_flag_dn1=0.0,
+                                                     after_jump_flag_n1=2)
+
+    # 2 groups after CR should be flagged
+    for k in range(6, 9):
+        assert 4 == out_gdq[0, k, 100, 100], f"after jump flagging failed in group {k}"
+
+    # rest not flagged
+    for k in range(9, 10):
+        assert 0 == out_gdq[0, k, 100, 100], f"after jump flagging incorrect in group {k}"
+
+
+def test_10grps_1cr_afterjump_toosmall(setup_cube):
+    ngroups = 10
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 21
+    data[0, 3, 100, 100] = 33
+    data[0, 4, 100, 100] = 46
+    data[0, 5, 100, 100] = 60
+    data[0, 6, 100, 100] = 1160
+    data[0, 7, 100, 100] = 1175
+    data[0, 8, 100, 100] = 1190
+    data[0, 9, 100, 100] = 1209
+    out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                     rej_threshold, rej_threshold, nframes,
+                                                     False, 200, 10, DQFLAGS,
+                                                     after_jump_flag_dn1=10000,
+                                                     after_jump_flag_n1=10)
+    # all groups after CR should be flagged
+    for k in range(7, 10):
+        assert 0 == out_gdq[0, k, 100, 100], f"after jump flagging incorrect in group {k}"
+
+
+def test_10grps_1cr_afterjump_twothresholds(setup_cube):
+    ngroups = 10
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 121
+    data[0, 3, 100, 100] = 133
+    data[0, 4, 100, 100] = 146
+    data[0, 5, 100, 100] = 160
+    data[0, 6, 100, 100] = 1160
+    data[0, 7, 100, 100] = 1175
+    data[0, 8, 100, 100] = 1190
+    data[0, 9, 100, 100] = 1209
+    out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
+                                                     rej_threshold, rej_threshold, nframes,
+                                                     False, 200, 10, DQFLAGS,
+                                                     after_jump_flag_dn1=500,
+                                                     after_jump_flag_n1=10,
+                                                     after_jump_flag_dn2=10,
+                                                     after_jump_flag_n2=2)
+    # 2 groups after CR should be flagged
+    for k in range(2, 5):
+        assert 4 == out_gdq[0, k, 100, 100], f"after jump flagging incorrect in group {k}"
+
+    # all groups after CR should be flagged
+    for k in range(6, 10):
+        assert 4 == out_gdq[0, k, 100, 100], f"after jump flagging incorrect in group {k}"
+
+
 def test_median_func():
 
     """

--- a/tests/test_twopoint_difference.py
+++ b/tests/test_twopoint_difference.py
@@ -849,10 +849,12 @@ def test_10grps_1cr_afterjump(setup_cube):
     data[0, 7, 100, 100] = 1175
     data[0, 8, 100, 100] = 1190
     data[0, 9, 100, 100] = 1209
+
+    after_jump_flag_e1 = np.full(data.shape[2:4], 1.0) * 0.0
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_e1=0.0,
+                                                     after_jump_flag_e1=after_jump_flag_e1,
                                                      after_jump_flag_n1=10)
     # all groups after CR should be flagged
     for k in range(6, 10):
@@ -873,10 +875,12 @@ def test_10grps_1cr_afterjump_2group(setup_cube):
     data[0, 7, 100, 100] = 1175
     data[0, 8, 100, 100] = 1190
     data[0, 9, 100, 100] = 1209
+
+    after_jump_flag_e1 = np.full(data.shape[2:4], 1.0) * 0.0
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_e1=0.0,
+                                                     after_jump_flag_e1=after_jump_flag_e1,
                                                      after_jump_flag_n1=2)
 
     # 2 groups after CR should be flagged
@@ -902,10 +906,12 @@ def test_10grps_1cr_afterjump_toosmall(setup_cube):
     data[0, 7, 100, 100] = 1175
     data[0, 8, 100, 100] = 1190
     data[0, 9, 100, 100] = 1209
+
+    after_jump_flag_e1 = np.full(data.shape[2:4], 1.0) * 10000.0
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_e1=10000,
+                                                     after_jump_flag_e1=after_jump_flag_e1,
                                                      after_jump_flag_n1=10)
     # all groups after CR should be flagged
     for k in range(7, 10):
@@ -926,12 +932,15 @@ def test_10grps_1cr_afterjump_twothresholds(setup_cube):
     data[0, 7, 100, 100] = 1175
     data[0, 8, 100, 100] = 1190
     data[0, 9, 100, 100] = 1209
+
+    after_jump_flag_e1 = np.full(data.shape[2:4], 1.0) * 500.
+    after_jump_flag_e2 = np.full(data.shape[2:4], 1.0) * 10.
     out_gdq, row_below_gdq, row_above_gdq = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS,
-                                                     after_jump_flag_e1=500,
+                                                     after_jump_flag_e1=after_jump_flag_e1,
                                                      after_jump_flag_n1=10,
-                                                     after_jump_flag_e2=10,
+                                                     after_jump_flag_e2=after_jump_flag_e2,
                                                      after_jump_flag_n2=2)
     # 2 groups after CR should be flagged
     for k in range(2, 5):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2693](https://jira.stsci.edu/browse/JP-2693)

<!-- describe the changes comprising this PR here -->
This PR implements the enhancement to the jump step where groups after detected ramps are flagged as jumps.  This "corrects" transients seen that make the slope after a jump different than before.  This PR allows for flagging to be different for two different jump thresholds.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
