### PR TITLE
add fallback to `scikit-image` for ellipse functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,10 @@ jobs:
             python-version: '3.8'
           - toxenv: test-opencv-xdist
             os: ubuntu-latest
-            python-version: '3.x'
+            python-version: '3.10'
+          - toxenv: test-scikitimage-xdist
+            os: ubuntu-latest
+            python-version: '3.10'
           - toxenv: test-jwst-xdist-cov
             os: ubuntu-latest
             python-version: '3.x'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
     'pytest-doctestplus',
     'pytest-openfiles >=0.5.0',
 ]
-opencv = [
+ellipse = [
     'opencv-python >=4.6.0.66',
 ]
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -19,7 +19,8 @@ except (ImportError, ModuleNotFoundError):
         import skimage.measure
 
         ELLIPSE_PACKAGE = 'scikit-image'
-        ELLIPSE_PACKAGE_WARNING = f'`opencv-python` not installed; using `scikit-image` for ellipse construction'
+        ELLIPSE_PACKAGE_WARNING = '`opencv-python` not installed; ' \
+                                  'using `scikit-image` for ellipse construction'
     except (ImportError, ModuleNotFoundError):
         ELLIPSE_PACKAGE_WARNING = '`opencv-python` must be installed (`pip install stcal[ellipse]`) ' \
                                   'in order to use ellipses'

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -10,12 +10,12 @@ try:
     import cv2  # noqa: F401
 
     ELLIPSE_PACKAGE_INSTALLED = True
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     try:
         import skimage  # noqa: F401
 
         ELLIPSE_PACKAGE_INSTALLED = True
-    except:
+    except (ImportError, ModuleNotFoundError):
         ELLIPSE_PACKAGE_INSTALLED = False
 
 

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -7,11 +7,16 @@ from stcal.jump.jump import flag_large_events, find_circles, find_ellipses
 DQFLAGS = {'JUMP_DET': 4, 'SATURATED': 2, 'DO_NOT_USE': 1}
 
 try:
-    import cv2 as cv # noqa: F401
+    import cv2  # noqa: F401
 
-    OPENCV_INSTALLED = True
+    ELLIPSE_PACKAGE_INSTALLED = True
 except ImportError:
-    OPENCV_INSTALLED = False
+    try:
+        import skimage  # noqa: F401
+
+        ELLIPSE_PACKAGE_INSTALLED = True
+    except:
+        ELLIPSE_PACKAGE_INSTALLED = False
 
 
 @pytest.fixture(scope='function')
@@ -31,7 +36,7 @@ def setup_cube():
     return _cube
 
 
-@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
+@pytest.mark.xfail(not ELLIPSE_PACKAGE_INSTALLED, reason="`opencv-python` not installed")
 def test_find_simple_circle():
     plane = np.zeros(shape=(5, 5), dtype=np.uint8)
     plane[2, 2] = DQFLAGS['JUMP_DET']
@@ -43,7 +48,7 @@ def test_find_simple_circle():
     assert circle[0][1] == pytest.approx(1.0, 1e-3)
 
 
-@pytest.mark.xfail(not OPENCV_INSTALLED, reason="`opencv-python` not installed")
+@pytest.mark.xfail(not ELLIPSE_PACKAGE_INSTALLED, reason="`opencv-python` not installed")
 def test_find_simple_ellipse():
     plane = np.zeros(shape=(5, 5), dtype=np.uint8)
     plane[2, 2] = DQFLAGS['JUMP_DET']

--- a/tox.ini
+++ b/tox.ini
@@ -46,13 +46,13 @@ description =
     run tests
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
-    opencv: requiring opencv-python
+    ellipse: requiring opencv-python
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
 extras =
     test
-    opencv: opencv
+    ellipse: ellipse
 deps =
     xdist: pytest-xdist
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
@@ -75,7 +75,7 @@ commands =
     jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
-    opencv: -- tests/test_jump.py \
+    ellipse: -- tests/test_jump.py \
     {posargs}
 
 [testenv:build-docs]

--- a/tox.ini
+++ b/tox.ini
@@ -46,17 +46,19 @@ description =
     run tests
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
-    ellipse: requiring opencv-python
+    opencv: requiring opencv-python
+    scikitimage: requiring scikit-image
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
 extras =
     test
-    ellipse: ellipse
+    opencv: ellipse
 deps =
     xdist: pytest-xdist
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
+    scikitimage: scikit-image
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
@@ -75,7 +77,7 @@ commands =
     jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
-    ellipse: -- tests/test_jump.py \
+    opencv,scikitimage: -- tests/test_jump.py \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
This PR adds fallback functions for ellipse construction in case `opencv-python` is not installed.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
