### PR TITLE
JP-3111: Fix dark subtraction for MIRI segmented data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@
 Bug Fixes
 ---------
 
-- 
+dark_current
+~~~~~~~~~~~~
+
+- Fixed handling of MIRI segmented data files so that the correct dark
+  integrations get subtracted from the correct science integrations. [#165]
 
 Changes to API
 --------------

--- a/src/stcal/dark_current/dark_class.py
+++ b/src/stcal/dark_current/dark_class.py
@@ -98,6 +98,7 @@ class ScienceData:
 
             self.exp_nframes = science_model.meta.exposure.nframes
             self.exp_groupgap = science_model.meta.exposure.groupgap
+            self.exp_intstart = science_model.meta.exposure.integration_start
 
             self.cal_step = None
         else:
@@ -108,5 +109,6 @@ class ScienceData:
 
             self.exp_nframes = None
             self.exp_groupgap = None
+            self.exp_intstart = None
 
             self.cal_step = None

--- a/src/stcal/dark_current/dark_class.py
+++ b/src/stcal/dark_current/dark_class.py
@@ -98,7 +98,10 @@ class ScienceData:
 
             self.exp_nframes = science_model.meta.exposure.nframes
             self.exp_groupgap = science_model.meta.exposure.groupgap
-            self.exp_intstart = science_model.meta.exposure.integration_start
+            try:  # JWST only
+                self.exp_intstart = science_model.meta.exposure.integration_start
+            except AttributeError:
+                self.exp_intstart = None
 
             self.cal_step = None
         else:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3111](https://jira.stsci.edu/browse/JP-3111)


<!-- describe the changes comprising this PR here -->
This PR updates the dark_sub routine to fix the way darks are subtracted from MIRI segmented data files. The integration-dependent darks should only be subtracted when processing the segment containing the first integrations in the exposure. All other segments just use the last dark integration. So a check has been added to the logic of choosing dark integrations to see if the science segment starts at integration 1.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
