### PR TITLE
to match jwst testing, ignore scripts in jwst ci job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
     pytest \
     warnings: -W error \
     xdist: -n auto \
-    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
+    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=scripts \
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
     opencv: -- tests/test_jump.py \


### PR DESCRIPTION
jwst ignores the scripts directory for pytest
https://github.com/spacetelescope/jwst/blob/4285c4efb95bc368f36456e9e106e6aba6abd597/setup.cfg#L152
this PR replicates that ignore to allow the CI to pass

similar issues were found in other packages:
gwcs: https://github.com/spacetelescope/gwcs/pull/444
stpipe: https://github.com/spacetelescope/stpipe/pull/83

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
