### PR TITLE
[benchmark] use `mamba` in environment construction

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,7 +7,7 @@
     "main"
   ],
   "show_commit_url": "http://github.com/spacetelescope/stcal/commit/",
-  "environment_type": "conda",
+  "environment_type": "mamba",
   "install_command": [
     "pip install ."
   ],


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
the `conda` environment construction in `asv` currently fails on `tangra3` due to the current setup; however, switching the `environment_type` to `mamba` does work.

`mamba` is a rewrite of `conda` that is both significantly faster in the environment resolution step and has parity of commands with `conda`. Since the regular benchmarking on `tangra3` creates an environment, it makes sense to use `mamba` going forward.

`asv` currently supports `environment_type = mamba` in its main branch code, and AFAIK this will be included in the next release. For now, the `tangra3` benchmarks use `pip install git+https://github.com/airspeed-velocity/asv.git`

**Checklist**
- [ ] ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- [ ] ~updated relevant tests~
- [ ] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
