### PR TITLE
Use extension helpers instead of manual setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
     'astropy >=5.0.4',
     'scipy >=1.6.0',
-    'numpy >=1.20',
+    'numpy >=1.22',
     'opencv-python-headless >=4.6.0.66',
 ]
 dynamic = ['version']
@@ -46,7 +46,8 @@ requires = [
     'setuptools_scm[toml] >=3.4',
     'wheel',
     'Cython >=0.29.21',
-    'numpy >=1.18',
+    "numpy>=1.25,<2",
+    'extension-helpers >=1.1.0',
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
-from setuptools import setup, Extension
-from Cython.Build import cythonize
-from Cython.Compiler import Options
-import numpy as np
+from setuptools import setup
+from extension_helpers import get_extensions
 
-Options.docstrings = True
-Options.annotate = False
+ext_modules = get_extensions()
 
-extensions = [Extension('stcal.ramp_fitting.ols_cas22',
-                        ['src/stcal/ramp_fitting/ols_cas22.pyx'],
-                        include_dirs=[np.get_include()])]
+# Specify the minimum version for the Numpy C-API
+for ext in ext_modules:
+    if ext.include_dirs and "numpy" in ext.include_dirs[0]:
+        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_21_API_VERSION"))
+        ext.extra_compile_args.append("-std=c99")
 
-setup(ext_modules=cythonize(extensions), extra_compile_args=['-std=c99'])
+setup(ext_modules=ext_modules)


### PR DESCRIPTION
This PR uses the `extension-helpers` build dependency to simplify the cython code build.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
