### PR TITLE
JP-2988: Set saturation only if fully saturated.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 ==================
 
 
+ramp_fitting
+~~~~~~~~~~~~
+
+- Set saturation flag only for full saturation.  The rateints product will
+  have the saturation flag set for an integration only if saturation starts
+  in group 0.  The rate product will have the saturation flag set only if
+  each integration for a pixel is marked as fully saturated. [#125]
 
 1.2.1 (2022-10-14)
 ==================

--- a/docs/stcal/ramp_fitting/description.rst
+++ b/docs/stcal/ramp_fitting/description.rst
@@ -284,3 +284,18 @@ For the optional output product, the variance of the slope due to the Poisson
 noise of the segment-specific slope is written to the VAR_POISSON extension.
 Similarly, the variance of the slope due to the read noise of the
 segment-specific slope  is written to the VAR_RNOISE extension.
+
+Data Quality Propagation
+=================
+
+If all groups in an integration are flagged as DO_NOT_USE or SATURATED, then
+the rateints product will be flagged as DO_NOT_USE.  For the rates product, the
+DO_NOT_USE flag will be set if all integrations are flagged as DO_NOT_USE.
+
+If all groups in an integration are flaggd as SATURATED, then the rateints
+product will be flagged as SATURATED and DO_NOT_USE.  If all integrations are
+flagged as SATURATED, the rates product will be flagged as SATURATED and DO_NOT_USE.
+
+If a group in an integration is flagged as JUMP_DET, then rateints will be
+flagged as JUMP_DET.  If any integration is flagged as JUMP_DET, the rates
+product will be flagged as JUMP_DET.

--- a/docs/stcal/ramp_fitting/description.rst
+++ b/docs/stcal/ramp_fitting/description.rst
@@ -286,16 +286,26 @@ Similarly, the variance of the slope due to the read noise of the
 segment-specific slope  is written to the VAR_RNOISE extension.
 
 Data Quality Propagation
-=================
+========================
+For a given pixel, if all groups in an integration are flagged as DO_NOT_USE or
+SATURATED, then that pixel will be flagged as DO_NOT_USE in the corresponding
+integration in the rateints product.  Note this does NOT mean that all groups
+are flagged as SATURATED, nor that all groups are flagged as DO_NOT_USE.  For
+example, suppressed one ramp groups will be flagged as DO_NOT_USE in the
+zeroeth group, but not necessarily any other group, while only groups one and
+on are flagged as SATURATED.  Further, only if all integrations in the rateints
+product are marked as DO_NOT_USE, then the pixel will be flagged as DO_NOT_USE
+in the rate product.
 
-If all groups in an integration are flagged as DO_NOT_USE or SATURATED, then
-the rateints product will be flagged as DO_NOT_USE.  For the rates product, the
-DO_NOT_USE flag will be set if all integrations are flagged as DO_NOT_USE.
+For a given pixel, if all groups in an integration are flagged as SATURATED,
+then that pixel will be flagged as SATURATED and DO_NOT_USE in the corresponding
+integration in the rateints product.  This is different from the above case in
+that this is only for all groups flagged as SATURATED, not for some combination
+of DO_NOT_USE and SATURATED.  Further, only if all integrations in the rateints
+product are marked as SATURATED, then the pixel will be flagged as SATURATED
+and DO_NOT_USE in the rate product.
 
-If all groups in an integration are flaggd as SATURATED, then the rateints
-product will be flagged as SATURATED and DO_NOT_USE.  If all integrations are
-flagged as SATURATED, the rates product will be flagged as SATURATED and DO_NOT_USE.
-
-If a group in an integration is flagged as JUMP_DET, then rateints will be
-flagged as JUMP_DET.  If any integration is flagged as JUMP_DET, the rates
-product will be flagged as JUMP_DET.
+For a given pixel, if any group in an integration is flagged as JUMP_DET, then
+that pixel will be flagged as JUMP_DET in the corresponding integration in the
+rateints product.  Also, that pixel will be flagged as JUMP_DET in the rate
+product.

--- a/src/stcal/ramp_fitting/gls_fit.py
+++ b/src/stcal/ramp_fitting/gls_fit.py
@@ -645,8 +645,7 @@ def gls_fit_single(ramp_data, gain_2d, readnoise_2d, max_num_cr, save_opt):
 
     # Compress all integration's dq arrays to create 2D PIXELDDQ array for
     #   primary output
-    final_pixeldq = utils.dq_compress_final(
-        dq_int, ramp_data.flags_do_not_use)
+    final_pixeldq = utils.dq_compress_final(dq_int, ramp_data)
 
     integ_info = (slope_int, dq_int, slope_err_int)
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1364,8 +1364,7 @@ def ramp_fit_overall(
 
     # Compress all integration's dq arrays to create 2D PIXELDDQ array for
     #   primary output
-    final_pixeldq = utils.dq_compress_final(
-        dq_int, ramp_data.flags_do_not_use)
+    final_pixeldq = utils.dq_compress_final(dq_int, ramp_data)
 
     if dq_int is not None:
         del dq_int

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1414,7 +1414,10 @@ def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):
 
     # XXX JP-2988
     # If all groups are set to SATURATED, mark as SATURATED.
-    is_flag_set_for_all_groups(pixeldq_sect, gdq_sect, sat_flag)
+    # A group 0 marked as saturated implies all groups are saturated.
+    gdq0_sat = np.bitwise_and(gdq_sect[0], sat_flag)
+    pixeldq_sect[gdq0_sat != 0] = np.bitwise_or(
+        pixeldq_sect[gdq0_sat != 0], sat_flag)
 
     # If jump occures mark the appropriate flag.
     cr_loc_r = np.bitwise_and(gdq_sect, jump_flag)

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1290,7 +1290,9 @@ def dq_compress_final(dq_int, ramp_data):
     """
     Combine the integration-specific dq arrays (which have already been
     compressed and combined with the PIXELDQ array) to create the dq array
-    of the primary output product.
+    of the primary output product.  The saturation flag is set only if the
+    saturation flag is set for all integrations; in this case, the do not
+    use flag is also set.
 
     Parameters
     ----------
@@ -1320,10 +1322,7 @@ def dq_compress_final(dq_int, ramp_data):
     dnu_flag = ramp_data.flags_do_not_use
     is_flag_set_for_all_ints(dq_int, f_dq, dnu_flag)
 
-    # XXX JP-2988
-    # XXX This change breaks tests, so leave it out for now.
-    # Do something similar for the SATURATED flag.  If all integrations
-    # for a pixel are saturated, it also must be marked as DO_NOT_USE.
+    # Set the SATURATED flag in a similar way DO_NOT_USE is set.
     sat_flag = ramp_data.flags_saturated
     is_flag_set_for_all_ints(dq_int, f_dq, sat_flag)
 
@@ -1372,15 +1371,11 @@ def is_flag_set_for_all_ints(dq_int, f_dq, flag):
 
 def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):
     """
-    Get ramp locations where the data has been flagged as saturated in the 4D
-    GROUPDQ array for the current data section, find the corresponding image
-    locations, and set the SATURATED flag in those locations in the PIXELDQ
-    array. Similarly, get the ramp locations where the data has been flagged as
-    a jump detection in the 4D GROUPDQ array, find the corresponding image
-    locations, and set the JUMP_DET flag in those locations in the PIXELDQ
-    array. These modifications to the section of the PIXELDQ array are not used
-    to flag groups for any computations; they are used only in the integration-
-    specific output.
+    This sets the integration level flags for DO_NOT_USE, JUMP_DET and
+    SATURATED.  If any ramp has a jump, this flag will be set for the
+    integraion.  If all groups in a ramp are flagged as DO_NOT_USE, then the
+    integration level DO_NOT_USE flag will be set.  If a ramp is saturated in
+    group 0, then the integration level flag is marked as SATURATED.
 
     Parameters
     ----------
@@ -1412,7 +1407,6 @@ def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):
     # If all groups are set to DO_NOT_USE, mark as DO_NOT_USE.
     is_flag_set_for_all_groups(pixeldq_sect, gdq_sect, dnu_flag)
 
-    # XXX JP-2988
     # If all groups are set to SATURATED, mark as SATURATED.
     # A group 0 marked as saturated implies all groups are saturated.
     gdq0_sat = np.bitwise_and(gdq_sect[0], sat_flag)

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1329,8 +1329,8 @@ def dq_compress_final(dq_int, ramp_data):
     # If the saturated flag is set, then the entire pixel is
     # saturated, so should be marked as DO_NOT_USE.
     sat_loc = np.zeros(f_dq.shape, dtype=f_dq.dtype)
-    sat_loc[np.where(np.bitwise_and(f_dq, sat_flag))] = True
-    f_dq[sat_loc==True] = np.bitwise_or(f_dq[sat_loc==True], dnu_flag)
+    sat_loc[np.where(np.bitwise_and(f_dq, sat_flag))] = 1
+    f_dq[sat_loc == 1] = np.bitwise_or(f_dq[sat_loc == 1], dnu_flag)
 
     return f_dq
 
@@ -1344,7 +1344,7 @@ def is_flag_set_for_all_ints(dq_int, f_dq, flag):
     dq_int : ndarray
         Cube of the compressed pixel DQ per integration.  It is
         a 3-D cube with dimensions (nints, nrows, ncols).
-        
+
     f_dq : ndarray
         The flattened DQ array that is only 2-D, (nrows, ncols),
         containing the Or'ing of each integration.
@@ -1365,7 +1365,7 @@ def is_flag_set_for_all_ints(dq_int, f_dq, flag):
 
     not_flag = np.uint32(~flag)
     f_dq[not_all_flag] = np.bitwise_and(f_dq[not_all_flag], not_flag)
-    
+
     return not_all_flag
 
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1370,7 +1370,7 @@ def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):
     Parameters
     ----------
     ramp_data : RampData
-        Contains the data needed to compute the median rates.
+        Contains the DQ flag information.
 
     num_int : int
         The current integration number.

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1408,6 +1408,23 @@ def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):
 
 
 def set_if_total_ramp(pixeldq_sect, gdq_sect, flag, set_flag):
+    """
+    Set set_flag in final_dq if flag is present in all integrations.
+
+    Parameters
+    ----------
+    pixeldq_sect: ndarray
+        2-D array (nrows, ncols) of the integration DQ.
+
+    gdq_dq : ndarray
+        3-D array (ngroups, nrows, ncols) of the integration level DQ.
+
+    flag : int
+        Flag to check in each integration.
+
+    set_flag : int
+        Flag to set if flag is found in each integration.
+    """
     # Checking for all groups is the same as checking for all integrations
     # because in both we are checking cubes.  For the integration check the
     # first dimension is the number of integrations, for the ramp check the

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1296,7 +1296,12 @@ def dq_compress_final(dq_int, ramp_data):
         The integration level DQ flags, 3-D (nints, nrows, ncols).
 
     ramp_data : RampData
-        Contains the DQ flag information
+        Contains the DQ flag information.
+
+    Return
+    ------
+    final_dq : ndarray
+        The final 2-D (nrows, ncols) pixel DQ array.
     """
     final_dq = dq_int[0, :, :]
     nints = dq_int.shape[0]
@@ -1310,13 +1315,6 @@ def dq_compress_final(dq_int, ramp_data):
     # in one of the integrations.
     not_sat_or_dnu = np.uint32(~(dnu | sat))
     final_dq = np.bitwise_and(final_dq, not_sat_or_dnu)
-
-    '''
-    not_dnu = np.uint32(~dnu)
-    not_sat = np.uint32(~sat)
-    final_dq = np.bitwise_and(final_dq, not_dnu)
-    final_dq = np.bitwise_and(final_dq, not_sat)
-    '''
 
     # If all integrations are DO_NOT_USE or SATURATED, then set DO_NOT_USE.
     set_if_total_integ(final_dq, dq_int, dnu | sat, dnu)
@@ -1359,91 +1357,6 @@ def set_if_total_integ(final_dq, integ_dq, flag, set_flag):
     final_dq[all_set] = np.bitwise_or(final_dq[all_set], set_flag)
 
 
-def dq_compress_final_dep(dq_int, ramp_data):
-    """
-    Combine the integration-specific dq arrays (which have already been
-    compressed and combined with the PIXELDQ array) to create the dq array
-    of the primary output product.  The SATURATED flag is set only if the
-    SATURATED flag is set for all integrations; in this case, the
-    DO_NOT_USE flag is also set.
-
-    Parameters
-    ----------
-    dq_int : ndarray
-        Cube of the compressed pixel DQ per integration.  It is
-        a 3-D cube with dimensions (nints, nrows, ncols).
-
-    ramp_data : RampData
-        Contains the DQ flag information
-
-    Returns
-    -------
-    f_dq : ndarray
-        combination of all integration's pixeldq arrays, 2-D flag
-    """
-    f_dq = dq_int[0, :, :]
-    nints = dq_int.shape[0]
-    dnu, sat = ramp_data.flags_do_not_use, ramp_data.flags_saturated
-
-    for jj in range(1, nints):
-        f_dq = np.bitwise_or(f_dq, dq_int[jj, :, :])
-
-    # Sum each pixel over all integrations where DO_NOT_USE is set.  If
-    # the number of integrations with DO_NOT_USE set is less than the
-    # total number of integrations, that means at least one integration
-    # has good data, so the final DQ flag for that pixel should NOT
-    # include the DO_NOT_USE flag.
-    is_flag_set_for_all_ints(dq_int, f_dq, dnu)
-
-    # Set the SATURATED flag in a similar way DO_NOT_USE is set.
-    is_flag_set_for_all_ints(dq_int, f_dq, sat)
-
-    # If the saturated flag is set, then the entire pixel is
-    # saturated, so should be marked as DO_NOT_USE.
-    sat_loc = np.zeros(f_dq.shape, dtype=f_dq.dtype)
-    sat_loc[np.where(np.bitwise_and(f_dq, sat))] = 1
-    f_dq[sat_loc == 1] = np.bitwise_or(f_dq[sat_loc == 1], dnu)
-
-    return f_dq
-
-
-def is_flag_set_for_all_ints(dq_int, f_dq, flag):
-    """
-    In the calling function (dq_compress_final) any flag that occurs in any
-    integration is set in the final pixel DQ flag.  This behavior is not
-    desired for some flags.  This function removes a flag from the pixel
-    DQ array if they are not present in all integrations.
-
-    Parameters
-    ----------
-    dq_int : ndarray
-        Cube of the compressed pixel DQ per integration.  It is
-        a 3-D cube with dimensions (nints, nrows, ncols).
-
-    f_dq : ndarray
-        The flattened DQ array that is only 2-D, (nrows, ncols),
-        containing the Or'ing of each integration.
-
-    flag : int
-        The DQ flag of interest
-    """
-    nints = dq_int.shape[0]
-
-    # Create an array the same shape as dq_int that is zero everywhere,
-    # except where the flag of interest is set.
-    flag_locs = np.zeros(dq_int.shape, dtype=np.uint32)
-    flag_locs[np.where(np.bitwise_and(dq_int, flag))] = 1
-
-    # Find the pixels where the flag is not set for all pixels.
-    flag_sum = flag_locs.sum(axis=0)
-    not_all_flag = np.where(flag_sum < nints)
-
-    # If the flag is not present in all integrations, remove it from the final
-    # pixel DQ.
-    not_flag = np.uint32(~flag)
-    f_dq[not_all_flag] = np.bitwise_and(f_dq[not_all_flag], not_flag)
-
-
 def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):
     """
     This sets the integration level flags for DO_NOT_USE, JUMP_DET and
@@ -1454,6 +1367,24 @@ def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):
     all groups are marked as DO_NOT_USE or SATURATED (as in suppressed one
     groups), then the DO_NOT_USE flag is set.
 
+    Parameters
+    ----------
+    ramp_data : RampData
+        Contains the data needed to compute the median rates.
+
+    num_int : int
+        The current integration number.
+
+    gdq_sect : ndarray
+        The current 3-D (ngroups, nrows, ncols) integration DQ array.
+
+    pixeldq_sect : ndarray
+        The 2-D (nrows, ncols) pixel DQ flags for the current integration.
+
+    Return
+    ------
+    pixeldq_sect : ndarray
+        The 2-D (nrows, ncols) pixel DQ flags for the current integration.
     """
     sat = ramp_data.flags_saturated
     jump = ramp_data.flags_jump_det
@@ -1482,87 +1413,6 @@ def set_if_total_ramp(pixeldq_sect, gdq_sect, flag, set_flag):
     # first dimension is the number of integrations, for the ramp check the
     # first dimension is the number of groups.
     set_if_total_integ(pixeldq_sect, gdq_sect, flag, set_flag)
-
-
-def dq_compress_sect_dep(ramp_data, num_int, gdq_sect, pixeldq_sect):
-    """
-    This sets the integration level flags for DO_NOT_USE, JUMP_DET and
-    SATURATED.  If any ramp has a jump, this flag will be set for the
-    integration.  If all groups in a ramp are flagged as DO_NOT_USE, then the
-    integration level DO_NOT_USE flag will be set.  If a ramp is saturated in
-    group 0, then the integration level flag is marked as SATURATED.
-
-    Parameters
-    ----------
-    ramp_data : ramp_fit_class.RampData
-        Contains the DQ flags needed for this function
-
-    num_int : int
-        The current integration being processed
-
-    gdq_sect : ndarray
-        cube of GROUPDQ array for a data section, 3-D flag
-
-    pixeldq_sect : ndarray
-        dq array of data section of input model, 2-D flag
-
-    Returns
-    -------
-    pixeldq_sect : ndarray
-        dq array of data section updated with saturated and jump-detected
-        flags, 2-D flag
-
-    """
-    sat_flag = ramp_data.flags_saturated
-    jump_flag = ramp_data.flags_jump_det
-    dnu_flag = ramp_data.flags_do_not_use
-
-    ngroups, nrows, ncols = gdq_sect.shape
-
-    # If all groups are set to DO_NOT_USE, mark as DO_NOT_USE.
-    is_flag_set_for_all_groups(pixeldq_sect, gdq_sect, dnu_flag)
-
-    # If all groups are set to SATURATED, mark as SATURATED.
-    # A group 0 marked as saturated implies all groups are saturated.
-    gdq0_sat = np.bitwise_and(gdq_sect[0], sat_flag)
-    pixeldq_sect[gdq0_sat != 0] = np.bitwise_or(
-        pixeldq_sect[gdq0_sat != 0], sat_flag)
-
-    # If jump occurs mark the appropriate flag.
-    cr_loc_r = np.bitwise_and(gdq_sect, jump_flag)
-    cr_loc_im = np.where(cr_loc_r.sum(axis=0) > 0)
-    pixeldq_sect[cr_loc_im] = np.bitwise_or(pixeldq_sect[cr_loc_im], jump_flag)
-
-    return pixeldq_sect
-
-
-def is_flag_set_for_all_groups(pixeldq_sect, gdq_sect, flag):
-    """
-    Only set pixel flag if the flag is set for all groups.
-
-    gdq_sect : ndarray
-        Cube of GROUPDQ array for a data section, 3-D flag.
-
-    pixeldq_sect : ndarray
-        DQ array of data section of input model, 2-D flag.
-
-    flag : uint
-        The flag of interest.
-    """
-    ngroups = gdq_sect.shape[0]
-
-    # Create an array of all zeros, then put 1's where for each
-    # group where the flag is set.
-    flag_locs = np.zeros(gdq_sect.shape, dtype=np.uint32)
-    flag_locs[np.where(np.bitwise_and(gdq_sect, flag))] = 1
-
-    # Sum over groups.
-    flag_sum = flag_locs.sum(axis=0)
-
-    # The flag is set for all groups if the sum equals the number of groups.
-    all_flag = np.where(flag_sum == ngroups)
-
-    pixeldq_sect[all_flag] = np.bitwise_or(pixeldq_sect[all_flag], flag)
 
 
 def compute_median_rates(ramp_data):

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1309,7 +1309,7 @@ def dq_compress_final(dq_int, ramp_data):
         final_dq = np.bitwise_or(final_dq, dq_int[integ, :, :])
 
     dnu, sat = ramp_data.flags_do_not_use, ramp_data.flags_saturated
-    
+
     # Remove DO_NOT_USE and SATURATED because they need special handling.
     # These flags are not set in the final pixel DQ array by simply being set
     # in one of the integrations.

--- a/tests/test_ramp_fitting_gls_fit.py
+++ b/tests/test_ramp_fitting_gls_fit.py
@@ -515,7 +515,7 @@ def test_two_groups_fit():
     np.testing.assert_allclose(ans_data, check, tol)
 
     assert ans_dq[0, 0] == GOOD
-    assert ans_dq[0, 1] == SATURATED | UNRELIABLE_SLOPE
+    assert ans_dq[0, 1] == UNRELIABLE_SLOPE
     assert ans_dq[0, 2] == SATURATED | DO_NOT_USE
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2988](https://jira.stsci.edu/browse/JP-2988)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses setting the saturation flag.  In the rateints product, the saturation flag will only be set if the ramp for that pixel is fully saturated, i.e., saturation starts in group 0.  In the rate product, the saturation flag will only be set if the saturation flag is set for each integration.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
