### PR TITLE
replace `opencv-python` with pre-built CPU-only `opencv-python-headless`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     'astropy >=5.0.4',
     'scipy >=1.6.0',
     'numpy >=1.20',
-    'opencv-python >=4.6.0.66',
+    'opencv-python-headless >=4.6.0.66',
 ]
 dynamic = ['version']
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/stenv/issues/103

<!-- describe the changes comprising this PR here -->
This PR tests replacing `opencv-python` with `opencv-python-headless`, a pre-built CPU-only binary, to resolve the issue raised in https://github.com/spacetelescope/stenv/issues/103

**Checklist**
- [ ] ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- [ ] ~updated relevant tests~
- [ ] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
