### PR TITLE
add specific exception when ellipse construction attempted without `opencv-python` installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
           - toxenv: test-numpy120
             os: ubuntu-latest
             python-version: '3.8'
+          - toxenv: test-opencv-xdist
+            os: ubuntu-latest
+            python-version: '3.x'
           - toxenv: test-jwst-xdist-cov
             os: ubuntu-latest
             python-version: '3.x'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ General
 Bug Fixes
 ---------
 
--
+- improve exception handling when attempting to use ellipses without ``opencv-python`` installed [#136]
 
 Changes to API
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
     'pytest-doctestplus',
     'pytest-openfiles >=0.5.0',
 ]
-opencv = [
+jump_ellipses = [
     'opencv-python >=4.6.0.66',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
     'pytest-doctestplus',
     'pytest-openfiles >=0.5.0',
 ]
-jump_ellipses = [
+opencv = [
     'opencv-python >=4.6.0.66',
 ]
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -13,8 +13,7 @@ try:
 
     ELLIPSE_PACKAGE = 'opencv-python'
 except (ImportError, ModuleNotFoundError):
-    ELLIPSE_PACKAGE_WARNING = '`opencv-python` must be installed (`pip install jwst[jump_ellipses]`) ' \
-                              'in order to use ellipses'
+    ELLIPSE_PACKAGE_WARNING = '`opencv-python` must be installed (`pip install stcal[opencv]`) in order to use ellipses'
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -13,7 +13,8 @@ try:
 
     ELLIPSE_PACKAGE = 'opencv-python'
 except (ImportError, ModuleNotFoundError):
-    ELLIPSE_PACKAGE_WARNING = '`opencv-python` must be installed (`pip install stcal[opencv]`) in order to use ellipses'
+    ELLIPSE_PACKAGE_WARNING = '`opencv-python` must be installed (`pip install stcal[opencv]`) ' \
+                              'in order to use ellipses'
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -13,7 +13,8 @@ try:
 
     ELLIPSE_PACKAGE = 'opencv-python'
 except (ImportError, ModuleNotFoundError):
-    ELLIPSE_PACKAGE_WARNING = f'`opencv-python` must be installed (`pip install jwst[jump_ellipses]`) to use ellipses'
+    ELLIPSE_PACKAGE_WARNING = '`opencv-python` must be installed (`pip install jwst[jump_ellipses]`) ' \
+                              'in order to use ellipses'
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -1,7 +1,6 @@
 import logging
 import multiprocessing
 import time
-import warnings
 
 import numpy as np
 
@@ -14,7 +13,7 @@ try:
 
     ELLIPSE_PACKAGE = 'opencv-python'
 except (ImportError, ModuleNotFoundError):
-    ELLIPSE_PACKAGE_WARNING = f'`opencv-python` must be installed to use ellipse construction'
+    ELLIPSE_PACKAGE_WARNING = f'`opencv-python` must be installed (`pip install jwst[jump_ellipses]`) to use ellipses'
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -31,7 +31,7 @@ def setup_cube():
     return _cube
 
 
-@pytest.mark.skipif(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
+@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_find_simple_circle():
     plane = np.zeros(shape=(5, 5), dtype=np.uint8)
     plane[2, 2] = DQFLAGS['JUMP_DET']
@@ -43,7 +43,7 @@ def test_find_simple_circle():
     assert circle[0][1] == pytest.approx(1.0, 1e-3)
 
 
-@pytest.mark.skipif(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
+@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
 def test_find_simple_ellipse():
     plane = np.zeros(shape=(5, 5), dtype=np.uint8)
     plane[2, 2] = DQFLAGS['JUMP_DET']

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ description =
     xdist: using parallel processing
 extras =
     test
+    jump_ellipses: jump_ellipses
 deps =
     xdist: pytest-xdist
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
@@ -73,6 +74,7 @@ commands =
     jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
+    jump_ellipses: -- tests/test_jump.py \
     {posargs}
 
 [testenv:build-docs]

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ description =
     run tests
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
+    opencv: requiring opencv-python
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ description =
     xdist: using parallel processing
 extras =
     test
-    jump_ellipses: jump_ellipses
+    opencv: opencv
 deps =
     xdist: pytest-xdist
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
@@ -74,7 +74,7 @@ commands =
     jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
-    jump_ellipses: -- tests/test_jump.py \
+    opencv: -- tests/test_jump.py \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Addresses https://github.com/spacetelescope/jwst/issues/7409
related to https://github.com/spacetelescope/jwst/pull/7414

<!-- describe the changes comprising this PR here -->
This PR addresses the issue brought up in https://github.com/spacetelescope/jwst/issues/7409; a lack of specificity when using `jump.use_ellipses = True` without an `opencv` installation. Instead of a `UserWarning` being printed at import time, a `ModuleNotFoundError` is raised in runtime if ellipse functionality is selected and `opencv-python` is not detected.

```python
ELLIPSE_PACKAGE_WARNING = '`opencv-python` must be installed (`pip install stcal[opencv]`) in order to use ellipses'
```

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
