### PR TITLE
use OpenAstronomy workflows and move MacOS jobs to schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,85 +16,56 @@ on:
 
 jobs:
   check:
-    name: ${{ matrix.toxenv }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        toxenv: [ check-style, check-security, check-build ]
-        python-version: [ '3.x' ]
-        os: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-      - run: pip install tox
-      - run: tox -e ${{ matrix.toxenv }}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: check-style
+        - linux: check-security
+        - linux: check-build
   test:
-    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: [ check ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        toxenv: [ test-xdist ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
-        os: [ ubuntu-latest, macos-latest ]
-        include:
-          - toxenv: test-cov
-            os: ubuntu-latest
-            python-version: '3.11'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.10'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.10'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy120
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.8'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.8'
-          - toxenv: test-numpy120
-            os: ubuntu-latest
-            python-version: '3.8'
-          - toxenv: test-opencv-xdist
-            os: ubuntu-latest
-            python-version: '3.x'
-          - toxenv: test-jwst-xdist-cov
-            os: ubuntu-latest
-            python-version: '3.x'
-          - toxenv: test-romancal-xdist-cov
-            os: ubuntu-latest
-            python-version: '3.x'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install tox
-      - run: tox -e ${{ matrix.toxenv }}
-      - if: ${{ contains(matrix.toxenv,'-cov') }}
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
-          flags: unit
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: test-xdist
+          python-version: '3.8'
+        - linux: test-xdist
+          python-version: '3.9'
+        - linux: test-xdist
+          python-version: '3.10'
+        - linux: test-xdist
+          python-version: '3.11'
+        - macos: test-xdist
+          python-version: '3.11'
+        - linux: test-opencv-xdist
+        - linux: test-cov-xdist
+          coverage: 'codecov'
+  test_numpy:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: test-numpy120-xdist
+          python-version: '3.8'
+        - linux: test-numpy121-xdist
+          python-version: '3.8'
+        - linux: test-numpy122-xdist
+          python-version: '3.8'
+        - linux: test-numpy120-xdist
+          python-version: '3.9'
+        - linux: test-numpy121-xdist
+          python-version: '3.9'
+        - linux: test-numpy122-xdist
+          python-version: '3.9'
+        - linux: test-numpy121-xdist
+          python-version: '3.10'
+        - linux: test-numpy122-xdist
+          python-version: '3.10'
+  test_downstream:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    with:
+      setenv: |
+        CRDS_PATH: /tmp/crds_cache
+        CRDS_CLIENT_RETRY_COUNT: 3
+        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+      envs: |
+        - linux: test-jwst-cov-xdist
+        - linux: test-romancal-cov-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
+        - linux: test-oldestdeps-cov-xdist
+          python-version: 3.8
         - linux: test-xdist
           python-version: '3.8'
         - linux: test-xdist
@@ -39,26 +41,6 @@ jobs:
         - linux: test-opencv-xdist
         - linux: test-cov-xdist
           coverage: 'codecov'
-  test_numpy:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      envs: |
-        - linux: test-numpy120-xdist
-          python-version: '3.8'
-        - linux: test-numpy121-xdist
-          python-version: '3.8'
-        - linux: test-numpy122-xdist
-          python-version: '3.8'
-        - linux: test-numpy120-xdist
-          python-version: '3.9'
-        - linux: test-numpy121-xdist
-          python-version: '3.9'
-        - linux: test-numpy122-xdist
-          python-version: '3.9'
-        - linux: test-numpy121-xdist
-          python-version: '3.10'
-        - linux: test-numpy122-xdist
-          python-version: '3.10'
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,0 +1,19 @@
+name: Weekly cron
+
+on:
+  schedule:
+    # Weekly Monday 6AM build
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - macos: test-xdist
+          python-version: 3.8
+        - macos: test-xdist
+          python-version: 3.9
+        - macos: test-xdist
+          python-version: 3.10

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Other
 - Remove the ``dqflags``, ``dynamicdq``, and ``basic_utils`` modules and replace
   them with thin imports from ``stdatamodels`` where the code as been moved. [#146]
 
+- update minimum version of ``numpy`` to ``1.20`` and add minimum dependency testing to CI [#153]
+
 1.3.4 (2023-02-13)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
     'astropy >=5.0.4',
     'scipy >=1.6.0',
-    'numpy >=1.17',
+    'numpy >=1.20',
 ]
 dynamic = ['version']
 

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands =
     pytest \
     warnings: -W error \
     xdist: -n auto \
-    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=scripts \
+    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=*/scripts/* \
     romancal: --pyargs romancal \
     cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
     opencv: -- tests/test_jump.py \

--- a/tox.ini
+++ b/tox.ini
@@ -44,9 +44,10 @@ commands =
 [testenv]
 description =
     run tests
+    opencv: requiring opencv-python
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
-    opencv: requiring opencv-python
+    oldestdeps: with the oldest supported version of key dependencies
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
@@ -57,9 +58,7 @@ deps =
     xdist: pytest-xdist
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
-    numpy122: numpy==1.22.*
+    oldestdeps: minimum_dependencies
 pass_env =
     CI
 set_env =
@@ -69,6 +68,8 @@ set_env =
     jwst,romancal: CRDS_CLIENT_RETRY_COUNT=3
     jwst,romancal: CRDS_CLIENT_RETRY_DELAY_SECONDS=20
 commands_pre =
+    oldestdeps: minimum_dependencies stcal --filename requirements-min.txt
+    oldestdeps: pip install --ignore-installed -r requirements-min.txt
     pip freeze
 commands =
     pytest \

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ set_env =
     jwst,romancal: CRDS_CLIENT_RETRY_DELAY_SECONDS=20
 commands_pre =
     oldestdeps: minimum_dependencies stcal --filename requirements-min.txt
-    oldestdeps: pip install --ignore-installed -r requirements-min.txt
+    oldestdeps: pip install -r requirements-min.txt
     pip freeze
 commands =
     pytest \


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR abstracts CI workflows to the OpenAstronomy workflows; this should reduce maintenance for updating and maintaining actions. Additionally, these changes move the majority of MacOS jobs to the weekly scheduled workflow. This should alleviate the issue where the limited MacOS runners for the organization are not available for CI jobs.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/16024299/225095981-493a49bb-b48c-44bd-a203-112b2baad837.png">


**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
