### PR TITLE
import `tomli` as `tomllib` for `docs` builds before Python 3.11

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,11 @@ from datetime import datetime
 from pathlib import Path
 
 import stsci_rtd_theme
-import tomli
-
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+    
 
 def setup(app):
     try:
@@ -23,7 +26,7 @@ sys.path.insert(0, str(REPO_ROOT / "src" / "stcal"))
 # Read the package's `pyproject.toml` so that we can use relevant
 # values here:
 with open(REPO_ROOT / "pyproject.toml", "rb") as configuration_file:
-    conf = tomli.load(configuration_file)
+    conf = tomllib.load(configuration_file)
 setup_metadata = conf['project']
 
 project = setup_metadata["name"]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
`tomli` is implemented read-only as `tomllib` in Python 3.11; this change ensures that the documentation build doesn't fail in Python 3.11 and above 

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
