### PR TITLE
Remove use of `pytest-openfiles`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,13 @@ Changes to API
 
 - 
 
+Other
+-----
+
+- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
+  catching ``ResourceWarning``s. [#159]
+
+
 1.3.5 (2023-03-30)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ test = [
     'pytest >=4.6.0',
     'pytest-cov',
     'pytest-doctestplus',
-    'pytest-openfiles >=0.5.0',
 ]
 
 [project.urls]
@@ -63,7 +62,7 @@ minversion = 4.6
 doctest_plus = true
 doctest_rst = true
 text_file_format = 'rst'
-addopts = '--open-files'
+addopts = ''
 norecursedirs = [
     'benchmarks',
     '.asv',
@@ -71,6 +70,9 @@ norecursedirs = [
     '.tox',
     'build',
     'venv',
+]
+filterwarnings = [
+    "error::ResourceWarning",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
`pytest-openfiles` has been deprecated and is interfering with the use of fixtures in our test code (ones that handle files). This PR switches `ResourceWarnings` into errors which will catch almost all cases of files left open. The only cases it does not catch is if an open file handle is assigned to a global variable as the "warning" will not be emitted until python stops running, which occurs after pytest has completed.

Similar to spacetelescope/romancal#666

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
