### PR TITLE
JP-3368: Changing ramp_fit Median Rate and Variance Calculations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ ramp_fitting
 - Added more allowable selections for the number of cores to use for
   multiprocessing [#183].
 
+- Updating variance computation for invalid integrations, as well as
+  updating the median rate computation by excluding groups marked as
+  DO_NOT_USE. [#208]
+
 saturation
 ~~~~~~~~~~
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1298,6 +1298,11 @@ def ramp_fit_overall(
     invalid_data = ramp_data.flags_saturated | ramp_data.flags_do_not_use
     wh_invalid = np.where(np.bitwise_and(dq_int, invalid_data))
     s_inv_var_both3[wh_invalid] = 0.
+
+    # XXX
+    # var_p3[wh_invalid] = 0.
+    # var_r3[wh_invalid] = 0.
+
     s_inv_var_both2 = s_inv_var_both3.sum(axis=0)
 
     # Compute the 'dataset-averaged' slope

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1298,12 +1298,14 @@ def ramp_fit_overall(
     invalid_data = ramp_data.flags_saturated | ramp_data.flags_do_not_use
     wh_invalid = np.where(np.bitwise_and(dq_int, invalid_data))
     s_inv_var_both3[wh_invalid] = 0.
-
-    # XXX
-    # var_p3[wh_invalid] = 0.
-    # var_r3[wh_invalid] = 0.
-
     s_inv_var_both2 = s_inv_var_both3.sum(axis=0)
+
+    var_p3[wh_invalid] = 0.
+    var_r3[wh_invalid] = 0.
+    var_both3[wh_invalid] = 0.
+    s_inv_var_p3[wh_invalid] = 0.
+    s_inv_var_r3[wh_invalid] = 0.
+    s_inv_var_both3[wh_invalid] = 0.
 
     # Compute the 'dataset-averaged' slope
     # Suppress, then re-enable harmless arithmetic warnings
@@ -1440,8 +1442,10 @@ def ramp_fit_overall(
     log.debug('The execution time in seconds: %f', tstop - tstart)
 
     # Compute the 2D variances due to Poisson and read noise
-    var_p2 = 1 / (s_inv_var_p3.sum(axis=0))
-    var_r2 = 1 / (s_inv_var_r3.sum(axis=0))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
+        var_p2 = 1 / (s_inv_var_p3.sum(axis=0))
+        var_r2 = 1 / (s_inv_var_r3.sum(axis=0))
 
     # Huge variances correspond to non-existing segments, so are reset to 0
     #  to nullify their contribution.

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -5,6 +5,13 @@ import logging
 import numpy as np
 import warnings
 
+################## DEBUG ################## 
+#                  HELP!!
+import sys
+sys.path.insert(1, "/Users/kmacdonald/code/common")
+from general_funcs import *
+################## DEBUG ################## 
+
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -1489,7 +1496,9 @@ def compute_median_rates(ramp_data):
         gdq_sect = ramp_data.groupdq[integ, :, :, :]
 
         # Reset all saturated groups in the input data array to NaN
-        data_sect[np.bitwise_and(gdq_sect, ramp_data.flags_saturated).astype(bool)] = np.NaN
+        # data_sect[np.bitwise_and(gdq_sect, ramp_data.flags_saturated).astype(bool)] = np.NaN
+        invalid_flags = ramp_data.flags_saturated | ramp_data.flags_do_not_use
+        data_sect[np.bitwise_and(gdq_sect, invalid_flags).astype(bool)] = np.NaN
 
         data_sect = data_sect / group_time
 
@@ -1557,6 +1566,8 @@ def compute_median_rates(ramp_data):
     median_rates = median_diffs_2d / nints
     del median_diffs_2d
     del data_sect
+
+    dbg_print(f"median_rates = \n{median_rates}")
 
     return median_rates
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -5,14 +5,6 @@ import logging
 import numpy as np
 import warnings
 
-################## DEBUG ################## 
-#                  HELP!!
-import sys
-sys.path.insert(1, "/Users/kmacdonald/code/common")
-from general_funcs import *
-################## DEBUG ################## 
-
-
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -1566,8 +1558,6 @@ def compute_median_rates(ramp_data):
     median_rates = median_diffs_2d / nints
     del median_diffs_2d
     del data_sect
-
-    dbg_print(f"median_rates = \n{median_rates}")
 
     return median_rates
 

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -3,7 +3,17 @@ from stcal.ramp_fitting.ramp_fit import ramp_fit_data
 from stcal.ramp_fitting.ramp_fit_class import RampData
 from stcal.ramp_fitting.utils import compute_num_slices
 
-DELIM = "-" * 70
+################## DEBUG ################## 
+#                  HELP!!
+import sys
+sys.path.insert(1, "/Users/kmacdonald/code/common")
+from general_funcs import dbg_print, \
+                          print_ramp_dq, \
+                          print_ramp_data, \
+                          dbg_float_arr_str
+################## DEBUG ################## 
+
+DELIM = "=" * 70
 
 # single group intergrations fail in the GLS fitting
 # so, keep the two method test separate and mark GLS test as
@@ -1251,7 +1261,11 @@ def test_invalid_integrations():
 
     # Check slopes information
     sdata, sdq, svp, svr, serr = slopes
-
+    print(DELIM)
+    dbg_print(f"{sdq = }")
+    dbg_print(f"{svp = }")
+    dbg_print(f"{svr = }")
+    print(DELIM)
 
     check = np.array([[5434.022]])
     np.testing.assert_allclose(sdata, check, tol, tol)
@@ -1270,6 +1284,11 @@ def test_invalid_integrations():
 
     # Check slopes information
     cdata, cdq, cvp, cvr, cerr = cube
+    print(DELIM)
+    dbg_print(f"{cdq[:, 0, 0] = }")
+    dbg_print(f"cvp = {dbg_float_arr_str(cvp[:, 0, 0])}")
+    dbg_print(f"cvr = {dbg_float_arr_str(cvr[:, 0, 0])}")
+    print(DELIM)
 
     check = np.array([5291.4556, np.nan, np.nan, 5576.588,
                       np.nan, np.nan, np.nan, np.nan], dtype=np.float32)
@@ -1281,12 +1300,13 @@ def test_invalid_integrations():
 
     check = np.array([369.51498, 369.51498, 369.51498, 369.51498,
                       369.51498, 369.51498, 369.51498, 369.51498], dtype=np.float32)
-    print_real_check(cvp[:, 0, 0], check)
+    # print_real_check(cvp[:, 0, 0], check, "cvp")
+    c_check = np.array([369.51913, 0., 0., 369.51913, 0., 0., 0., 0.], dtype=np.float32)
     # np.testing.assert_allclose(cvp[:, 0, 0], check, tol, tol)
 
     check = np.array([4.827828, 4.827828, 4.827828, 4.827828,
                       4.827828, 4.827828, 4.827828, 4.827828], dtype=np.float32)
-    np.testing.assert_allclose(cvr[:, 0, 0], check, tol, tol)
+    # np.testing.assert_allclose(cvr[:, 0, 0], check, tol, tol)
 
     check = np.array([19.348047, 19.348047, 19.348047, 19.348047,
                       19.348047, 19.348047, 19.348047, 19.348047], dtype=np.float32)
@@ -1422,13 +1442,16 @@ def setup_inputs(dims, var, tm):
 # The functions below are only used for DEBUGGING tests and developing tests. #
 ###############################################################################
 
-def print_real_check(real, check):
+def print_real_check(real, check, label=None):
     import inspect
     cf = inspect.currentframe()
     line_number = cf.f_back.f_lineno
     print("=" * 80)
     print(f"----> Line = {line_number} <----")
-    base_print("real", real)
+    if label:
+        base_print(label, real)
+    else:
+        base_print("real", real)
     print("=" * 80)
     base_print("check", check)
     print("=" * 80)

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1260,13 +1260,13 @@ def test_invalid_integrations():
     np.testing.assert_allclose(sdq, check, tol, tol)
 
     check = np.array([[46.189373]])
-    np.testing.assert_allclose(svp, check, tol, tol)
+    # np.testing.assert_allclose(svp, check, tol, tol)
 
     check = np.array([[0.6034785]])
     np.testing.assert_allclose(svr, check, tol, tol)
 
     check = np.array([[6.84053]])
-    np.testing.assert_allclose(serr, check, tol, tol)
+    # np.testing.assert_allclose(serr, check, tol, tol)
 
     # Check slopes information
     cdata, cdq, cvp, cvr, cerr = cube
@@ -1281,7 +1281,8 @@ def test_invalid_integrations():
 
     check = np.array([369.51498, 369.51498, 369.51498, 369.51498,
                       369.51498, 369.51498, 369.51498, 369.51498], dtype=np.float32)
-    np.testing.assert_allclose(cvp[:, 0, 0], check, tol, tol)
+    print_real_check(cvp[:, 0, 0], check)
+    # np.testing.assert_allclose(cvp[:, 0, 0], check, tol, tol)
 
     check = np.array([4.827828, 4.827828, 4.827828, 4.827828,
                       4.827828, 4.827828, 4.827828, 4.827828], dtype=np.float32)
@@ -1289,7 +1290,7 @@ def test_invalid_integrations():
 
     check = np.array([19.348047, 19.348047, 19.348047, 19.348047,
                       19.348047, 19.348047, 19.348047, 19.348047], dtype=np.float32)
-    np.testing.assert_allclose(cerr[:, 0, 0], check, tol, tol)
+    # np.testing.assert_allclose(cerr[:, 0, 0], check, tol, tol)
 
 
 def test_one_group():

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -3,15 +3,6 @@ from stcal.ramp_fitting.ramp_fit import ramp_fit_data
 from stcal.ramp_fitting.ramp_fit_class import RampData
 from stcal.ramp_fitting.utils import compute_num_slices
 
-################## DEBUG ################## 
-#                  HELP!!
-import sys
-sys.path.insert(1, "/Users/kmacdonald/code/common")
-from general_funcs import dbg_print, \
-                          print_ramp_dq, \
-                          print_ramp_data, \
-                          dbg_float_arr_str
-################## DEBUG ################## 
 
 DELIM = "=" * 70
 
@@ -464,7 +455,6 @@ def test_2_group_cases():
     np.testing.assert_allclose(dq, check, tol)
 
     check = np.array([[38.945766, 0., 0., 0., 0., 0., 0.]])
-    print_real_check(var_poisson, check, "var_poisson")
     np.testing.assert_allclose(var_poisson, check, tol)
 
     check = np.array([[0.420046, 0., 0., 0., 0.420046, 0.420046, 0.420046]])

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -455,18 +455,23 @@ def test_2_group_cases():
 
     # Check the outputs
     data, dq, var_poisson, var_rnoise, err = slopes
-    chk_dt = np.array([[551.0735, np.nan, np.nan, np.nan, -293.9943, -845.0678, -845.0677]])
-    chk_dq = np.array([[GOOD, DNU | SAT, DNU | SAT, DNU, GOOD, GOOD, GOOD]])
-    chk_vp = np.array([[38.945766, 0., 0., 0., 38.945766, 38.945766, 0.]])
-    chk_vr = np.array([[0.420046, 0.420046, 0.420046, 0., 0.420046, 0.420046, 0.420046]])
-    chk_er = np.array([[6.274218, 0.64811, 0.64811, 0., 6.274218, 6.274218, 0.64811]])
 
     tol = 1.e-6
-    np.testing.assert_allclose(data, chk_dt, tol)
-    np.testing.assert_allclose(dq, chk_dq, tol)
-    np.testing.assert_allclose(var_poisson, chk_vp, tol)
-    np.testing.assert_allclose(var_rnoise, chk_vr, tol)
-    np.testing.assert_allclose(err, chk_er, tol)
+    check = np.array([[551.0735, np.nan, np.nan, np.nan, -293.9943, -845.0678, -845.0677]])
+    np.testing.assert_allclose(data, check, tol)
+
+    check = np.array([[GOOD, DNU | SAT, DNU | SAT, DNU, GOOD, GOOD, GOOD]])
+    np.testing.assert_allclose(dq, check, tol)
+
+    check = np.array([[38.945766, 0., 0., 0., 0., 0., 0.]])
+    print_real_check(var_poisson, check, "var_poisson")
+    np.testing.assert_allclose(var_poisson, check, tol)
+
+    check = np.array([[0.420046, 0., 0., 0., 0.420046, 0.420046, 0.420046]])
+    np.testing.assert_allclose(var_rnoise, check, tol)
+
+    check = np.array([[6.274218 , 0., 0., 0., 0.6481096, 0.6481096, 0.6481096]])
+    np.testing.assert_allclose(err, check, tol)
 
 
 def run_one_group_ramp_suppression(nints, suppress):
@@ -635,13 +640,13 @@ def test_one_group_ramp_suppressed_two_integrations():
     check = np.array([[GOOD, GOOD, GOOD]])
     np.testing.assert_allclose(sdq, check, tol)
 
-    check = np.array([[0.125, 0.25, 0.125]])
+    check = np.array([[0.125, 0.125, 0.125]])
     np.testing.assert_allclose(svp, check, tol)
 
     check = np.array([[4.999998 , 4.999998 , 2.4999995]])
     np.testing.assert_allclose(svr, check, tol)
 
-    check = np.array([[2.263846 , 2.2912874, 1.620185]])
+    check = np.array([[2.263846 , 2.263846 , 1.620185]])
     np.testing.assert_allclose(serr, check, tol)
 
     # Check slopes information
@@ -656,7 +661,7 @@ def test_one_group_ramp_suppressed_two_integrations():
     np.testing.assert_allclose(cdq, check, tol)
 
     check = np.array([[[0.,    0.,    0.25]],
-                      [[0.125, 0.25, 0.25]]])
+                      [[0.125, 0.125, 0.25]]])
     np.testing.assert_allclose(cvp, check, tol)
 
     check = np.array([[[0.,             0., 4.999999]],
@@ -664,7 +669,7 @@ def test_one_group_ramp_suppressed_two_integrations():
     np.testing.assert_allclose(cvr, check, tol)
 
     check = np.array([[[0.,             0., 2.291288]],
-                      [[2.2638464, 2.291288, 2.291288]]])
+                      [[2.2638464, 2.2638464, 2.291288]]])
     np.testing.assert_allclose(cerr, check, tol)
 
 
@@ -1012,13 +1017,13 @@ def test_dq_multi_int_dnu():
     check = np.array([[0]])
     np.testing.assert_allclose(sdq, check, tol, tol)
 
-    check = np.array([[0.00173518]])
+    check = np.array([[0.00086759]])
     np.testing.assert_allclose(svp, check, tol, tol)
 
     check = np.array([[0.0004338]])
     np.testing.assert_allclose(svr, check, tol, tol)
 
-    check = np.array([[0.04657228]])
+    check = np.array([[0.03607474]])
     np.testing.assert_allclose(serr, check, tol, tol)
 
     # Check slopes information
@@ -1033,7 +1038,7 @@ def test_dq_multi_int_dnu():
     np.testing.assert_allclose(cdq, check, tol, tol)
 
     check = np.array([[[0.]],
-                      [[0.00173518]]])
+                      [[0.00086759]]])
     np.testing.assert_allclose(cvp, check, tol, tol)
 
     check = np.array([[[0.]],
@@ -1041,7 +1046,7 @@ def test_dq_multi_int_dnu():
     np.testing.assert_allclose(cvr, check, tol, tol)
 
     check = np.array([[[0.]],
-                      [[0.04657228]]])
+                      [[0.03607474]]])
     np.testing.assert_allclose(cerr, check, tol, tol)
 
 
@@ -1261,11 +1266,6 @@ def test_invalid_integrations():
 
     # Check slopes information
     sdata, sdq, svp, svr, serr = slopes
-    print(DELIM)
-    dbg_print(f"{sdq = }")
-    dbg_print(f"{svp = }")
-    dbg_print(f"{svr = }")
-    print(DELIM)
 
     check = np.array([[5434.022]])
     np.testing.assert_allclose(sdata, check, tol, tol)
@@ -1273,22 +1273,17 @@ def test_invalid_integrations():
     check = np.array([[JUMP]])
     np.testing.assert_allclose(sdq, check, tol, tol)
 
-    check = np.array([[46.189373]])
-    # np.testing.assert_allclose(svp, check, tol, tol)
+    check = np.array([[44.503918]])
+    np.testing.assert_allclose(svp, check, tol, tol)
 
-    check = np.array([[0.6034785]])
+    check = np.array([[2.4139147]])
     np.testing.assert_allclose(svr, check, tol, tol)
 
-    check = np.array([[6.84053]])
-    # np.testing.assert_allclose(serr, check, tol, tol)
+    check = np.array([[6.8496594]])
+    np.testing.assert_allclose(serr, check, tol, tol)
 
     # Check slopes information
     cdata, cdq, cvp, cvr, cerr = cube
-    print(DELIM)
-    dbg_print(f"{cdq[:, 0, 0] = }")
-    dbg_print(f"cvp = {dbg_float_arr_str(cvp[:, 0, 0])}")
-    dbg_print(f"cvr = {dbg_float_arr_str(cvr[:, 0, 0])}")
-    print(DELIM)
 
     check = np.array([5291.4556, np.nan, np.nan, 5576.588,
                       np.nan, np.nan, np.nan, np.nan], dtype=np.float32)
@@ -1298,19 +1293,14 @@ def test_invalid_integrations():
                       JUMP | DNU, JUMP | DNU, JUMP | DNU, JUMP | DNU], dtype=np.uint8)
     np.testing.assert_allclose(cdq[:, 0, 0], check, tol, tol)
 
-    check = np.array([369.51498, 369.51498, 369.51498, 369.51498,
-                      369.51498, 369.51498, 369.51498, 369.51498], dtype=np.float32)
-    # print_real_check(cvp[:, 0, 0], check, "cvp")
-    c_check = np.array([369.51913, 0., 0., 369.51913, 0., 0., 0., 0.], dtype=np.float32)
-    # np.testing.assert_allclose(cvp[:, 0, 0], check, tol, tol)
+    check = np.array([89.007835, 0., 0., 89.007835, 0., 0., 0., 0.], dtype=np.float32)
+    np.testing.assert_allclose(cvp[:, 0, 0], check, tol, tol)
 
-    check = np.array([4.827828, 4.827828, 4.827828, 4.827828,
-                      4.827828, 4.827828, 4.827828, 4.827828], dtype=np.float32)
-    # np.testing.assert_allclose(cvr[:, 0, 0], check, tol, tol)
+    check = np.array([4.8278294, 0., 0., 4.8278294, 0., 0., 0., 0.], dtype=np.float32)
+    np.testing.assert_allclose(cvr[:, 0, 0], check, tol, tol)
 
-    check = np.array([19.348047, 19.348047, 19.348047, 19.348047,
-                      19.348047, 19.348047, 19.348047, 19.348047], dtype=np.float32)
-    # np.testing.assert_allclose(cerr[:, 0, 0], check, tol, tol)
+    check = np.array([9.686893, 0., 0., 9.686893, 0., 0., 0., 0.0], dtype=np.float32)
+    np.testing.assert_allclose(cerr[:, 0, 0], check, tol, tol)
 
 
 def test_one_group():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3368](https://jira.stsci.edu/browse/JP-3368)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #203 
Closes #192 

<!-- describe the changes comprising this PR here -->
This PR corrects the calculations of median rates and variance calculations.  These errors were found during the C implementation for special cases.

Originally, the median rates excluded SATURATED flagged groups, but should exclude DO_NOT_USE flagged groups as well.  This change affects slope and Poisson variance calculations.

Also, for invalid integrations, non-zero variances were computed, but they should be 0.0.  This had already been properly handled for slope calculations in a previous PR addressing JP-3004.  Unfortunately, improper calculation of rateints and rate variances continued. 

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
