### PR TITLE
JP-3075: Updating dynamic_mask function to include inversion functionality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Bug Fixes
 1.3.4 (2023-02-13)
 ==================
 
+- Updated the `dynamic_mask` function to include an inversion. [#145]
+
 ramp_fitting
 ~~~~~~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,13 @@
 Bug Fixes
 ---------
 
--
+Other
+-----
+
+- Updated the ``dynamic_mask`` function to include an inversion. [#145]
 
 1.3.4 (2023-02-13)
 ==================
-
-- Updated the `dynamic_mask` function to include an inversion. [#145]
 
 ramp_fitting
 ~~~~~~~~~~~~

--- a/src/stcal/dynamicdq.py
+++ b/src/stcal/dynamicdq.py
@@ -6,7 +6,7 @@ log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
 
-def dynamic_mask(input_model, mnemonic_map):
+def dynamic_mask(input_model, mnemonic_map, inv=False):
     """
     Return a mask model given a mask with dynamic DQ flags.
 
@@ -16,7 +16,13 @@ def dynamic_mask(input_model, mnemonic_map):
     ----------
     input_model : ``MaskModel``
         An instance of a Mask model defined in jwst or romancal.
+
     mnemonic_map : dict
+        Dictionary of flag names and values.
+
+    inv : bool
+        If true, compress using the dq_def.  If false, decompress
+        using the dq_def.
 
     Returns
     -------
@@ -36,15 +42,26 @@ def dynamic_mask(input_model, mnemonic_map):
         for record in dq_table:
             bitplane = record['VALUE']
             dqname = record['NAME'].strip()
+
+            # Check that a flag in the 'dq_def' is a valid DQ flag.
             try:
                 standard_bitvalue = mnemonic_map[dqname]
             except KeyError:
                 log.warning('Keyword %s does not correspond to an existing '
                             'DQ mnemonic, so will be ignored' % (dqname))
                 continue
-            just_this_bit = np.bitwise_and(input_model.dq, bitplane)
-            pixels = np.where(just_this_bit != 0)
-            dqmask[pixels] = np.bitwise_or(dqmask[pixels], standard_bitvalue)
+
+            if not inv:
+                # Decompress the DQ array using 'dq_def'.
+                just_this_bit = np.bitwise_and(input_model.dq, bitplane)
+                pixels = np.where(just_this_bit != 0)
+                dqmask[pixels] = np.bitwise_or(dqmask[pixels], standard_bitvalue)
+            else:
+                # Compress the DQ array using 'dq_def'.
+                just_this_bit = np.bitwise_and(input_model.dq, standard_bitvalue)
+                pixels = np.where(just_this_bit != 0)
+                dqmask[pixels] = np.bitwise_or(dqmask[pixels], bitplane)
+                
     else:
         dqmask = input_model.dq
 

--- a/src/stcal/dynamicdq.py
+++ b/src/stcal/dynamicdq.py
@@ -61,7 +61,7 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
                 just_this_bit = np.bitwise_and(input_model.dq, standard_bitvalue)
                 pixels = np.where(just_this_bit != 0)
                 dqmask[pixels] = np.bitwise_or(dqmask[pixels], bitplane)
-                
+
     else:
         dqmask = input_model.dq
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -582,7 +582,7 @@ def find_0th_one_good_group(ramp_data):
     one_group = [None] * nints  # One good group list of pixels per integration
     for integ in range(nints):
         cintegdq = ramp_data.groupdq[integ, :, :, :]  # Current integration DQ array
-        
+
         # Find pixels with good group 0
         good_0 = np.zeros((nrows, ncols), dtype=int)
         cintegdq_0  = cintegdq[0, :, :]
@@ -608,7 +608,7 @@ def find_0th_one_good_group(ramp_data):
     ramp_data.one_groups_locs = one_group
     # (NFrames + 1) * TFrame / 2
     ramp_data.one_groups_time = (ramp_data.nframes + 1) * ramp_data.frame_time / 2
-        
+
 
 def ols_ramp_fit_single(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, weighting):

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -786,7 +786,7 @@ def test_zeroframe():
     The second integration has all good groups with half the data values.
     """
     ramp_data, gain, rnoise = create_zero_frame_data()
-    
+
     algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo,
@@ -905,7 +905,7 @@ def test_only_good_0th_group():
 
     # Dimensions are (1, 5, 1, 3)
     ramp_data, gain, rnoise = create_only_good_0th_group_data()
-    
+
     algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo,


### PR DESCRIPTION
…he 'dq_def' attribute to compress the DQ array.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3075](https://jira.stsci.edu/browse/JP-3075)


<!-- describe the changes comprising this PR here -->
This PR addresses round tripping issues for datamodels that use `dq_def`.  The `dq_def` table details how DQ flags are compressed for saving and how to be uncompressed when opened.  When opened, datamodels automatically call `dynamic_mask` to properly uncompress DQ arrays.   However, the inverse was not true during save, which meant that if these datamodels got saved, the uncompressed DQ array got saved to disk, so that when opened again the decompression failed.

An `inv` parameter got added to the `dynamic_mask` function to compress uncompressed DQ arrays.  This inversion is used for datamodels that use `dq_def`.  In particular, in `stdatamodels` the inversion is used for ReferenceFileModel during save to ensure the uncompressed DQ array does not get saved, but is properly transformed using the `dq_def` table before saving.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
