### PR TITLE
download WebbPSF data for downstream tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,44 @@ jobs:
           python-version: '3.11'
         - linux: test-cov-xdist
           coverage: 'codecov'
+  data:
+    name: retrieve data
+    runs-on: ubuntu-latest
+    outputs:
+      data_path: ${{ steps.data.outputs.path }}
+      data_hash: ${{ steps.data_hash.outputs.hash }}
+    steps:
+      # webbpsf:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: data
+        run: |
+          echo "path=/tmp/data" >> $GITHUB_OUTPUT
+          echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
+      - run: |
+          mkdir -p tmp/data/
+          mkdir -p ${{ steps.data.outputs.path }}
+      - run: wget ${{ steps.data.outputs.webbpsf_url }} -O tmp/minimal-webbpsf-data.tar.gz
+      - run: tar -xzvf tmp/minimal-webbpsf-data.tar.gz -C tmp/data/
+      - id: data_hash
+        run: echo "hash=${{ hashFiles( 'tmp/data' ) }}" >> $GITHUB_OUTPUT
+      - run: mv tmp/data/* ${{ steps.data.outputs.path }}
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.data.outputs.path }}
+          key: data-${{ steps.data_hash.outputs.hash }}
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    needs: [ data ]
     with:
       setenv: |
         CRDS_PATH: /tmp/crds_cache
         CRDS_CLIENT_RETRY_COUNT: 3
-        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20 
+        WEBBPSF_PATH: ${{ needs.data.outputs.data_path }}/webbpsf-data
+      cache-path: ${{ needs.data.outputs.data_path }}
+      cache-key: data-${{ needs.data.outputs.data_hash }}
       envs: |
         - linux: test-jwst-cov-xdist
         - linux: test-romancal-cov-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,7 @@ deps =
 use_develop = true
 pass_env =
     CI
+    WEBBPSF_PATH
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses the issue where downstream `romancal` tests don't have WebbPSF data: https://github.com/spacetelescope/stcal/actions/runs/6331167369/job/17195146180?pr=196

**Checklist**
- [ ] ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- [x] updated relevant tests
- [ ] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
