### PR TITLE
JP-2938: Fix total frames computation in dark current

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@
 Bug Fixes
 ---------
 
+dark_current
+~~~~~~~~~~~~
+
+- Bug fix for computation of the total number of frames when science data
+  use on-board frame averaging and/or group gaps. [#121]
+
 ramp_fitting
 ~~~~~~~~~~~~
 

--- a/src/stcal/dark_current/dark_sub.py
+++ b/src/stcal/dark_current/dark_sub.py
@@ -96,12 +96,11 @@ def do_correction_data(science_data, dark_data, dark_output=None):
 
     # Check that the number of groups in the science data does not exceed
     # the number of groups in the dark current array.
-    sci_total_frames = sci_ngroups * (sci_nframes + sci_groupgap)
-    drk_total_frames = drk_ngroups * (drk_nframes + drk_groupgap)
+    sci_total_frames = sci_ngroups * sci_nframes + (sci_ngroups - 1) * sci_groupgap
+    drk_total_frames = drk_ngroups * drk_nframes + (drk_ngroups - 1) * drk_groupgap
     if sci_total_frames > drk_total_frames:
         log.warning(
-            "Not enough data in dark reference file to match to "
-            "science data."
+            "Not enough data in dark reference file to match to science data."
         )
         log.warning("Input will be returned without subtracting dark current.")
         science_data.cal_step = 'SKIPPED'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2938](https://jira.stsci.edu/browse/JP-2938)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #120 

<!-- describe the changes comprising this PR here -->
This PR fixes a bug in the computation of the total number of data frames in science and dark ramps when nframes > 1 and/or groupgap > 0.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
