### PR TITLE
JP-3221: Fixing Segment Length Computation Needed for Optimal Weighting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,13 @@
 Bug Fixes
 ---------
 
--
+ramp_fitting
+~~~~~~~~~~~~
+
+- Correctly compute the number of groups in a segment to properly compute the
+  optimal weights for the OLS ramp fitting algorithm.  Originally, this
+  computation had the potential to include groups not in the segment being
+  computed. [#163]
 
 Changes to API
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,16 +4,6 @@
 Bug Fixes
 ---------
 
-Changes to API
---------------
-
-- drop support for Python 3.8 [#162]
-
-Other
------
-
--
-
 ramp_fitting
 ~~~~~~~~~~~~
 
@@ -21,6 +11,17 @@ ramp_fitting
   optimal weights for the OLS ramp fitting algorithm.  Originally, this
   computation had the potential to include groups not in the segment being
   computed. [#163]
+
+Changes to API
+--------------
+
+- Drop support for Python 3.8 [#162]
+
+Other
+-----
+
+-
+
 
 1.3.6 (2023-04-19)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,6 @@
 Bug Fixes
 ---------
 
-ramp_fitting
-~~~~~~~~~~~~
-
-- Correctly compute the number of groups in a segment to properly compute the
-  optimal weights for the OLS ramp fitting algorithm.  Originally, this
-  computation had the potential to include groups not in the segment being
-  computed. [#163]
-
 Changes to API
 --------------
 
@@ -21,6 +13,14 @@ Other
 -----
 
 -
+
+ramp_fitting
+~~~~~~~~~~~~
+
+- Correctly compute the number of groups in a segment to properly compute the
+  optimal weights for the OLS ramp fitting algorithm.  Originally, this
+  computation had the potential to include groups not in the segment being
+  computed. [#163]
 
 1.3.6 (2023-04-19)
 ==================

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -3615,7 +3615,7 @@ def calc_opt_sums(ramp_data, rn_sect, gain_sect, data_masked, mask_2d, xvalues, 
 
     # Make array of number of good groups, and exponents for each pixel
     power_wt_r = calc_power(snr)  # Get the interpolated power for this SNR
-    num_nz = (c_mask_2d == True).sum(0)  # number of groups in segment
+    num_nz = c_mask_2d.sum(0)  # number of groups in segment
     nrd_prime = (num_nz - 1) / 2.
     num_nz = 0
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -920,6 +920,7 @@ def ramp_fit_slopes(ramp_data, gain_2d, readnoise_2d, save_opt, weighting):
     # Loop over data integrations:
     for num_int in range(0, n_int):
         # Loop over data sections
+        ramp_data.current_integ = num_int
         for rlo in range(0, cubeshape[1], nrows):
             rhi = rlo + nrows
 
@@ -2841,7 +2842,7 @@ def fit_lines(data, mask_2d, rn_sect, gain_sect, ngroups, weighting, gdq_sect_r,
     if weighting.lower() == 'optimal':  # fit using optimal weighting
         # get sums from optimal weighting
         sumx, sumxx, sumxy, sumy, nreads_wtd, xvalues = calc_opt_sums(
-            rn_sect, gain_sect, data_masked, c_mask_2d, xvalues, good_pix)
+            ramp_data, rn_sect, gain_sect, data_masked, c_mask_2d, xvalues, good_pix)
 
         slope, intercept, sig_slope, sig_intercept = \
             calc_opt_fit(nreads_wtd, sumxx, sumx, sumxy, sumy)
@@ -3500,7 +3501,7 @@ def calc_unwtd_sums(data_masked, xvalues):
     return sumx, sumxx, sumxy, sumy
 
 
-def calc_opt_sums(rn_sect, gain_sect, data_masked, mask_2d, xvalues, good_pix):
+def calc_opt_sums(ramp_data, rn_sect, gain_sect, data_masked, mask_2d, xvalues, good_pix):
     """
     Calculate the sums needed to determine the slope and intercept (and sigma of
     each) using the optimal weights.  For each good pixel's segment, from the
@@ -3571,6 +3572,7 @@ def calc_opt_sums(rn_sect, gain_sect, data_masked, mask_2d, xvalues, good_pix):
 
     # get SCI value of initial good group for semiramp
     data_zero = data_masked[fnz, range(data_masked.shape[1])]
+    fnz = 0
 
     # get SCI value of final good group for semiramp
     data_final = data_masked[(ind_lastnz), range(data_masked.shape[1])]
@@ -3581,6 +3583,7 @@ def calc_opt_sums(rn_sect, gain_sect, data_masked, mask_2d, xvalues, good_pix):
     # Use the readnoise and gain for good pixels only
     rn_sect_rav = rn_sect.flatten()[good_pix]
     rn_2_r = rn_sect_rav * rn_sect_rav
+    rn_sect = 0
 
     gain_sect_r = gain_sect.flatten()[good_pix]
 
@@ -3610,23 +3613,17 @@ def calc_opt_sums(rn_sect, gain_sect, data_masked, mask_2d, xvalues, good_pix):
     data_diff = 0
     sigma_ir = 0
 
-    power_wt_r = calc_power(snr)  # Get the interpolated power for this SNR
     # Make array of number of good groups, and exponents for each pixel
-    num_nz = (data_masked != 0.).sum(0)  # number of nonzero groups per pixel
-    nrd_data_a = num_nz.copy()
+    power_wt_r = calc_power(snr)  # Get the interpolated power for this SNR
+    num_nz = (c_mask_2d == True).sum(0)  # number of groups in segment
+    nrd_prime = (num_nz - 1) / 2.
     num_nz = 0
-
-    nrd_prime = (nrd_data_a - 1) / 2.
-    nrd_data_a = 0
 
     # Calculate inverse read noise^2 for use in weights
     # Suppress, then re-enable, harmless arithmetic warning
     warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
     invrdns2_r = 1. / rn_2_r
     warnings.resetwarnings()
-
-    rn_sect = 0
-    fnz = 0
 
     # Set optimal weights for each group of each pixel;
     #    for all pixels at once, loop over the groups

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1156,7 +1156,7 @@ def test_new_saturation():
     # Check slopes information
     sdata, sdq, svp, svr, serr = slopes
 
-    check = np.array([[2.797567 , 2.8022935, np.nan]])
+    check = np.array([[2.795187 , 2.795632, np.nan]])
     np.testing.assert_allclose(sdata, check, tol, tol)
 
     check = np.array([[JUMP, JUMP, DNU | SAT]])
@@ -1174,8 +1174,8 @@ def test_new_saturation():
     # Check slopes information
     cdata, cdq, cvp, cvr, cerr = cube
 
-    check = np.array([[[2.7949152, 2.8022935, np.nan]],
-                      [[2.8020892, np.nan, np.nan]]])
+    check = np.array([[[2.7949152, 2.7956316, np.nan]],
+                      [[2.7956493, np.nan, np.nan]]])
     np.testing.assert_allclose(cdata, check, tol, tol)
 
     check = np.array([[[GOOD, JUMP, DNU | SAT]],


### PR DESCRIPTION
Correcting the way the number of groups in a segment gets calculated for the optimal weighting during the weighted OLS fitting for each segment.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3221](https://jira.stsci.edu/browse/JP-3221)

<!-- describe the changes comprising this PR here -->
This PR addresses the computation of segment lengths for the purposes of optimal weighting.  Originally, this was done by counting the non-zero groups in an integration ramp of the masked data.  The masked data was created by multiplying a boolean array where contiguous `True` values defined the current segment being computed.  This multiplication had the side effect that `np.nan * False = np.nan`, so NaN groups were incorrectly being included in the computation of the number of groups in a segment.

Specifically, a test ramp with the group DQ flags as follows:

GDQ: [0, 0, 0, 4, 0, 0, 0, 0, 2, 2] (where 4 is JUMP_DET and 2 is SATURATED)

resulted in two segments, [0, 2] and [3, 7].  Because groups flagged as SATURATED have SCI data set to NaN, the last two groups are erroneously included in the computation of the length of each group.  Instead of computing two segments of length 3 and 5, the segment lengths were computed as 5 and 7.

The computation of the segment length is now changed to consider only the mask, which, as mentioned, is a boolean array with contiguous `True` values denoting the groups of a segment.

This PR will affect regression tests, since there are pixels with saturated groups in ramps.  JWST regression tests have been run locally using the `-k rate` filter and the tests showing differences in outputted data and the truth table show differences in pixels that have saturated ramps, as expected.


**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
