### PR TITLE
remove dependency on `opencv-python`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ General
 -------
 
 - Moved build configuration from ``setup.cfg`` to ``pyproject.toml`` to support PEP621 [#95]
-
+- made dependency on ``opencv-python`` conditional [#126]
 
 ramp_fitting
 ~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     'astropy >=5.0.4',
     'scipy >=1.6.0',
     'numpy >=1.17',
-    'opencv-python >=4.6.0.66',
 ]
 dynamic = ['version']
 
@@ -35,6 +34,9 @@ test = [
     'pytest-cov',
     'pytest-doctestplus',
     'pytest-openfiles >=0.5.0',
+]
+opencv = [
+    'opencv-python >=4.6.0.66',
 ]
 
 [project.urls]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -14,7 +14,8 @@ try:
     OPENCV_INSTALLED = True
 except ImportError:
     OPENCV_INSTALLED = False
-    warnings.warn('Could not import `opencv-python`; certain snowball detection and usage of ellipses will be inoperable')
+    warnings.warn('Could not import `opencv-python`; '
+                  'certain snowball detection and usage of ellipses will be inoperable')
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -1,11 +1,20 @@
 import time
 import logging
+import warnings
+
 import numpy as np
-import cv2 as cv
 from . import twopoint_difference as twopt
 from . import constants
 
 import multiprocessing
+
+try:
+    import cv2 as cv
+
+    OPENCV_INSTALLED = True
+except ImportError:
+    OPENCV_INSTALLED = False
+    warnings.warn('Could not import `opencv-python`; certain snowball detection and usage of ellipses will be inoperable')
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -1,17 +1,21 @@
-import pytest
 import numpy as np
+import pytest
 from astropy.io import fits
 
 from stcal.jump.jump import flag_large_events, find_circles, find_ellipses
 
-
-
 DQFLAGS = {'JUMP_DET': 4, 'SATURATED': 2, 'DO_NOT_USE': 1}
+
+try:
+    import cv2 as cv
+
+    OPENCV_INSTALLED = True
+except ImportError:
+    OPENCV_INSTALLED = False
 
 
 @pytest.fixture(scope='function')
 def setup_cube():
-
     def _cube(ngroups, readnoise=10):
         nints = 1
         nrows = 204
@@ -27,6 +31,7 @@ def setup_cube():
     return _cube
 
 
+@pytest.mark.skipif(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_find_simple_circle():
     plane = np.zeros(shape=(5, 5), dtype=np.uint8)
     plane[2, 2] = DQFLAGS['JUMP_DET']
@@ -38,6 +43,7 @@ def test_find_simple_circle():
     assert circle[0][1] == pytest.approx(1.0, 1e-3)
 
 
+@pytest.mark.skipif(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_find_simple_ellipse():
     plane = np.zeros(shape=(5, 5), dtype=np.uint8)
     plane[2, 2] = DQFLAGS['JUMP_DET']
@@ -49,8 +55,9 @@ def test_find_simple_ellipse():
     plane[2, 4] = DQFLAGS['JUMP_DET']
     plane[3, 3] = DQFLAGS['JUMP_DET']
     ellipse = find_ellipses(plane, DQFLAGS['JUMP_DET'], 1)
-    assert ellipse[0][2] == pytest.approx(45.0, 1e-3) # 90 degree rotation
+    assert ellipse[0][2] == pytest.approx(45.0, 1e-3)  # 90 degree rotation
     assert ellipse[0][0] == pytest.approx((2.5, 2.0))  # center
+
 
 @pytest.mark.skip(reason="only for local testing")
 def test_single_group():
@@ -61,4 +68,3 @@ def test_single_group():
                       min_jump_area=15, max_offset=1, expand_factor=1.1, use_ellipses=True,
                       sat_required_snowball=False)
     fits.writeto("jumppix_expand.fits", indq, overwrite=True)
-


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [AL-691](https://jira.stsci.edu/browse/AL-691)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR removes unconditional dependency on `opencv-python` added in a previous PR; this was causing installation issues on some users' platforms.

I am also exploring replacing usage of `opencv-python` with `scikit-image`

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
