### PR TITLE
Update CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ ramp_fitting
 - Added more allowable selections for the number of cores to use for
   multiprocessing [#183].
 
+- Implement the Casertano, et.al, 2022 uneven ramp fitting [#175]
+
 saturation
 ~~~~~~~~~~
 
@@ -26,11 +28,6 @@ saturation
 
 1.4.2 (2023-07-11)
 ==================
-
-ramp_fitting
-~~~~~~~~~~~~
-
-- Implement the Casertano, et.al, 2022 uneven ramp fitting [#175]
 
 Bug Fixes
 ---------


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses a badly edited changelog for the uneven ramp fitting. This is NOT in the 1.4.2 release and should go into the unreleased section.


**Checklist**
- ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- ~updated relevant tests~
- ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
