### PR TITLE
JP-2944: Limit major axis expansion for MIRI shower flagging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 1.2.1 (unreleased)
 ==================
 
+Bug Fixes
+---------
+
+jump
+~~~~
+- Changes to limit the expansion of MIRI shower ellipses to be the same
+  number of pixels for both the major and minor axis. JP-2944 [#123]
 
 1.2.0 (2022-10-07)
 ==================
@@ -16,15 +23,13 @@ dark_current
 
 jump
 ~~~~
--- Changes to limit the expansion of MIRI shower ellipses to be the same
-number of pixels for both the major and minor axis. JP-2944 [#123]
 
 - Changes to flag both NIR snowballs and MIRI showers
-for  JP-#2645. [#118]
+  for  JP-#2645. [#118]
 
 - Early in the step, the object arrays are converted from DN to electrons
-by multiplying by the gain. The values need to be reverted back to DN
-at the end of the step. [#116]
+  by multiplying by the gain. The values need to be reverted back to DN
+  at the end of the step. [#116]
 
 1.1.0 (2022-08-17)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ dark_current
 
 jump
 ~~~~
+-- Changes to limit the expansion of MIRI shower ellipses to be the same
+number of pixels for both the major and minor axis. JP-2944 [#123]
 
 - Changes to flag both NIR snowballs and MIRI showers
 for  JP-#2645. [#118]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -411,6 +411,7 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
         # the number of pixels added to the minor axis. This prevents very large flagged ellipses
         # with high axis ratio ellipses. The major and minor axis are not always the same index.
         # Therefore, we have to test to find which is actually the minor axis.
+        print("expansion", expansion)
         if ellipse[1][1] < ellipse[1][0]:
             axis1 = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
             axis2 = ellipse[1][1] * expansion

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -408,7 +408,7 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
         majaxis = ellipse[1][1] + expansion * ellipse[1][0]
-        print("majaxis", majaxis, "original", ellipse[1][1])
+        print("majaxis", majaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ",ellipse[1][0])
         minaxis = ellipse[1][0] * expansion
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(majaxis / 2),

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -407,9 +407,9 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
     for ellipse in ellipses:
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
-        majaxis = ellipse[1][0] + expansion * ellipse[1][1]
-        print("majaxis", majaxis, "original", ellipse[1][0])
-        minaxis = ellipse[1][1] * expansion
+        majaxis = ellipse[1][1] + expansion * ellipse[1][0]
+        print("majaxis", majaxis, "original", ellipse[1][1])
+        minaxis = ellipse[1][0] * expansion
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(majaxis / 2),
                            round(minaxis / 2)), alpha, 0, 360, (0, 0, 4), -1)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -407,7 +407,7 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
     for ellipse in ellipses:
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
-        majaxis = ellipse[1][0] * expansion
+        majaxis = ellipse[1][0] + expansion * ellipse[1][1]
         minaxis = ellipse[1][1] * expansion
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(majaxis / 2),

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -411,13 +411,14 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
         # the number of pixels added to the minor axis. This prevents very large flagged ellipses
         # with high axis ratio ellipses. The major and minor axis are not always the same index.
         # Therefore, we have to test to find which is actually the minor axis.
-        print("expansion", expansion)
+        print("start ", ellipse[1][0], ellipse[1][1])
         if ellipse[1][1] < ellipse[1][0]:
             axis1 = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
             axis2 = ellipse[1][1] * expansion
         else:
             axis1 = ellipse[1][0] * expansion
             axis2 = ellipse[1][1] + (expansion - 1.0) * ellipse[1][0]
+        print("after ", axis1, axis2)
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(axis1 / 2),
                            round(axis2 / 2)), alpha, 0, 360, (0, 0, 4), -1)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -407,9 +407,9 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
     for ellipse in ellipses:
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
-        majaxis = ellipse[1][1] + expansion * ellipse[1][0]
+        majaxis = ellipse[1][0] + (1 - expansion) * ellipse[1][1]
         print("majaxis", majaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ",ellipse[1][0])
-        minaxis = ellipse[1][0] * expansion
+        minaxis = ellipse[1][1] * expansion
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(majaxis / 2),
                            round(minaxis / 2)), alpha, 0, 360, (0, 0, 4), -1)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -409,19 +409,17 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
         cenx = ellipse[0][1]
         # Expand the ellipse by the expansion factor. The number of pixels added to both axes is
         # the number of pixels added to the minor axis. This prevents very large flagged ellipses
-        # for high axis ratio ellipses. The major and minor axis are not always the same index.
+        # with high axis ratio ellipses. The major and minor axis are not always the same index.
         # Therefore, we have to test to find which is actually the minor axis.
         if ellipse[1][1] < ellipse[1][0]:
-            majaxis = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
-            print("bigaxis", majaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ",ellipse[1][0])
-            minaxis = ellipse[1][1] * expansion
+            axis1 = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
+            axis2 = ellipse[1][1] * expansion
         else:
-            majaxis = ellipse[1][0] * expansion
-            minaxis = ellipse[1][1] + (expansion - 1.0) * ellipse[1][0]
-            print("bigaxis2", minaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ", ellipse[1][0])
+            axis1 = ellipse[1][0] * expansion
+            axis2 = ellipse[1][1] + (expansion - 1.0) * ellipse[1][0]
         alpha = ellipse[2]
-        image = cv.ellipse(image, (round(ceny), round(cenx)), (round(majaxis / 2),
-                           round(minaxis / 2)), alpha, 0, 360, (0, 0, 4), -1)
+        image = cv.ellipse(image, (round(ceny), round(cenx)), (round(axis1 / 2),
+                           round(axis2 / 2)), alpha, 0, 360, (0, 0, 4), -1)
         jump_ellipse = image[:, :, 2]
         saty, satx = np.where(sat_pix == 2)
         jump_ellipse[saty, satx] = 0

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -407,7 +407,7 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
     for ellipse in ellipses:
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
-        majaxis = ellipse[1][0] + (1 - expansion) * ellipse[1][1]
+        majaxis = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
         print("majaxis", majaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ",ellipse[1][0])
         minaxis = ellipse[1][1] * expansion
         alpha = ellipse[2]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -407,9 +407,14 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
     for ellipse in ellipses:
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
-        majaxis = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
-        print("majaxis", majaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ",ellipse[1][0])
-        minaxis = ellipse[1][1] * expansion
+        if ellipse[1][1] < ellipse[1][0]:
+            majaxis = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
+            print("bigaxis", majaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ",ellipse[1][0])
+            minaxis = ellipse[1][1] * expansion
+        else:
+            majaxis = ellipse[1][0] * expansion
+            minaxis = ellipse[1][1] + (expansion - 1.0) * ellipse[1][0]
+            print("bigaxis2", minaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ", ellipse[1][0])
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(majaxis / 2),
                            round(minaxis / 2)), alpha, 0, 360, (0, 0, 4), -1)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -408,6 +408,7 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
         majaxis = ellipse[1][0] + expansion * ellipse[1][1]
+        print("majaxis", majaxis, "original", ellipse[1][0])
         minaxis = ellipse[1][1] * expansion
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(majaxis / 2),

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -407,6 +407,10 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
     for ellipse in ellipses:
         ceny = ellipse[0][0]
         cenx = ellipse[0][1]
+        # Expand the ellipse by the expansion factor. The number of pixels added to both axes is
+        # the number of pixels added to the minor axis. This prevents very large flagged ellipses
+        # for high axis ratio ellipses. The major and minor axis are not always the same index.
+        # Therefore, we have to test to find which is actually the minor axis.
         if ellipse[1][1] < ellipse[1][0]:
             majaxis = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
             print("bigaxis", majaxis, "orig 1 1", ellipse[1][1], "orig 1 0 ",ellipse[1][0])

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -411,14 +411,12 @@ def extend_ellipses(plane, ellipses, sat_flag, jump_flag, expansion=1.1):
         # the number of pixels added to the minor axis. This prevents very large flagged ellipses
         # with high axis ratio ellipses. The major and minor axis are not always the same index.
         # Therefore, we have to test to find which is actually the minor axis.
-        print("start ", ellipse[1][0], ellipse[1][1])
         if ellipse[1][1] < ellipse[1][0]:
             axis1 = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
             axis2 = ellipse[1][1] * expansion
         else:
             axis1 = ellipse[1][0] * expansion
             axis2 = ellipse[1][1] + (expansion - 1.0) * ellipse[1][0]
-        print("after ", axis1, axis2)
         alpha = ellipse[2]
         image = cv.ellipse(image, (round(ceny), round(cenx)), (round(axis1 / 2),
                            round(axis2 / 2)), alpha, 0, 360, (0, 0, 4), -1)


### PR DESCRIPTION

Resolves [JP-2944](https://jira.stsci.edu/browse/JP-2944)


This PR addresses the fact that the new expansion of the shower ellipses in the JUMP step increases both the major and minor axis of the ellipse by the same relative factor. The change is to instead increase both axes by the same number of pixels. The new code changes the expansion along the major axis to be the same number of pixels as along the minor axis.


**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
