### PR TITLE
HLA-1096: Added Reproject function

### DIFF
--- a/src/stcal/alignment/reproject.py
+++ b/src/stcal/alignment/reproject.py
@@ -27,7 +27,7 @@ def reproject_coords(wcs1, wcs2):
     def _get_forward_transform_func(wcs1):
         """Get the forward transform function from the input WCS. If the wcs is a
         fitswcs.WCS object all_pix2world requres three inputs, the x (str, ndarrray),
-        y (str, ndarray), and origin (int). The origin should be between 0, and 1, representing an origin pixel at t
+        y (str, ndarray), and origin (int). The origin should be between 0, and 1
         https://docs.astropy.org/en/latest/wcs/index.html#loading-wcs-information-from-a-fits-file
         )
         """

--- a/src/stcal/alignment/reproject.py
+++ b/src/stcal/alignment/reproject.py
@@ -79,7 +79,6 @@ def reproject_coords(wcs1, wcs2):
             x = [x]
         if not isinstance(y, list):
             y = [y]
-        print(x)
         if len(x) != len(y):
             raise ValueError("x and y must be the same length")
         sky = _get_forward_transform_func(wcs1)(x, y, 0)

--- a/src/stcal/alignment/tests/test_reproject.py
+++ b/src/stcal/alignment/tests/test_reproject.py
@@ -1,14 +1,59 @@
+import pytest
 import numpy as np
 from astropy.io import fits
+from astropy.wcs import WCS
 from stcal.alignment import reproject
 
 
+def get_fake_wcs():
+    fake_wcs1 = WCS(
+        fits.Header(
+            {
+                "NAXIS": 2,
+                "NAXIS1": 1,
+                "NAXIS2": 1,
+                "CTYPE1": "RA---TAN",
+                "CTYPE2": "DEC--TAN",
+                "CRVAL1": 0,
+                "CRVAL2": 0,
+                "CRPIX1": 1,
+                "CRPIX2": 1,
+                "CDELT1": -0.1,
+                "CDELT2": 0.1,
+            }
+        )
+    )
+    fake_wcs2 = WCS(
+        fits.Header(
+            {
+                "NAXIS": 2,
+                "NAXIS1": 1,
+                "NAXIS2": 1,
+                "CTYPE1": "RA---TAN",
+                "CTYPE2": "DEC--TAN",
+                "CRVAL1": 0,
+                "CRVAL2": 0,
+                "CRPIX1": 1,
+                "CRPIX2": 1,
+                "CDELT1": -0.05,
+                "CDELT2": 0.05,
+            }
+        )
+    )
+    return fake_wcs1, fake_wcs2
 
-def test__reproject():
-    x_inp, y_inp = 1000, 2000
-    # Create a test image with a single pixel
-    fake_wcs1 = fits.Header({'NAXIS': 2, 'NAXIS1': 1, 'NAXIS2': 1, 'CTYPE1': 'RA---TAN', 'CTYPE2': 'DEC--TAN', 'CRVAL1': 0, 'CRVAL2': 0, 'CRPIX1': 1, 'CRPIX2': 1, 'CDELT1': -0.1, 'CDELT2': 0.1})
-    fake_wcs2 = fits.Header({'NAXIS': 2, 'NAXIS1': 1, 'NAXIS2': 1, 'CTYPE1': 'RA---TAN', 'CTYPE2': 'DEC--TAN', 'CRVAL1': 0, 'CRVAL2': 0, 'CRPIX1': 1, 'CRPIX2': 1, 'CDELT1': -0.05, 'CDELT2': 0.05})
 
-    # Call the function
-    reproject.reproject_coords(fake_wcs1, fake_wcs2)
+@pytest.mark.parametrize(
+    "x_inp, y_inp, x_expected, y_expected",
+    [
+        (1000, 2000, 2000, 4000),  # string input test
+        ([1000], [2000], 2000, 4000),  # array input test
+        pytest.param(1, 2, 3, 4, marks=pytest.mark.xfail),  # expected failure test
+    ],
+)
+def test__reproject(x_inp, y_inp, x_expected, y_expected):
+    wcs1, wcs2 = get_fake_wcs()
+    f = reproject.reproject_coords(wcs1, wcs2)
+    x_out, y_out = f(x_inp, y_inp)
+    assert np.allclose(x_out, x_expected, rtol=1e-05)
+    assert np.allclose(y_out, y_expected, rtol=1e-05)


### PR DESCRIPTION
Resolves [HLA-1096](https://jira.stsci.edu/browse/HLA-1096)

This PR adds the reproject function to the codebase. This code was based on a similar function for JWST. A main difference between the two is that this code assumes that we are using the high-level [WCS API](https://docs.astropy.org/en/latest/wcs/index.html#loading-wcs-information-from-a-fits-file). Several unit tests are also added for the case of inputted strings, array, as well as an expected failure. 

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)