### PR TITLE
JP-3132: Errors During Multiprocessing When More Processors are Requested than Rows in the Data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ Bug Fixes
 
 -
 
+ramp_fitting
+~~~~~~~~~~~~
+
+- During multiprocessing, if the number of processors requested are greater
+  than the number of rows in the image, then ramp fitting errors out.  To
+  prevent this error, the during multiprocessing, the number of processors
+  actually used will be no greater than the number of rows in the image. [#154]
+
 Other
 ~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,8 @@ ramp_fitting
 
 - During multiprocessing, if the number of processors requested are greater
   than the number of rows in the image, then ramp fitting errors out.  To
-  prevent this error, the during multiprocessing, the number of processors
-  actually used will be no greater than the number of rows in the image. [#154]
+  prevent this error, during multiprocessing, the number of processors actually
+  used will be no greater than the number of rows in the image. [#154]
 
 Other
 ~~~~~

--- a/docs/stcal/ramp_fitting/description.rst
+++ b/docs/stcal/ramp_fitting/description.rst
@@ -33,7 +33,11 @@ default the step runs on a single processor. At the other extreme if max_cores i
 set to 'all', it will use all available cores (real and virtual). Testing has shown
 a reduction in the elapsed time for the step proportional to the number of real
 cores used. Using the virtual cores also reduces the elasped time but at a slightly
-lower rate than the real cores.
+lower rate than the real cores.  Since the data is sliced based on the number
+of rows, if the number of cores requested for multiprocessing is greater than
+the number of rows, the number of cores actually used will be no more than the
+number of rows.  This prevents any additional cores from operating on empty
+datasets, which would cause errors during ramp fitting.
 
 Special Cases
 +++++++++++++

--- a/src/stcal/ramp_fitting/gls_fit.py
+++ b/src/stcal/ramp_fitting/gls_fit.py
@@ -100,7 +100,8 @@ def gls_ramp_fit(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, max_cores
     gls_opt_info: tuple
         Tuple of optional product ndarrays computed for GLS ramp fitting.
     """
-    number_slices = utils.compute_slices(max_cores)
+    nrows = ramp_data.data.shape[2]
+    number_slices = utils.compute_slices(max_cores, nrows)
 
     log.info(f"Number of data slices: {number_slices}")
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -72,7 +72,8 @@ def ols_ramp_fit_multi(
     """
 
     # Determine number of slices to use for multi-processor computations
-    number_slices = utils.compute_slices(max_cores)
+    nrows = ramp_data.data.shape[2]
+    number_slices = utils.compute_slices(max_cores, nrows)
 
     # For MIRI datasets having >1 group, if all pixels in the final group are
     #   flagged as DO_NOT_USE, resize the input model arrays to exclude the

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1278,7 +1278,7 @@ def log_stats(c_rates):
               % (c_rates.min(), c_rates.mean(), c_rates.max(), c_rates.std()))
 
 
-def compute_slices(max_cores):
+def compute_slices(max_cores, nrows):
     """
     Computes the number of slices to be created for multiprocessing.
 
@@ -1308,6 +1308,8 @@ def compute_slices(max_cores):
             number_slices = num_cores
         else:
             number_slices = 1
+        if number_slices > nrows:
+            number_slices = nrows
     return number_slices
 
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -1308,8 +1308,14 @@ def compute_slices(max_cores, nrows):
             number_slices = num_cores
         else:
             number_slices = 1
+
+        # Make sure the number of slices created isn't more than the available
+        # number of rows.  If so, this would cause empty datasets to be run
+        # through ramp fitting with dimensions (nints, ngroups, 0, ncols),
+        # which would cause a crash.
         if number_slices > nrows:
             number_slices = nrows
+
     return number_slices
 
 

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1073,9 +1073,9 @@ def test_multi_more_cores_than_rows():
                 ramp.data[integ, :, row, col] = bramp
                 bramp = bramp * factor
 
-    algo, save_opt, ncores = "OLS", False, "all"
+    bufsize, algo, save_opt, ncores = 512, "OLS", False, "all"
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
-        ramp, 512, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags)
+        ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags)
     # This part of the test is simply to make sure ramp fitting
     # doesn't crash.  No asserts are necessary here.
 

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1051,6 +1051,18 @@ def test_multi_more_cores_than_rows():
     var = rnval, gval
     tm = frame_time, nframes, groupgap
 
+    from stcal.ramp_fitting.utils import compute_slices
+    requested_slices = 8
+    requested_slices = compute_slices(requested_slices, nrows)
+    assert requested_slices == 1
+
+    """
+    NOTE: The following is useful only on computers with more than
+          one available processor.  Running this test on one
+          processor does NOT test the safety features of multi-
+          processing preventing the number of processors used
+          being no more than the number of processors requested.
+    """
     ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
     bramp = np.array([ 150.4896,  299.7697,  449.0971,  600.6752,  749.6968,
                        900.9771, 1050.1395, 1199.9658, 1349.9163, 1499.8358])
@@ -1064,7 +1076,8 @@ def test_multi_more_cores_than_rows():
     algo, save_opt, ncores = "OLS", False, "all"
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, 512, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags)
-    # The test is simply to make sure ramp fitting doesn't crash
+    # This part of the test is simply to make sure ramp fitting
+    # doesn't crash.  No asserts are necessary here.
 
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3132](https://jira.stsci.edu/browse/JP-3132)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #152 

<!-- describe the changes comprising this PR here -->
This PR addresses errors during processing when invoking multiprocessing requesting more processors than rows.  The data is sliced up by dividing the number of rows by the number of processors requested.  If the number of rows is less than the number of processors requested, this results in processors running on empty data sets with dimensions (nints, ngroups, 0, ncols).

To prevent this from occurring safeguards have been implemented in multiprocessing to prevent the usage of more processors than rows available.  The number of processors actually used will now be no more than the number of rows, regardless of the number of processors requested.


**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
