### PR TITLE
JP-2817: GLS doesn't properly handle bad gain values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,9 +22,10 @@ ramp_fitting
 - Updating how NaNs and DO_NOT_USE flags are handled in the rateints
   product. [#112]
 
-- Updating how GLS handles bad gain values.  NaNs found in the image
-  data are set to 0.0 and the corresponding DQ flag is set to 
-  DO_NOT_USE. [#115]
+- Updating how GLS handles bad gain values.  NaNs and negative gain
+  values have the DO_NOT_USE and NO_GAIN_VALUE flag set.  Any NaNs
+  found in the image data are set to 0.0 and the corresponding DQ flag
+  is set to DO_NOT_USE. [#115]
 
 Changes to API
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ ramp_fitting
 - Updating how NaNs and DO_NOT_USE flags are handled in the rateints
   product. [#112]
 
+- Updating how GLS handles bad gain values. [#115]
+
 Changes to API
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,9 @@ ramp_fitting
 - Updating how NaNs and DO_NOT_USE flags are handled in the rateints
   product. [#112]
 
-- Updating how GLS handles bad gain values. [#115]
+- Updating how GLS handles bad gain values.  NaNs found in the image
+  data are set to 0.0 and the corresponding DQ flag is set to 
+  DO_NOT_USE. [#115]
 
 Changes to API
 --------------

--- a/src/stcal/ramp_fitting/gls_fit.py
+++ b/src/stcal/ramp_fitting/gls_fit.py
@@ -658,7 +658,7 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
     else:
         gls_opt_info = None
 
-    # Create new model...
+    # Get output image information
     if number_ints > 1:
         fslope, ferr = (slopes.astype(np.float32), gls_err.astype(np.float32))
     else:

--- a/src/stcal/ramp_fitting/gls_fit.py
+++ b/src/stcal/ramp_fitting/gls_fit.py
@@ -543,7 +543,6 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
     (intercept_int, intercept_err_int, pedestal_int, first_group, shape_ampl,
         ampl_int, ampl_err_int) = create_opt_res(save_opt, data.shape, max_num_cr)
 
-    # XXX Bad Gain Val
     pixeldq = utils.reset_bad_gain(ramp_data, pixeldq, gain_2d)  # Flag bad pixels in gain
 
     med_rates = None
@@ -661,10 +660,8 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
 
     # Create new model...
     if number_ints > 1:
-        # image_info = (slopes.astype(np.float32), final_pixeldq, gls_err.astype(np.float32))
         fslope, ferr = (slopes.astype(np.float32), gls_err.astype(np.float32))
     else:
-        # image_info = (slope_int[0], final_pixeldq, slope_err_int[0])
         fslope, ferr = (slope_int[0], slope_err_int[0])
 
     wh_nan = np.isnan(fslope)

--- a/src/stcal/ramp_fitting/gls_fit.py
+++ b/src/stcal/ramp_fitting/gls_fit.py
@@ -543,6 +543,9 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
     (intercept_int, intercept_err_int, pedestal_int, first_group, shape_ampl,
         ampl_int, ampl_err_int) = create_opt_res(save_opt, data.shape, max_num_cr)
 
+    # XXX Bad Gain Val
+    pixeldq = utils.reset_bad_gain(ramp_data, pixeldq, gain_2d)  # Flag bad pixels in gain
+
     med_rates = None
     if ngroups == 1:
         med_rates = utils.compute_median_rates(ramp_data)
@@ -656,30 +659,19 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
     else:
         gls_opt_info = None
 
-    '''
-    if number_ints > 1:
-        utils.log_stats(slopes)
-    else:
-        utils.log_stats(slope_int[0])
-    '''
-
-    '''
-    log.debug('Instrument: %s' % instrume)
-    log.debug('Number of pixels in 2D array: %d' % npix)
-    log.debug('Shape of 2D image: (%d, %d)' % imshape)
-    log.debug('Shape of data cube: (%d, %d, %d)' % cubeshape)
-    log.debug('Buffer size (bytes): %d' % buffsize)
-    log.debug('Number of rows per slice: %d' % rows_per_slice)
-    log.info('Number of groups per integration: %d' % nreads)
-    log.info('Number of integrations: %d' % n_int)
-    log.debug('The execution time in seconds: %f' % (tstop - tstart,))
-    '''
-
     # Create new model...
     if number_ints > 1:
-        image_info = (slopes.astype(np.float32), final_pixeldq, gls_err.astype(np.float32))
+        # image_info = (slopes.astype(np.float32), final_pixeldq, gls_err.astype(np.float32))
+        fslope, ferr = (slopes.astype(np.float32), gls_err.astype(np.float32))
     else:
-        image_info = (slope_int[0], final_pixeldq, slope_err_int[0])
+        # image_info = (slope_int[0], final_pixeldq, slope_err_int[0])
+        fslope, ferr = (slope_int[0], slope_err_int[0])
+
+    wh_nan = np.isnan(fslope)
+    fslope[wh_nan] = 0.0
+    final_pixeldq[wh_nan] |= ramp_data.flags_do_not_use
+
+    image_info = (fslope, final_pixeldq, ferr)
 
     return image_info, integ_info, gls_opt_info
 

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -875,7 +875,7 @@ def test_dq_multi_int_dnu():
     tm = frame_time, nframes, groupgap
 
     ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
-    base_arr = [(k+1) * 100 for k in range(ngroups)]
+    base_arr = [(k + 1) * 100 for k in range(ngroups)]
     dq_arr = [ramp.flags_do_not_use] * ngroups
 
     ramp.data[0, :, 0, 0] = np.array(base_arr)

--- a/tests/test_ramp_fitting_gls_fit.py
+++ b/tests/test_ramp_fitting_gls_fit.py
@@ -1,4 +1,3 @@
-import copy
 import pytest
 import numpy as np
 
@@ -142,7 +141,6 @@ def test_two_integrations():
         ramp_data, 512, save_opt, rnoise2d, gain2d, algo,
         "optimal", ncores, test_dq_flags)
 
-    ans = slopes[0][row, col]
     np.testing.assert_allclose(slopes[0][row, col], 133.3377685, 1e-6)
 
 

--- a/tests/test_ramp_fitting_gls_fit.py
+++ b/tests/test_ramp_fitting_gls_fit.py
@@ -281,9 +281,13 @@ def test_five_groups_two_integrations_Poisson_noise_only():
     np.testing.assert_allclose(out_slope, check, 75.0, 1e-6)
 
 
-@pytest.mark.skip(reason="GLS returns NaN's, but should return zeros.")
 def test_bad_gain_values():
-    nints, ngroups, nrows, ncols = 1, 5, 103, 102
+    """
+    Test for bad gain values where gain values are negative
+    and NaN.
+    """
+    nints, ngroups, nrows, ncols = 1, 5, 10, 11
+    r1, c1, r2, c2 = 3, 3, 7, 7
     dims = (nints, ngroups, nrows, ncols)
     rnoise, gain = 7, 2000
     group_time, frame_time = 3.0, 1
@@ -291,19 +295,21 @@ def test_bad_gain_values():
     ramp_data, gain2d, rnoise2d = setup_inputs(
         dims, gain, rnoise, group_time, frame_time
     )
-    gain2d[10, 10] = -10
-    gain2d[20, 20] = np.nan
+    gain2d[r1, c1] = -10
+    gain2d[r2, c2] = np.nan
 
+    # save_opt, algo, ncores = False, "OLS", "none"
     save_opt, algo, ncores = False, "GLS", "none"
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, 512, save_opt, rnoise2d, gain2d, algo,
         "optimal", ncores, test_dq_flags)
 
+    # data, dq, var_poisson, var_rnoise, err = slopes
     data, dq, err = slopes
     flag_check = NO_GAIN_VALUE | DO_NOT_USE
 
-    assert dq[10, 10] == flag_check
-    assert dq[20, 20] == flag_check
+    assert dq[r1, c1] == flag_check
+    assert dq[r2, c2] == flag_check
 
     # These asserts are wrong for some reason
     assert(0 == np.max(data))


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2817](https://jira.stsci.edu/browse/JP-2817)


<!-- describe the changes comprising this PR here -->
This PR addresses bad gain values.  Negative and NaN values should result in setting DQ flags for DO_NOT_USE and NO_GAIN_VALUE.  Also, NaN gain values results in NaNs in the final image product, which should not happen.  NaNs should be set to zero in the final image.


**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
