### PR TITLE
JP-3044 (partial): Changing Cast to Eliminate Cast Warning.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,13 @@ General
 
 Bug Fixes
 ---------
+  
+ramp_fitting
+~~~~~~~~~~~~
 
--
+- Changed a cast due to numpy deprecation that now throws a warning.  The
+  negation of a DQ flag then cast to a np.uint32 caused an over flow.  The
+  flag is now cast to a np.uint32 before negation. [#139]
 
 Changes to API
 --------------

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1315,7 +1315,8 @@ def dq_compress_final(dq_int, ramp_data):
     for integ in range(1, nints):
         final_dq = np.bitwise_or(final_dq, dq_int[integ, :, :])
 
-    dnu, sat = ramp_data.flags_do_not_use, ramp_data.flags_saturated
+    dnu = np.uint32(ramp_data.flags_do_not_use)
+    sat = np.uint32(ramp_data.flags_saturated)
 
     # Remove DO_NOT_USE and SATURATED because they need special handling.
     # These flags are not set in the final pixel DQ array by simply being set


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3044](https://jira.stsci.edu/browse/JP-3044)

<!-- describe the changes comprising this PR here -->
This PR addresses the cast warning associated with ramp fitting in the function `dq_final_compress`.  The casting of the negation for the variable `not_sat_or_dnu` caused an overflow.  To fix this `dnu` and `sat` are now cast to `uint32` before the creation of the variable `not_sat_or_dnu`.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
