### PR TITLE
JP-3004: Should have NaN's for Suppressed Ramps, but Getting Zeros.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Bug Fixes
 ramp_fitting
 ~~~~~~~~~~~~
 
-- Fixed zeros that should be NaNs in rateints product and suppressed
+- Fixed zeros that should be NaNs in rate and rateints product and suppressed
   a cast warning due to attempts to cast NaN to an integer. [#141]
 
 Changes to API

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,12 @@ General
 Bug Fixes
 ---------
 
--
+  
+ramp_fitting
+~~~~~~~~~~~~
+
+- Fixed zeros that should be NaNs in rateints product and suppressed
+  a cast warning due to attempts to cast NaN to an integer. [#141]
 
 Changes to API
 --------------

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1105,7 +1105,7 @@ def ramp_fit_compute_variances(ramp_data, gain_2d, readnoise_2d, fit_slopes_ans)
 
         # Huge variances correspond to non-existing segments, so are reset to 0
         #  to nullify their contribution.
-        var_p3[var_p3 > 0.1 * utils.LARGE_VARIANCE] = 0.
+        var_p3[var_p3 > utils.LARGE_VARIANCE_THRESHOLD] = 0.
         var_p3[:, med_rates <= 0.] = 0.
         warnings.resetwarnings()
 
@@ -1396,8 +1396,8 @@ def ramp_fit_overall(
     #  to nullify their contribution.
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "invalid value.*", RuntimeWarning)
-        var_p2[var_p2 > 0.1 * utils.LARGE_VARIANCE] = 0.
-        var_r2[var_r2 > 0.1 * utils.LARGE_VARIANCE] = 0.
+        var_p2[var_p2 > utils.LARGE_VARIANCE_THRESHOLD] = 0.
+        var_r2[var_r2 > utils.LARGE_VARIANCE_THRESHOLD] = 0.
 
     # Some contributions to these vars may be NaN as they are from ramps
     # having PIXELDQ=DO_NOT_USE

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -274,4 +274,5 @@ def suppress_one_good_group_ramps(ramp_data):
             # ramp saturated, mark the 0th groups as saturated, too.
             good_index = np.where(ramp_data.groupdq[integ, :, row, col] == 0)
             if ramp_data.groupdq[integ, good_index, row, col] == 0:
-                ramp_data.groupdq[integ, good_index, row, col] = dnu_flag
+                ramp_data.groupdq[integ, :, row, col] = np.bitwise_or(
+                 ramp_data.groupdq[integ, :, row, col], dnu_flag)

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -264,14 +264,15 @@ def suppress_one_good_group_ramps(ramp_data):
         ngood_groups = good_groups.sum(axis=0)
         wh_one = np.where(ngood_groups == 1)
 
-        # Suppress the ramps with only one good group by flagg
+        # Suppress the ramps with only one good group by flagging
+        # all groups in the ramp as DO_NOT_USE.
         wh1_rows = wh_one[0]
         wh1_cols = wh_one[1]
         for n in range(len(wh1_rows)):
             row = wh1_rows[n]
             col = wh1_cols[n]
-            # For ramps that have good 0th group, but the rest of the
-            # ramp saturated, mark the 0th groups as saturated, too.
+            # Find ramps that have good 0th group, but the rest of the
+            # ramp flagged.
             good_index = np.where(ramp_data.groupdq[integ, :, row, col] == 0)
             if ramp_data.groupdq[integ, good_index, row, col] == 0:
                 ramp_data.groupdq[integ, :, row, col] = np.bitwise_or(

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -924,7 +924,7 @@ def test_dq_multi_int_dnu():
                       [[0.00173518]]])
     np.testing.assert_allclose(cvp, check, tol, tol)
 
-    check = np.array([[[2.5000000e+07]],
+    check = np.array([[[0.]],
                       [[4.3379547e-04]]])
     np.testing.assert_allclose(cvr, check, tol, tol)
 
@@ -1038,8 +1038,8 @@ def test_new_saturation():
                       [[0.00086654, 0.        , 0.]]])
     np.testing.assert_allclose(cvp, check, tol, tol)
 
-    check = np.array([[[6.5232398e-06, 6.1970772e-05, 3.3333334e+07]],
-                      [[6.1970772e-05, 3.3333334e+07, 3.3333334e+07]]])
+    check = np.array([[[6.5232398e-06, 6.1970772e-05, 0.]],
+                      [[6.1970772e-05, 0., 0.]]])
     np.testing.assert_allclose(cvr, check, tol, tol)
 
     check = np.array([[[0.02353317, 0.02258242, 0.]],


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3004](https://jira.stsci.edu/browse/JP-3004)


<!-- describe the changes comprising this PR here -->
This PR addresses zero values for suppressed ramps that should have been set to NaN in both the rate and rateints product.  There was an unexpected edge case due to the jump step setting JUMP_DET because of the `flag_4_neighbors` being set to true.  This resulted in an effective 2 group ramp with the second ramp being flagged as JUMP_DET, which is nonsense.   Further, in ramp fitting, because the `suppress_one_group` is set to true, this has the result in the first group being marked as DO_NOT_USE, while the second group is only a jump detection.  A one group ramp with the DO_NOT_USE flagged has different results to a one group ramp flagged as JUMP_DET, a situation unanticipated.

The solution was to suppress all groups in a one group ramp, rather than just the first good group.  This, then had unexpected results.  Internally, LARGE_VARIANCE is used to compute variances with bad data.  This allows the inverse sums to be computed, while adding effectively nothing to good variance computations.  However, when all variances are LARGE_VARIANCE, the resultant sum will be large and should be set to zero.  The threshold to check this was set too high, allowing these large variances through, when they should have been set to zero.  Also, this threshold was defined inconsistently in the code, so a top level variable in the `utils.py` was created to use in all instances this variance threshold needs to be used.

Finally, and unrelated to the issue in JP-3004, a warning thrown when the code tried to cast NaN as an integer has been suppressed to make the output cleaner.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
