### PR TITLE
remove unsupported `system_packages` RTD config setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,6 @@ conda:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
RTD no longer supports any `system_packages` setting: https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused `system_packages` setting

**Checklist**
- [ ] ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- [ ] ~updated relevant tests~
- [x] updated relevant documentation
- [ ] ~updated relevant milestone(s)~
- [x] added relevant label(s)
