### PR TITLE
drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
     with:
       envs: |
         - linux: test-oldestdeps-cov-xdist
-          python-version: 3.8
-        - linux: test-xdist
-          python-version: '3.8'
+          python-version: 3.9
         - linux: test-xdist
           python-version: '3.9'
         - linux: test-xdist

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -12,8 +12,6 @@ jobs:
     with:
       envs: |
         - macos: test-xdist
-          python-version: 3.8
-        - macos: test-xdist
           python-version: 3.9
         - macos: test-xdist
           python-version: 3.10

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,9 +16,13 @@ formats:
   - htmlzip
   - pdf
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,10 +19,14 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: mambaforge-4.10
+
+conda:
+  environment: docs/rtd_environment.yaml
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
+  system_packages: false
   install:
     - method: pip
       path: .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Bug Fixes
 Changes to API
 --------------
 
-- 
+- drop support for Python 3.8 [#162]
 
 Other
 -----

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+ - conda-forge
+ - defaults
+dependencies:
+ - python=3.11
+ - pip
+ - graphviz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'stcal'
 description = 'STScI tools and algorithms used in calibration pipelines'
 readme = 'README.md'
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 license = { file = 'LICENSE' }
 authors = [{ name = 'STScI', email = 'help@stsci.edu' }]
 classifiers = [


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Numpy is imminently dropping support for Python 3.8

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
