### PR TITLE
Add c99 flag for gcc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,4 @@ extensions = [Extension('stcal.ramp_fitting.ols_cas22',
                         ['src/stcal/ramp_fitting/ols_cas22.pyx'],
                         include_dirs=[np.get_include()])]
 
-setup(ext_modules=cythonize(extensions))
+setup(ext_modules=cythonize(extensions), extra_compile_args=['-std=c99'])


### PR DESCRIPTION
The Jenkins build for JWST is now getting the error:
```
error: ‘for’ loop initial declarations are only allowed in C99 mode
```
when building `stcal`. It looks like someone turned of that flag for gcc there. This should add the flag in.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
