### PR TITLE
RCAL-438 Add support for Reference File Quantities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 General
 -------
 
--
+- 
 
 Bug Fixes
 ---------
@@ -15,6 +15,11 @@ Changes to API
 --------------
 
 -
+
+dark
+----
+
+- Modified dark class to support quantities in Roman.[#140]
 
 1.3.1 (2023-01-03)
 ==================

--- a/src/stcal/dark_current/dark_class.py
+++ b/src/stcal/dark_current/dark_class.py
@@ -36,7 +36,7 @@ class DarkData:
             meta data set based on the arrays in the dark_model.
         """
         if dark_model is not None:
-            if isinstance(dark_model.data,u.Quantity):
+            if isinstance(dark_model.data, u.Quantity):
                 self.data = dark_model.data.value
                 self.err = dark_model.err.value
             else:

--- a/src/stcal/dark_current/dark_class.py
+++ b/src/stcal/dark_current/dark_class.py
@@ -36,9 +36,13 @@ class DarkData:
             meta data set based on the arrays in the dark_model.
         """
         if dark_model is not None:
-            self.data = dark_model.data
+            if isinstance(dark_model.data,u.Quantity):
+                self.data = dark_model.data.value
+                self.err = dark_model.err.value
+            else:
+                self.data = dark_model.data
+                self.err = dark_model.err
             self.groupdq = dark_model.dq
-            self.err = dark_model.err
 
             self.exp_nframes = dark_model.meta.exposure.nframes
             self.exp_ngroups = dark_model.meta.exposure.ngroups


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
Resolves [RCAL-438](https://jira.stsci.edu/browse/RCAL-438)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds support for quantities within the dark class for Roman. Unit tested against both Roman & JWST.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
