### PR TITLE
JP-3077: Change the Computation in Ramps with only One Good Group in the 0th Group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ ramp_fitting
 - Fixed zeros that should be NaNs in rate and rateints product and suppressed
   a cast warning due to attempts to cast NaN to an integer. [#141]
 
+- Changed computations for ramps that have only one good group in the 0th
+  group.  Ramps that have a non-zero groupgap should not use group_time, but
+  (NFrames+1)*TFrame/2, instead. [#142]
+
 Changes to API
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,18 +1,24 @@
+1.3.4 (unreleased)
+==================
+
+ramp_fitting
+~~~~~~~~~~~~
+
+- Changed computations for ramps that have only one good group in the 0th
+  group.  Ramps that have a non-zero groupgap should not use group_time, but
+  (NFrames+1)*TFrame/2, instead. [#142]
+
 1.3.3 (2023-01-26)
 ==================
 
 Bug Fixes
 ---------
-  
+
 ramp_fitting
 ~~~~~~~~~~~~
 
 - Fixed zeros that should be NaNs in rate and rateints product and suppressed
   a cast warning due to attempts to cast NaN to an integer. [#141]
-
-- Changed computations for ramps that have only one good group in the 0th
-  group.  Ramps that have a non-zero groupgap should not use group_time, but
-  (NFrames+1)*TFrame/2, instead. [#142]
 
 Changes to API
 --------------

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -655,13 +655,17 @@ def ols_ramp_fit_single(
 
     # import ipdb; ipdb.set_trace()
     if not ramp_data.suppress_one_group_ramps:
+        # XXX JP-3077 Add one group finder here.
+        # This must be done before the ZEROFRAME replacements to prevent
+        # ZEROFRAME replacement being confused for one good group ramps
+        # in the 0th group.
+        if ramp_data.groupgap > 0:
+            find_0th_one_good_group(ramp_data)
+
         if ramp_data.zeroframe is not None:
             zframe_locs, cnt = utils.use_zeroframe_for_saturated_ramps(ramp_data)
             ramp_data.zframe_locs = zframe_locs
             ramp_data.cnt = cnt
-        # XXX JP-3077 Add one group finder here.
-        if ramp_data.groupgap > 0:
-            find_0th_one_good_group(ramp_data)
 
     # Save original shapes for writing to log file, as these may change for MIRI
     n_int, ngroups, nrows, ncols = ramp_data.data.shape

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -579,7 +579,7 @@ def find_0th_one_good_group(ramp_data):
         Input data necessary for computing ramp fitting.
     """
     nints, ngroups, nrows, ncols = ramp_data.groupdq.shape
-    _1ggroup = [None] * nints  # One good group list of pixels per integration
+    one_group = [None] * nints  # One good group list of pixels per integration
     for integ in range(nints):
         cintegdq = ramp_data.groupdq[integ, :, :, :]  # Current integration DQ array
         
@@ -598,16 +598,16 @@ def find_0th_one_good_group(ramp_data):
 
         # Get the locations of pixels that have good zeroeth group, with
         # all other groups bad.
-        _1ggroup_int = np.logical_and(good_0, bad_1_)
-        _1ggroup[integ] = np.where(_1ggroup_int)
+        one_group_int = np.logical_and(good_0, bad_1_)
+        one_group[integ] = np.where(one_group_int)
 
-        del _1ggroup_int
+        del one_group_int
         del good_0
         del bad_1_
 
-    ramp_data._1ggroups_locs = _1ggroup
+    ramp_data.one_groups_locs = one_group
     # (NFrames + 1) * TFrame / 2
-    ramp_data._1ggroups_time = (ramp_data.nframes + 1) * ramp_data.frame_time / 2
+    ramp_data.one_groups_time = (ramp_data.nframes + 1) * ramp_data.frame_time / 2
         
 
 def ols_ramp_fit_single(

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -579,9 +579,9 @@ def find_0th_one_good_group(ramp_data):
         Input data necessary for computing ramp fitting.
     """
     nints, ngroups, nrows, ncols = ramp_data.groupdq.shape
-    _1ggroup = [None] * nints
+    _1ggroup = [None] * nints  # One good group list of pixels per integration
     for integ in range(nints):
-        cintegdq = ramp_data.groupdq[integ, :, :, :]
+        cintegdq = ramp_data.groupdq[integ, :, :, :]  # Current integration DQ array
         
         # Find pixels with good group 0
         good_0 = np.zeros((nrows, ncols), dtype=int)
@@ -590,11 +590,11 @@ def find_0th_one_good_group(ramp_data):
 
         # Find pixels with only one good group
         cinteg_sm = np.zeros((ngroups-1, nrows, ncols), dtype=int)
-        cintegdq_1 = cintegdq[1:, :, :]
-        cinteg_sm[cintegdq_1 != 0] = 1
-        gp_sum = cinteg_sm.sum(axis=0)
+        cintegdq_1 = cintegdq[1:, :, :]  # Current integration DQ array excluding 0th group
+        cinteg_sm[cintegdq_1 != 0] = 1  # Mark flagged groups to use in sum
+        gp_sum = cinteg_sm.sum(axis=0)  # Find the number of flagged groups excluding 0th group
         bad_1_ = np.zeros((nrows, ncols), dtype=int)
-        bad_1_[gp_sum == ngroups-1] = 1  # Pixels with groups 1: bad
+        bad_1_[gp_sum == ngroups-1] = 1  # Pixels with all groups flagged after the 0th group
 
         # Get the locations of pixels that have good zeroeth group, with
         # all other groups bad.

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -578,7 +578,6 @@ def find_0th_one_good_group(ramp_data):
     ramp_data : RampData
         Input data necessary for computing ramp fitting.
     """
-    # XXX JP-3077
     nints, ngroups, nrows, ncols = ramp_data.groupdq.shape
     _1ggroup = [None] * nints
     for integ in range(nints):
@@ -652,9 +651,7 @@ def ols_ramp_fit_single(
     """
     tstart = time.time()
 
-    # import ipdb; ipdb.set_trace()
     if not ramp_data.suppress_one_group_ramps:
-        # XXX JP-3077 Add one group finder here.
         # This must be done before the ZEROFRAME replacements to prevent
         # ZEROFRAME replacement being confused for one good group ramps
         # in the 0th group.

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -608,8 +608,7 @@ def find_0th_one_good_group(ramp_data):
 
     ramp_data._1ggroups_locs = _1ggroup
     # (NFrames + 1) * TFrame / 2
-    nframes = ramp_data.nframes - ramp_data.groupgap
-    ramp_data._1ggroups_time = (nframes + 1) * ramp_data.frame_time / 2
+    ramp_data._1ggroups_time = (ramp_data.nframes + 1) * ramp_data.frame_time / 2
         
 
 def ols_ramp_fit_single(

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -142,13 +142,14 @@ class RampData:
         # Meta information
         print("-" * 80)
         print("    Meta:")
-        print(f"Instumet: {self.instrument_name}")
+        print(f"Instrument: {self.instrument_name}")
 
         print(f"Frame time : {self.frame_time}")
         print(f"Group time : {self.group_time}")
         print(f"Group Gap : {self.groupgap}")
         print(f"Nframes : {self.nframes}")
         print(f"Drop Frames : {self.drop_frames1}")
+        print("-" * 80)
 
     def dbg_print_mp(self):
         # Multiprocessing
@@ -171,14 +172,15 @@ class RampData:
 
     def dbg_print_basic_info(self):
         # Arrays from the data model
-        print("-" * 80)
-        print(f"Shape : {self.data.shape}")
-        print(f"data : {self.data}")
-        print(f"err : {self.err}")
-        print(f"groupdq : {self.groupdq}")
-        print(f"pixeldq : {self.pixeldq}")
-
         self.dbg_print_meta()
+
+        print(f"Shape : {self.data.shape}")
+        print(f"data : \n{self.data}")
+        print(f"err : \n{self.err}")
+        print(f"groupdq : \n{self.groupdq}")
+        print(f"pixeldq : \n{self.pixeldq}")
+        print("-" * 80)
+
 
     def dbg_print_pixel_info(self, row, col):
         print("-" * 80)

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -37,8 +37,8 @@ class RampData:
         # One group ramp suppression for saturated ramps after 0th group.
         self.suppress_one_group_ramps = False
 
-        self._1ggroups_locs = None
-        self._1ggroups_time = None
+        self._1ggroups_locs = None  # One good group locations.
+        self._1ggroups_time = None  # Time to use for one good group ramps.
 
         self.current_integ = -1
 

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -37,6 +37,9 @@ class RampData:
         # One group ramp suppression for saturated ramps after 0th group.
         self.suppress_one_group_ramps = False
 
+        self._1ggroups_locs = None
+        self._1ggroups_time = None
+
         self.current_integ = -1
 
     def set_arrays(self, data, err, groupdq, pixeldq):

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -37,8 +37,8 @@ class RampData:
         # One group ramp suppression for saturated ramps after 0th group.
         self.suppress_one_group_ramps = False
 
-        self._1ggroups_locs = None  # One good group locations.
-        self._1ggroups_time = None  # Time to use for one good group ramps.
+        self.one_groups_locs = None  # One good group locations.
+        self.one_groups_time = None  # Time to use for one good group ramps.
 
         self.current_integ = -1
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -583,16 +583,16 @@ def calc_slope_vars(ramp_data, rn_sect, gain_sect, gdq_sect, group_time, max_seg
     den_p3 = 1. / (group_time * gain_1d.reshape(imshape) * segs_beg_3_m1)
 
     if ramp_data.zframe_locs:
-        integ_locs = ramp_data.zframe_locs[ramp_data.current_integ]
+        zinteg_locs = ramp_data.zframe_locs[ramp_data.current_integ]
         frame_time = ramp_data.frame_time
         tmp_den_p3 = den_p3[0, :, :]
-        tmp_den_p3[integ_locs] = 1. / (frame_time * gain_sect[integ_locs])
+        tmp_den_p3[zinteg_locs] = 1. / (frame_time * gain_sect[zinteg_locs])
         den_p3[0, :, :] = tmp_den_p3
 
     if ramp_data._1ggroups_time is not None:
-        integ_locs = ramp_data._1ggroups_locs[ramp_data.current_integ]
+        ginteg_locs = ramp_data._1ggroups_locs[ramp_data.current_integ]
         tmp_den_p3 = den_p3[0, :, :]
-        tmp_den_p3[integ_locs] = 1. / (ramp_data._1ggroups_time * gain_sect[integ_locs])
+        tmp_den_p3[ginteg_locs] = 1. / (ramp_data._1ggroups_time * gain_sect[ginteg_locs])
         den_p3[0, :, :] = tmp_den_p3
 
     warnings.resetwarnings()
@@ -602,13 +602,13 @@ def calc_slope_vars(ramp_data, rn_sect, gain_sect, gdq_sect, group_time, max_seg
     num_r3 = 12. * (rn_sect / group_time)**2.  # always >0
 
     if ramp_data.zframe_locs:
-        integ_locs = ramp_data.zframe_locs[ramp_data.current_integ]
+        zinteg_locs = ramp_data.zframe_locs[ramp_data.current_integ]
         frame_time = ramp_data.frame_time
-        num_r3[integ_locs] = 12. * (rn_sect[integ_locs] / frame_time)**2.
+        num_r3[zinteg_locs] = 12. * (rn_sect[zinteg_locs] / frame_time)**2.
 
     if ramp_data._1ggroups_time is not None:
-        integ_locs = ramp_data._1ggroups_locs[ramp_data.current_integ]
-        num_r3[integ_locs] = 12. * (rn_sect[integ_locs] / ramp_data._1ggroups_time)**2.
+        ginteg_locs = ramp_data._1ggroups_locs[ramp_data.current_integ]
+        num_r3[ginteg_locs] = 12. * (rn_sect[ginteg_locs] / ramp_data._1ggroups_time)**2.
 
     # Reshape for every group, every pixel in section
     num_r3 = np.dstack([num_r3] * max_seg)
@@ -1505,9 +1505,9 @@ def compute_median_rates(ramp_data):
             data_sect[0, :, :] = tmp_dsect
 
         if ramp_data.zframe_locs is not None:
-            integ_locs = ramp_data.zframe_locs[integ]
+            zinteg_locs = ramp_data.zframe_locs[integ]
             tmp_dsect = data_sect[0, :, :]
-            tmp_dsect[integ_locs] = tmp_dsect[integ_locs] * adjustment
+            tmp_dsect[zinteg_locs] = tmp_dsect[zinteg_locs] * adjustment
             data_sect[0, :, :] = tmp_dsect
 
         # Compute the first differences of all groups

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1480,9 +1480,9 @@ def compute_median_rates(ramp_data):
     adjustment = group_time / frame_time
 
     if ramp_data._1ggroups_time is not None:
-        _1ggroups_time = group_time / ramp_data._1ggroups_time
+        _1ggroups_time_adjustment = group_time / ramp_data._1ggroups_time
     else:
-        _1ggroups_time = None
+        _1ggroups_time_adjustment = None
 
     median_diffs_2d = np.zeros(imshape, dtype=np.float32)
 
@@ -1498,10 +1498,10 @@ def compute_median_rates(ramp_data):
 
         data_sect = data_sect / group_time
 
-        if _1ggroups_time is not None:
+        if _1ggroups_time_adjustment is not None:
             _1ggroups_locs = ramp_data._1ggroups_locs[integ]
             tmp_dsect = data_sect[0, :, :]
-            tmp_dsect[_1ggroups_locs] = tmp_dsect[_1ggroups_locs] * _1ggroups_time
+            tmp_dsect[_1ggroups_locs] = tmp_dsect[_1ggroups_locs] * _1ggroups_time_adjustment
             data_sect[0, :, :] = tmp_dsect
 
         if ramp_data.zframe_locs is not None:

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -589,10 +589,10 @@ def calc_slope_vars(ramp_data, rn_sect, gain_sect, gdq_sect, group_time, max_seg
         tmp_den_p3[zinteg_locs] = 1. / (frame_time * gain_sect[zinteg_locs])
         den_p3[0, :, :] = tmp_den_p3
 
-    if ramp_data._1ggroups_time is not None:
-        ginteg_locs = ramp_data._1ggroups_locs[ramp_data.current_integ]
+    if ramp_data.one_groups_time is not None:
+        ginteg_locs = ramp_data.one_groups_locs[ramp_data.current_integ]
         tmp_den_p3 = den_p3[0, :, :]
-        tmp_den_p3[ginteg_locs] = 1. / (ramp_data._1ggroups_time * gain_sect[ginteg_locs])
+        tmp_den_p3[ginteg_locs] = 1. / (ramp_data.one_groups_time * gain_sect[ginteg_locs])
         den_p3[0, :, :] = tmp_den_p3
 
     warnings.resetwarnings()
@@ -606,9 +606,9 @@ def calc_slope_vars(ramp_data, rn_sect, gain_sect, gdq_sect, group_time, max_seg
         frame_time = ramp_data.frame_time
         num_r3[zinteg_locs] = 12. * (rn_sect[zinteg_locs] / frame_time)**2.
 
-    if ramp_data._1ggroups_time is not None:
-        ginteg_locs = ramp_data._1ggroups_locs[ramp_data.current_integ]
-        num_r3[ginteg_locs] = 12. * (rn_sect[ginteg_locs] / ramp_data._1ggroups_time)**2.
+    if ramp_data.one_groups_time is not None:
+        ginteg_locs = ramp_data.one_groups_locs[ramp_data.current_integ]
+        num_r3[ginteg_locs] = 12. * (rn_sect[ginteg_locs] / ramp_data.one_groups_time)**2.
 
     # Reshape for every group, every pixel in section
     num_r3 = np.dstack([num_r3] * max_seg)
@@ -1479,10 +1479,10 @@ def compute_median_rates(ramp_data):
     frame_time = ramp_data.frame_time
     adjustment = group_time / frame_time
 
-    if ramp_data._1ggroups_time is not None:
-        _1ggroups_time_adjustment = group_time / ramp_data._1ggroups_time
+    if ramp_data.one_groups_time is not None:
+        one_groups_time_adjustment = group_time / ramp_data.one_groups_time
     else:
-        _1ggroups_time_adjustment = None
+        one_groups_time_adjustment = None
 
     median_diffs_2d = np.zeros(imshape, dtype=np.float32)
 
@@ -1498,10 +1498,10 @@ def compute_median_rates(ramp_data):
 
         data_sect = data_sect / group_time
 
-        if _1ggroups_time_adjustment is not None:
-            _1ggroups_locs = ramp_data._1ggroups_locs[integ]
+        if one_groups_time_adjustment is not None:
+            one_groups_locs = ramp_data.one_groups_locs[integ]
             tmp_dsect = data_sect[0, :, :]
-            tmp_dsect[_1ggroups_locs] = tmp_dsect[_1ggroups_locs] * _1ggroups_time_adjustment
+            tmp_dsect[one_groups_locs] = tmp_dsect[one_groups_locs] * one_groups_time_adjustment
             data_sect[0, :, :] = tmp_dsect
 
         if ramp_data.zframe_locs is not None:

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -839,6 +839,105 @@ def test_zeroframe():
     np.testing.assert_allclose(cerr, check, tol, tol)
 
 
+def create_only_good_0th_group_data():
+    """
+    Create three ramps to the the good 0th group.
+    1. An all good ramp.
+    2. A saturated ramp starting at group 2 with the first two groups good.
+    3. A saturated ramp starting at group 1 with only group 0 good.
+    """
+    # Create meta data.
+    frame_time, nframes, groupgap = 10.736, 2, 3
+    group_time = (nframes + groupgap) * frame_time
+    nints, ngroups, nrows, ncols = 1, 5, 1, 3
+    rnval, gval = 10., 5.
+
+    # Create arrays for RampData.
+    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
+    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
+    pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
+    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
+
+    # Create base ramps for each pixel in each integration.
+    base_slope = 2000.0
+    base_arr = [8000. + k * base_slope for k in range(ngroups)]
+    base_ramp = np.array(base_arr, dtype=np.float32)
+
+    data[0, :, 0, 0] = base_ramp
+    data[0, :, 0, 1] = base_ramp
+    data[0, :, 0, 2] = base_ramp
+
+    # Set up group DQ array.
+    gdq[0, :, 0, 0] = np.array([GOOD] * ngroups)
+
+    gdq[0, :, 0, 1] = np.array([SAT] * ngroups)
+    gdq[0, 0, 0, 1] = GOOD
+    gdq[0, 1, 0, 1] = GOOD
+
+    gdq[0, :, 0, 2] = np.array([SAT] * ngroups)
+    gdq[0, 0, 0, 2] = GOOD
+
+    # Create RampData for testing.
+    ramp_data = RampData()
+    ramp_data.set_arrays(
+        data=data, err=err, groupdq=gdq, pixeldq=pixdq)
+    ramp_data.set_meta(
+        name="NIRCam", frame_time=frame_time, group_time=group_time,
+        groupgap=groupgap, nframes=nframes, drop_frames1=None)
+    ramp_data.set_dqflags(dqflags)
+
+    ramp_data.suppress_one_group_ramps = False
+
+    # Create variance arrays
+    gain = np.ones((nrows, ncols), np.float32) * gval
+    rnoise = np.ones((nrows, ncols), np.float32) * rnval
+
+    return ramp_data, gain, rnoise
+
+
+def test_only_good_0th_group():
+    """
+    Tests three ramps to the the good 0th group.
+    1. An all good ramp.
+    2. A saturated ramp starting at group 2 with the first two groups good.
+    3. A saturated ramp starting at group 1 with only group 0 good.
+    """
+    ramp_data, gain, rnoise = create_only_good_0th_group_data()
+    
+    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    slopes, cube, ols_opt, gls_opt = ramp_fit_data(
+        ramp_data, bufsize, save_opt, rnoise, gain, algo,
+        "optimal", ncores, dqflags)
+
+    tol = 1.e-5
+
+    # Check slopes information
+    sdata, sdq, svp, svr, serr = slopes
+
+    # The slopes for the first two ramps should be the same, including
+    # for the rateints directory.  The last ramp will be different
+    # because a different time is used as the denominator for the slope.
+    # Because the number of groups used in the first two ramps are different
+    # the variances are expected to be different, even though the slopes
+    # should be the same.
+    check = np.array([[37.257824,  37.257824, 149.0313]])
+    np.testing.assert_allclose(sdata, check, tol, tol)
+
+    check = np.array([[GOOD, GOOD, GOOD]])
+    np.testing.assert_allclose(sdq, check, tol, tol)
+
+    check = np.array([[0.03470363, 0.13881457, 6.169534]])
+    np.testing.assert_allclose(svp, check, tol, tol)
+
+    check = np.array([[0.00086759, 0.01735182, 0.19279794]])
+    np.testing.assert_allclose(svr, check, tol, tol)
+
+    check = np.array([[0.18860336, 0.39517894, 2.5223665]])
+    np.testing.assert_allclose(serr, check, tol, tol)
+
+    # Cube checks ignored because the data has only one integration.
+
+
 def test_all_sat():
     """
     Test all ramps in all integrations saturated.

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -786,7 +786,7 @@ def test_zeroframe():
     The second integration has all good groups with half the data values.
     """
     ramp_data, gain, rnoise = create_zero_frame_data()
-
+    
     algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo,
@@ -797,19 +797,19 @@ def test_zeroframe():
     # Check slopes information
     sdata, sdq, svp, svr, serr = slopes
 
-    check = np.array([[44.256306, 18.62891, 23.787909]])
+    check = np.array([[30.196423, 18.62891, 23.787909]])
     np.testing.assert_allclose(sdata, check, tol, tol)
 
     check = np.array([[GOOD, GOOD, GOOD]])
     np.testing.assert_allclose(sdq, check, tol, tol)
 
-    check = np.array([[0.06246654, 0.00867591, 0.29745975]])
+    check = np.array([[0.165631, 0.00867591, 0.29745975]])
     np.testing.assert_allclose(svp, check, tol, tol)
 
-    check = np.array([[0.00041314, 0.0004338, 0.00043293]])
+    check = np.array([[0.00043035, 0.0004338, 0.00043293]])
     np.testing.assert_allclose(svr, check, tol, tol)
 
-    check = np.array([[0.2507582, 0.09544477, 0.54579544]])
+    check = np.array([[0.40750626, 0.09544477, 0.54579544]])
     np.testing.assert_allclose(serr, check, tol, tol)
 
     # Check slopes information
@@ -826,16 +826,16 @@ def test_zeroframe():
                       [[GOOD, GOOD, GOOD]]])
     np.testing.assert_allclose(cdq, check, tol, tol)
 
-    check = np.array([[[0.31233272, 0., 6.246655]],
-                      [[0.07808318, 0.00867591, 0.31233275]]])
+    check = np.array([[[1.821941, 0., 6.246655]],
+                      [[0.1821941, 0.00867591, 0.31233275]]])
     np.testing.assert_allclose(cvp, check, tol, tol)
 
-    check = np.array([[[0.00867591, 0., 0.21689774]],
+    check = np.array([[[0.05422444, 0., 0.21689774]],
                       [[0.0004338, 0.0004338, 0.0004338]]])
     np.testing.assert_allclose(cvr, check, tol, tol)
 
-    check = np.array([[[0.56657624, 0., 2.542352]],
-                      [[0.2802088, 0.09544477, 0.55925536]]])
+    check = np.array([[[1.3697318, 0., 2.542352]],
+                      [[0.42734987, 0.09544477, 0.55925536]]])
     np.testing.assert_allclose(cerr, check, tol, tol)
 
 
@@ -1121,6 +1121,17 @@ def setup_inputs(dims, var, tm):
 ###############################################################################
 # The functions below are only used for DEBUGGING tests and developing tests. #
 ###############################################################################
+
+def print_real_check(real, check):
+    import inspect
+    cf = inspect.currentframe()
+    line_number = cf.f_back.f_lineno
+    print("=" * 80)
+    print(f"----> Line = {line_number} <----")
+    base_print("real", real)
+    print("=" * 80)
+    base_print("check", check)
+    print("=" * 80)
 
 
 def base_print(label, arr):

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -902,6 +902,8 @@ def test_only_good_0th_group():
     2. A saturated ramp starting at group 2 with the first two groups good.
     3. A saturated ramp starting at group 1 with only group 0 good.
     """
+
+    # Dimensions are (1, 5, 1, 3)
     ramp_data, gain, rnoise = create_only_good_0th_group_data()
     
     algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -797,19 +797,19 @@ def test_zeroframe():
     # Check slopes information
     sdata, sdq, svp, svr, serr = slopes
 
-    check = np.array([[30.196423, 18.62891, 23.787909]])
+    check = np.array([[32.78594, 18.62891, 23.787909]])
     np.testing.assert_allclose(sdata, check, tol, tol)
 
     check = np.array([[GOOD, GOOD, GOOD]])
     np.testing.assert_allclose(sdq, check, tol, tol)
 
-    check = np.array([[0.165631, 0.00867591, 0.29745975]])
+    check = np.array([[0.13110262, 0.00867591, 0.29745975]])
     np.testing.assert_allclose(svp, check, tol, tol)
 
     check = np.array([[0.00043035, 0.0004338, 0.00043293]])
     np.testing.assert_allclose(svr, check, tol, tol)
 
-    check = np.array([[0.40750626, 0.09544477, 0.54579544]])
+    check = np.array([[0.36267212, 0.09544477, 0.54579544]])
     np.testing.assert_allclose(serr, check, tol, tol)
 
     # Check slopes information
@@ -826,16 +826,16 @@ def test_zeroframe():
                       [[GOOD, GOOD, GOOD]]])
     np.testing.assert_allclose(cdq, check, tol, tol)
 
-    check = np.array([[[1.821941, 0., 6.246655]],
-                      [[0.1821941, 0.00867591, 0.31233275]]])
+    check = np.array([[[1.1799237 , 0.        , 6.246655  ]],
+                      [[0.14749046, 0.00867591, 0.31233275]]])
     np.testing.assert_allclose(cvp, check, tol, tol)
 
-    check = np.array([[[0.05422444, 0., 0.21689774]],
+    check = np.array([[[0.03470363, 0., 0.21689774]],
                       [[0.0004338, 0.0004338, 0.0004338]]])
     np.testing.assert_allclose(cvr, check, tol, tol)
 
-    check = np.array([[[1.3697318, 0., 2.542352]],
-                      [[0.42734987, 0.09544477, 0.55925536]]])
+    check = np.array([[[1.1021013, 0., 2.542352]],
+                      [[0.38460922, 0.09544477, 0.55925536]]])
     np.testing.assert_allclose(cerr, check, tol, tol)
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3077](https://jira.stsci.edu/browse/JP-3077)


<!-- describe the changes comprising this PR here -->
This PR addresses the incorrect usage of group_time for ramps that have non-zero groupgap and the 0th group the only good group in the ramp.  Because of the readout pattern, the time for the 0th group alone is computed using `(NFrames+1)*TFrame/2`, instead.

This had similar computations for ZEROFRAME handling and was noted the use of for loops during computation, so an effort was made to use a numpy approach so that numpy will handle the for loops for performance reasons.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
