### PR TITLE
set `build_platform_wheels` to `true`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,7 +9,7 @@ jobs:
     uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
     with:
       test: false
-      build_platform_wheels: false # Set to true if your package contains a C extension
+      build_platform_wheels: true # Set to true if your package contains a C extension
     secrets:
       user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
       password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #200 

<!-- describe the changes comprising this PR here -->
This PR attempts to build wheels using `cibuildwheel` for specific platforms

If we would like to use the [OpenAstronomy action](https://github-actions-workflows.openastronomy.org/en/stable/publish.html), we'll need the PyPI token (instead of the username and password)

**Checklist**
- [ ] ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- [ ] ~updated relevant tests~
- [ ] ~updated relevant documentation~
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
