### PR TITLE
Jump modifies input data by gain multiplier (JP-2696).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ jump
 
  - Early in the step, the object arrays are converted from DN to electrons
    by multiplying by the gain. The values need to be reverted back to DN
-   at the end of the step. [#666]
+   at the end of the step. [#116]
 
 ramp_fitting
 ~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,13 @@ General
 Bug Fixes
 ---------
 
+jump
+~~~~
+
+ - Early in the step, the object arrays are converted from DN to electrons
+   by multiplying by the gain. The values need to be reverted back to DN
+   at the end of the step. [#666]
+
 ramp_fitting
 ~~~~~~~~~~~~
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -254,5 +254,11 @@ def detect_jumps(frames_per_group, data, gdq, pdq, err,
     elapsed = time.time() - start
     log.info('Total elapsed time = %g sec' % elapsed)
 
+    # Back out the applied gain to the SCI, ERR, and readnoise arrays so they're
+    #    back in units of DN
+    data /= gain_2d
+    err /= gain_2d
+    readnoise_2d /= gain_2d
+
     # Return the updated data quality arrays
     return gdq, pdq


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2696](https://jira.stsci.edu/browse/JP-2696)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/jwst/issues/6944

<!-- describe the changes comprising this PR here -->
This PR addresses https://github.com/spacetelescope/jwst/issues/6944 - "Jump detection modifies input data by gain multiplier". In this step the data in the input object is multiplied by the gain (converting from DN to electrons) within the algorithm. This PR reconverts that data back to DN at the end of the step. This solves the user's problem of not being able to test multiple jump detection parameters using the same input.

**Checklist**
- [X] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [X] added relevant label(s)
