### PR TITLE
Adding proper 'meta' tag when checking for dropframe.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@
 Bug Fixes
 ---------
 
--
+ramp_fitting
+~~~~~~~~~~~~
+
+- The ``meta`` tag was missing when checking for ``drop_frame1``.  It has been
+  added to the check. [#161]
+
 
 Changes to API
 --------------

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -59,7 +59,7 @@ def create_ramp_fit_class(model, dqflags=None, suppress_one_group=False):
 
     # Attribute may not be supported by all pipelines.  Default is NoneType.
     if hasattr(model, 'drop_frames1'):
-        drop_frames1 = model.exposure.drop_frames1
+        drop_frames1 = model.meta.exposure.drop_frames1
     else:
         drop_frames1 = None
     ramp_data.set_meta(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/jwst/issues/7554

<!-- describe the changes comprising this PR here -->
This PR addresses the missing `meta` tag from the attributes path checking for `drop_frame1`.  The attribute has been properly added.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
