### PR TITLE
use canonical filename of RTD configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@ documentation:
   - 'docs/**/*'
   - any: [ '*.rst', '!CHANGES.rst' ]
   - '*.md'
-  - '.readthedocs.yml'
+  - '.readthedocs.yaml'
   - 'LICENSE'
 
 installation:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,3 +53,6 @@ html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
 html_domain_indices = True
 html_sidebars = {"**": ["globaltoc.html", "relations.html", "searchbox.html"]}
 html_use_index = True
+
+# Enable nitpicky mode - which ensures that all references in the docs resolve.
+nitpicky = True


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
update the name of the ReadTheDocs configuration file to `.readthedocs.yaml` and add `nitpicky` and `fail_on_warning`

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
