### PR TITLE
JP-3562: Shower flagging enhancement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ jump
 - Fix the code to at least always flag the group with the shower and the requested
   groups after the primary shower. [#237]
 
+- Updated the shower flagging code to mask reference pixels, require a minimum
+  number of groups to trigger the detection, and use all integrations to determine
+  the median value. [#248]
+
 Other
 -----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ Changes to API
 Bug Fixes
 ---------
 
+jump
+~~~~
+
+- Updated the shower flagging code to mask reference pixels, require a minimum
+  number of groups to trigger the detection, and use all integrations to determine
+  the median value. [#248]
+
 Other
 -----
 
@@ -45,10 +52,6 @@ jump
 
 - Fix the code to at least always flag the group with the shower and the requested
   groups after the primary shower. [#237]
-
-- Updated the shower flagging code to mask reference pixels, require a minimum
-  number of groups to trigger the detection, and use all integrations to determine
-  the median value. [#248]
 
 Other
 -----

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -937,9 +937,9 @@ def find_faint_extended(
             nrows = ratio.shape[1]
             ncols = ratio.shape[2]
             extended_emission = np.zeros(shape=(nrows, ncols), dtype=np.uint8)
-            mean2, median2, stddev2 = astropy.stats.sigma_clipped_stats(masked_smoothed_ratio)
-            cutoff = median2 + snr_threshold * stddev2
-            print("intg ", intg, "grp ", grp, "median2 ", median2, "stddev2 ", stddev2)
+#            mean2, median2, stddev2 = astropy.stats.sigma_clipped_stats(masked_smoothed_ratio)
+            cutoff = median_diffs + snr_threshold * sigma
+#            print("intg ", intg, "grp ", grp, "median2 ", median2, "stddev2 ", stddev2)
             exty, extx = np.where(masked_smoothed_ratio > cutoff)
             extended_emission[exty, extx] = 1
             extended_emission_cube[intg, grp, :, :] = extended_emission

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -435,9 +435,13 @@ def detect_jumps(
             k += 1
         # remove redundant flagging of pixels that have jump flagged but were
         # already flagged as do_not_use or saturated.
-        gdq[gdq == np.logical_or(dqflags['DO_NOT_USE'], dqflags['JUMP_DET'])] = \
+   #     ints, grps, rows, cols = np.where(np.logical_or(dqflags['DO_NOT_USE'], dqflags['JUMP_DET']))
+   #     gdq[ints, grps, rows, cols] = dqflags['DO_NOT_USE']
+   #     ints, grps, rows, cols = np.where(np.logical_or(dqflags['SATURATED'], dqflags['JUMP_DET']))
+   #     gdq[ints, grps, rows, cols] = dqflags['SATURATED']
+        gdq[gdq == np.bitwise_or(dqflags['DO_NOT_USE'], dqflags['JUMP_DET'])] = \
             dqflags['DO_NOT_USE']
-        gdq[gdq == np.logical_or(dqflags['SATURATED'], dqflags['JUMP_DET'])] = \
+        gdq[gdq == np.bitwise_or(dqflags['SATURATED'], dqflags['JUMP_DET'])] = \
             dqflags['SATURATED']
         #  This is the flag that controls the flagging of snowballs.
         if expand_large_events:

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -873,7 +873,7 @@ def find_faint_extended(
     masked_ratio_cube = np.zeros_like(data)
     masked_smoothed_ratio_cube = np.zeros_like(data)
     extended_emission_cube = np.zeros_like(data)
-    e_jump_cube = np.zeros_like(data)
+    e_jump_cube = np.zeros_like(shape=(data.shape[0], data.shape[1]-1, data.shape[2], data.shape[3]))
     median_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
     all_ellipses = []
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -540,7 +540,7 @@ def flag_large_events(
 
     Returns
     -------
-    Nothing, gdq array is modified.
+    total Snowballs
 
     """
     log.info("Flagging Snowballs")

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -847,6 +847,7 @@ def find_faint_extended(
     bad_pixels_array = np.bitwise_and(pdq, 1)
     dnuy, dnux = np.where(bad_pixels_array == 1)
     data[:, :, dnuy, dnux] = np.nan
+    gdq[:, :, dnuy, dnux] = np.nan
 
     first_diffs = np.diff(data, axis=1)
     fits.writeto("first_diffs.fits", first_diffs, overwrite=True)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -3,6 +3,7 @@ import multiprocessing
 import time
 import warnings
 import astropy.stats
+from astropy.io import fits
 import cv2 as cv
 import numpy as np
 from astropy import stats
@@ -989,6 +990,7 @@ def find_faint_extended(
                 # add all the showers for this integration to the list
                 all_ellipses.append([intg, grp, ellipses])
                 # Reset the warnings filter to its original state
+    fits.writeto("masked_smoothed_ratio_cube.fits",masked_smoothed_ratio_cube, overwrite=True)
     warnings.resetwarnings()
 
     if all_ellipses:

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -842,14 +842,17 @@ def find_faint_extended(
     Total number of showers detected.
 
     """
+    fits.writeto("ingdq.fits", ingdq, overwrite=True)
+    fits.writeto("inpdg.fits", pdq, overwrite=True)
     gdq = ingdq.copy()
     data = indata.copy()
     read_noise_2 = readnoise_2d**2
     bad_pixels_array = np.bitwise_and(pdq, 1)
+    fits.writeto("badpixelsarray.fits", bad_pixels_array, overwrite=True)
     dnuy, dnux = np.where(bad_pixels_array == 1)
     data[:, :, dnuy, dnux] = np.nan
     gdq = np.bitwise_or(bad_pixels_array[np.newaxis, np.newaxis, :, :], gdq)
-
+    fits.writeto("updategdq.fits". gdq, overwrite=True)
     first_diffs = np.diff(data, axis=1)
     fits.writeto("first_diffs.fits", first_diffs, overwrite=True)
     all_ellipses = []

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -446,6 +446,9 @@ def detect_jumps(
             )
             log.info("Total snowballs = %i", total_snowballs)
             number_extended_events = total_snowballs
+        fits.writeto("incoming_data.fits", data, overwrite=True)
+        fits.writeto("incoming_pdq.fits", pdq, overwrite=True)
+        fits.writeto("incoming_gdq.fits", gdq, overwrite=True)
         if find_showers:
             gdq, num_showers = find_faint_extended(
                 data,

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -433,16 +433,13 @@ def detect_jumps(
             # save the neighbors to be flagged that will be in the next slice
             previous_row_above_gdq = row_above_gdq.copy()
             k += 1
-        # remove redundant flagging of pixels that have jump flagged but were
+        # remove redundant bits in pixels that have jump flagged but were
         # already flagged as do_not_use or saturated.
-   #     ints, grps, rows, cols = np.where(np.logical_or(dqflags['DO_NOT_USE'], dqflags['JUMP_DET']))
-   #     gdq[ints, grps, rows, cols] = dqflags['DO_NOT_USE']
-   #     ints, grps, rows, cols = np.where(np.logical_or(dqflags['SATURATED'], dqflags['JUMP_DET']))
-   #     gdq[ints, grps, rows, cols] = dqflags['SATURATED']
         gdq[gdq == np.bitwise_or(dqflags['DO_NOT_USE'], dqflags['JUMP_DET'])] = \
             dqflags['DO_NOT_USE']
         gdq[gdq == np.bitwise_or(dqflags['SATURATED'], dqflags['JUMP_DET'])] = \
             dqflags['SATURATED']
+
         #  This is the flag that controls the flagging of snowballs.
         if expand_large_events:
             total_snowballs = flag_large_events(

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -854,8 +854,6 @@ def find_faint_extended(
     Total number of showers detected.
 
     """
-#    fits.writeto("ingdq.fits", ingdq, overwrite=True)
-#    fits.writeto("inpdg.fits", pdq, overwrite=True)
     log.info("Flagging Showers")
     gdq = ingdq.copy()
     data = indata.copy()

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -939,6 +939,7 @@ def find_faint_extended(
             extended_emission = np.zeros(shape=(nrows, ncols), dtype=np.uint8)
             mean2, median2, stddev2 = astropy.stats.sigma_clipped_stats(masked_smoothed_ratio)
             cutoff = median2 + snr_threshold * stddev2
+            print("intg ", intg, "grp ", grp, "median2 ", median2, "stddev2 ", stddev2)
             exty, extx = np.where(masked_smoothed_ratio > cutoff)
             extended_emission[exty, extx] = 1
             extended_emission_cube[intg, grp, :, :] = extended_emission

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -996,6 +996,7 @@ def find_faint_extended(
                 all_ellipses.append([intg, grp, ellipses])
                 # Reset the warnings filter to its original state
     print("writing msr cube")
+    fits.writeto("extended_emission_cube.fits",  extended_emission_cube, overwrite=True)
     fits.writeto("sigma_cube.fits", sigma_cube, overwrite=True)
     fits.writeto("ratio_cube.fits", ratio_cube, overwrite=True)
     fits.writeto("median_cube.fits", median_cube, overwrite=True)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -884,13 +884,16 @@ def find_faint_extended(
     nints = data.shape[0]
     if nints > minimum_sigclip_groups:
         mean, median, stddev = stats.sigma_clipped_stats(first_diffs_masked, sigma=5, axis=0)
+    else:
+        median_diffs = np.nanmedian(first_diffs_masked, axis=(0, 1))
+        sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
 #    warnings.filterwarnings("ignore", ".*Input data contains invalid values.*", RuntimeWarning)
     warnings.filterwarnings("ignore")
     for intg in range(nints):
         # calculate sigma for each pixel
         if nints < minimum_sigclip_groups:
-            median_diffs = np.nanmedian(first_diffs_masked[intg], axis=0)
-            sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
+#            median_diffs = np.nanmedian(first_diffs_masked[intg], axis=0)
+#            sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
             # The difference from the median difference for each group
             e_jump = first_diffs_masked[intg] - median_diffs[np.newaxis, :, :]
             e_jump_cube[intg, :, :, :] = e_jump
@@ -902,6 +905,7 @@ def find_faint_extended(
         #  The convolution kernel creation
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]
+        nints = data.shape[0]
         first_good_group = find_first_good_group(gdq[intg, :, :, :], donotuse_flag)
         for grp in range(first_good_group + 1, ngrps):
             if nints >= minimum_sigclip_groups:
@@ -912,7 +916,6 @@ def find_faint_extended(
                 # SNR ratio of each diff.
                 ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
             masked_ratio = ratio[grp - 1].copy()
-            if ndiffs > 
 
             #  mask pixels that are already flagged as jump
             combined_pixel_mask = np.bitwise_or(gdq[intg, grp, :, :], pdq[:, :])

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -938,9 +938,9 @@ def find_faint_extended(
             ncols = ratio.shape[2]
             extended_emission = np.zeros(shape=(nrows, ncols), dtype=np.uint8)
 #            mean2, median2, stddev2 = astropy.stats.sigma_clipped_stats(masked_smoothed_ratio)
-            cutoff = median_diffs + snr_threshold * sigma
+#            cutoff = median_diffs + snr_threshold * sigma
 #            print("intg ", intg, "grp ", grp, "median2 ", median2, "stddev2 ", stddev2)
-            exty, extx = np.where(masked_smoothed_ratio > cutoff)
+            exty, extx = np.where(masked_smoothed_ratio > snr_threshold)
             extended_emission[exty, extx] = 1
             extended_emission_cube[intg, grp, :, :] = extended_emission
             #  find the contours of the extended emission

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -877,6 +877,7 @@ def find_faint_extended(
     e_jump_cube = np.zeros(shape=(data.shape[0], data.shape[1]-1, data.shape[2], data.shape[3]))
     median_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
     sigma_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
+    ratio_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
     all_ellipses = []
 
     first_diffs_masked = np.ma.masked_array(first_diffs, mask=np.isnan(first_diffs))
@@ -897,7 +898,7 @@ def find_faint_extended(
             sigma_cube[intg, :, :] = sigma
             # SNR ratio of each diff.
             ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
-
+            ratio_cube[intg, :, :] = ratio
         #  The convolution kernel creation
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]
@@ -998,6 +999,7 @@ def find_faint_extended(
                 # Reset the warnings filter to its original state
     print("writing msr cube")
     fits.writeto("sigma_cube.fits", sigma_cube, overwrite=True)
+    fits.writeto("ratio_cube.fits", ratio_cube, overwrite=True)
     fits.writeto("median_cube.fits", median_cube, overwrite=True)
     fits.writeto("e_jump_cube.fits", e_jump_cube, overwrite=True)
     fits.writeto("masked_smoothed_ratio_cube.fits",masked_smoothed_ratio_cube, overwrite=True)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -873,7 +873,8 @@ def find_faint_extended(
     masked_ratio_cube = np.zeros_like(data)
     masked_smoothed_ratio_cube = np.zeros_like(data)
     extended_emission_cube = np.zeros_like(data)
-
+    e_jump_cube = np.zeros_like(data)
+    median_cube = np.zeros_like(shape=(data.shape[0], data.shape[2], data.shape[3]))
     all_ellipses = []
 
     first_diffs_masked = np.ma.masked_array(first_diffs, mask=np.isnan(first_diffs))
@@ -889,6 +890,8 @@ def find_faint_extended(
             sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
             # The difference from the median difference for each group
             e_jump = first_diffs_masked[intg] - median_diffs[np.newaxis, :, :]
+            e_jump_cube[intg, :, :, :] = e_jump
+            median_cube[intg, :, :] = median_diffs
             # SNR ratio of each diff.
             ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
 
@@ -991,6 +994,8 @@ def find_faint_extended(
                 all_ellipses.append([intg, grp, ellipses])
                 # Reset the warnings filter to its original state
     print("writing msr cube")
+    fits.writeto("median_cube.fits", median_cube, overwrite=True)
+    fits.writeto("e_jump_cube.fits", e_jump_cube, overwrite=True)
     fits.writeto("masked_smoothed_ratio_cube.fits",masked_smoothed_ratio_cube, overwrite=True)
     warnings.resetwarnings()
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -912,6 +912,7 @@ def find_faint_extended(
                 # SNR ratio of each diff.
                 ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
             masked_ratio = ratio[grp - 1].copy()
+            if ndiffs > 
 
             #  mask pixels that are already flagged as jump
             combined_pixel_mask = np.bitwise_or(gdq[intg, grp, :, :], pdq[:, :])

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -891,7 +891,7 @@ def find_faint_extended(
         #  The convolution kernel creation
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]
-        first_good_group = find_first_good_group(gdq[intg, :, :, :])
+        first_good_group = find_first_good_group(gdq[intg, :, :, :], donotuse_flag)
         for grp in range(first_good_group, ngrps):
             if nints > minimum_sigclip_groups:
                 median_diffs = median[grp - 1]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -873,7 +873,7 @@ def find_faint_extended(
     masked_ratio_cube = np.zeros_like(data)
     masked_smoothed_ratio_cube = np.zeros_like(data)
     extended_emission_cube = np.zeros_like(data)
-    e_jump_cube = np.zeros_like(shape=(data.shape[0], data.shape[1]-1, data.shape[2], data.shape[3]))
+    e_jump_cube = np.zeros(shape=(data.shape[0], data.shape[1]-1, data.shape[2], data.shape[3]))
     median_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
     all_ellipses = []
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -346,7 +346,7 @@ def detect_jumps(
                 i,
                 (
                     data[:, :, i * yinc: (i + 1) * yinc, :],
-                    gdq[:, :, i * yinc: (i + 1) * yinc, :],
+                    gdq[:, :, i * yinc: (i + 1) * yinc, :].copy(),
                     readnoise_2d[i * yinc: (i + 1) * yinc, :],
                     rejection_thresh,
                     three_grp_thresh,
@@ -372,7 +372,7 @@ def detect_jumps(
             n_slices - 1,
             (
                 data[:, :, (n_slices - 1) * yinc: n_rows, :],
-                gdq[:, :, (n_slices - 1) * yinc: n_rows, :],
+                gdq[:, :, (n_slices - 1) * yinc: n_rows, :].copy(),
                 readnoise_2d[(n_slices - 1) * yinc: n_rows, :],
                 rejection_thresh,
                 three_grp_thresh,

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -877,7 +877,7 @@ def find_faint_extended(
     e_jump_cube = np.zeros(shape=(data.shape[0], data.shape[1]-1, data.shape[2], data.shape[3]))
     median_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
     sigma_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
-    ratio_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
+    ratio_cube = np.zeros(shape=(data.shape[0], data.shape[1]-1, data.shape[2], data.shape[3]))
     all_ellipses = []
 
     first_diffs_masked = np.ma.masked_array(first_diffs, mask=np.isnan(first_diffs))

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -898,9 +898,9 @@ def find_faint_extended(
             masked_ratio[saty, satx] = np.nan
 
             #  mask pixels that are already flagged as do not use
-            sat_pixels_array = np.bitwise_and(combined_pixel_mask, 1)
-            dnuy, dnux = np.where(sat_pixels_array == 1)
-            masked_ratio[saty, satx] = np.nan
+            dnu_pixels_array = np.bitwise_and(combined_pixel_mask, 1)
+            dnuy, dnux = np.where(dnu_pixels_array == 1)
+            masked_ratio[dnuy, dnux] = np.nan
 #            if grp == 1:
 #               fits.writeto("masked_ratio1.fits", masked_ratio., overwrite=True)
             masked_smoothed_ratio = convolve(masked_ratio, ring_2D_kernel)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -874,7 +874,7 @@ def find_faint_extended(
     masked_smoothed_ratio_cube = np.zeros_like(data)
     extended_emission_cube = np.zeros_like(data)
     e_jump_cube = np.zeros_like(data)
-    median_cube = np.zeros_like(shape=(data.shape[0], data.shape[2], data.shape[3]))
+    median_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
     all_ellipses = []
 
     first_diffs_masked = np.ma.masked_array(first_diffs, mask=np.isnan(first_diffs))

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -914,6 +914,8 @@ def find_faint_extended(
                 median_cube[intg, :, :] = median_diffs
                 sigma_cube[intg, :, :] = sigma
                 ratio_cube[intg, :, :, :] = ratio
+                median_diffs = np.nanmedian(first_diffs_masked, axis=(0, 1))
+                sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
         #  The convolution kernel creation
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -6,7 +6,6 @@ import cv2 as cv
 import numpy as np
 from astropy import stats
 from astropy.convolution import Ring2DKernel, convolve
-
 from . import constants
 from . import twopoint_difference as twopt
 
@@ -217,7 +216,6 @@ def detect_jumps(
     constants.update_dqflags(dqflags)  # populate dq flags
     sat_flag = dqflags["SATURATED"]
     jump_flag = dqflags["JUMP_DET"]
-    refpix_flag = dqflags["REFERENCE_PIXEL"]
     number_extended_events = 0
     # Flag the pixeldq where the gain is <=0 or NaN so they will be ignored
     wh_g = np.where(gain_2d <= 0.0)
@@ -303,13 +301,13 @@ def detect_jumps(
                 readnoise_2d,
                 frames_per_group,
                 minimum_sigclip_groups,
+                dqflags,
                 snr_threshold=extend_snr_threshold,
                 min_shower_area=extend_min_area,
                 inner=extend_inner_radius,
                 outer=extend_outer_radius,
                 sat_flag=sat_flag,
                 jump_flag=jump_flag,
-                refpix_flag=refpix_flag,
                 ellipse_expand=extend_ellipse_expand_ratio,
                 num_grps_masked=grps_masked_after_shower,
                 max_extended_radius=max_extended_radius,
@@ -462,13 +460,13 @@ def detect_jumps(
                 readnoise_2d,
                 frames_per_group,
                 minimum_sigclip_groups,
+                dqflags,
                 snr_threshold=extend_snr_threshold,
                 min_shower_area=extend_min_area,
                 inner=extend_inner_radius,
                 outer=extend_outer_radius,
                 sat_flag=sat_flag,
                 jump_flag=jump_flag,
-                refpix_flag=refpix_flag,
                 ellipse_expand=extend_ellipse_expand_ratio,
                 num_grps_masked=grps_masked_after_shower,
                 max_extended_radius=max_extended_radius,
@@ -801,6 +799,7 @@ def find_faint_extended(
     readnoise_2d,
     nframes,
     minimum_sigclip_groups,
+    dqflags,
     snr_threshold=1.3,
     min_shower_area=40,
     inner=1,
@@ -808,7 +807,6 @@ def find_faint_extended(
     donotuse_flag = 1,
     sat_flag=2,
     jump_flag=4,
-    refpix_flag=2147483648,
     ellipse_expand=1.1,
     num_grps_masked=25,
     max_extended_radius=200,
@@ -855,6 +853,7 @@ def find_faint_extended(
 
     """
     log.info("Flagging Showers")
+    refpix_flag = dqflags["REFERENCE_PIXEL"]
     gdq = ingdq.copy()
     data = indata.copy()
     nints = data.shape[0]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -237,6 +237,7 @@ def detect_jumps(
     data *= gain_2d
     err *= gain_2d
     readnoise_2d *= gain_2d
+    print("median gain", np.median(gain_2d))
     # also apply to the after_jump thresholds
     after_jump_flag_e1 = after_jump_flag_dn1 * gain_2d
     after_jump_flag_e2 = after_jump_flag_dn2 * gain_2d

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -320,7 +320,7 @@ def detect_jumps(
             log.info("Total showers= %i", num_showers)
             number_extended_events = num_showers
     else:
-        yinc = int(n_rows / n_slices)
+        yinc = int(n_rows // n_slices)
         slices = []
         # Slice up data, gdq, readnoise_2d into slices
         # Each element of slices is a tuple of

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -895,13 +895,25 @@ def find_faint_extended(
 #            median_diffs = np.nanmedian(first_diffs_masked[intg], axis=0)
 #            sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
             # The difference from the median difference for each group
-            e_jump = first_diffs_masked[intg] - median_diffs[np.newaxis, :, :]
-            e_jump_cube[intg, :, :, :] = e_jump
-            median_cube[intg, :, :] = median_diffs
-            sigma_cube[intg, :, :] = sigma
-            # SNR ratio of each diff.
-            ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
-            ratio_cube[intg, :, :, :] = ratio
+            if intg > 0:
+                e_jump = first_diffs_masked[intg] - median_diffs[np.newaxis, :, :]
+                e_jump_cube[intg, :, :, :] = e_jump
+                median_cube[intg, :, :] = median_diffs
+                sigma_cube[intg, :, :] = sigma
+                # SNR ratio of each diff.
+                ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
+                ratio_cube[intg, :, :, :] = ratio
+            else:
+                median_diffs = np.nanmedian(first_diffs_masked[intg], axis=0)
+                sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
+                # The difference from the median difference for each group
+                e_jump = first_diffs_masked[intg] - median_diffs[np.newaxis, :, :]
+                # SNR ratio of each diff.
+                ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
+                e_jump_cube[intg, :, :, :] = e_jump
+                median_cube[intg, :, :] = median_diffs
+                sigma_cube[intg, :, :] = sigma
+                ratio_cube[intg, :, :, :] = ratio
         #  The convolution kernel creation
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -1020,8 +1020,8 @@ def find_first_good_group(int_gdq, do_not_use):
     skip_grp = True
     first_good_group = 0
     for grp in range(ngrps):
-        mask = np.logical_and(int_gdq[grp], do_not_use)
-        skip_grp = np.unique(mask)
+        mask = np.bitwise_and(int_gdq[grp], do_not_use)
+        skip_grp = np.all(mask)
         if not skip_grp:
             first_good_group = grp
             break

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -433,6 +433,12 @@ def detect_jumps(
             # save the neighbors to be flagged that will be in the next slice
             previous_row_above_gdq = row_above_gdq.copy()
             k += 1
+        # remove redundant flagging of pixels that have jump flagged but were
+        # already flagged as do_not_use or saturated.
+        gdq[gdq == np.logical_or(dqflags['DO_NOT_USE'], dqflags['JUMP_DET'])] = \
+            dqflags['DO_NOT_USE']
+        gdq[gdq == np.logical_or(dqflags['SATURATED'], dqflags['JUMP_DET'])] = \
+            dqflags['SATURATED']
         #  This is the flag that controls the flagging of snowballs.
         if expand_large_events:
             total_snowballs = flag_large_events(

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -852,7 +852,7 @@ def find_faint_extended(
     dnuy, dnux = np.where(bad_pixels_array == 1)
     data[:, :, dnuy, dnux] = np.nan
     gdq = np.bitwise_or(bad_pixels_array[np.newaxis, np.newaxis, :, :], gdq)
-    fits.writeto("updategdq.fits". gdq, overwrite=True)
+    fits.writeto("updategdq.fits", gdq, overwrite=True)
     first_diffs = np.diff(data, axis=1)
     fits.writeto("first_diffs.fits", first_diffs, overwrite=True)
     all_ellipses = []

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -895,6 +895,11 @@ def find_faint_extended(
             saty, satx = np.where(sat_pixels_array == sat_flag)
             masked_ratio[saty, satx] = np.nan
 
+            #  mask pixels that are already flagged as do not use
+            sat_pixels_array = np.bitwise_and(combined_pixel_mask, 1)
+            dnuy, dnux = np.where(sat_pixels_array == 1)
+            masked_ratio[saty, satx] = np.nan
+
             masked_smoothed_ratio = convolve(masked_ratio, ring_2D_kernel)
             nrows = ratio.shape[1]
             ncols = ratio.shape[2]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -888,7 +888,7 @@ def find_faint_extended(
     warnings.filterwarnings("ignore")
     for intg in range(nints):
         # calculate sigma for each pixel
-        if nints <= minimum_sigclip_groups:
+        if nints < minimum_sigclip_groups:
             median_diffs = np.nanmedian(first_diffs_masked[intg], axis=0)
             sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
             # The difference from the median difference for each group
@@ -898,13 +898,13 @@ def find_faint_extended(
             sigma_cube[intg, :, :] = sigma
             # SNR ratio of each diff.
             ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
-            ratio_cube[intg, :, :] = ratio
+            ratio_cube[intg, :, :, :] = ratio
         #  The convolution kernel creation
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]
         first_good_group = find_first_good_group(gdq[intg, :, :, :], donotuse_flag)
         for grp in range(first_good_group + 1, ngrps):
-            if nints > minimum_sigclip_groups:
+            if nints >= minimum_sigclip_groups:
                 median_diffs = median[grp - 1]
                 sigma = stddev[grp - 1]
                 # The difference from the median difference for each group
@@ -946,8 +946,6 @@ def find_faint_extended(
             contours, hierarchy = cv.findContours(extended_emission, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
             #  get the contours that are above the minimum size
             bigcontours = [con for con in contours if cv.contourArea(con) > min_shower_area]
-            if grp == 5:
-                 a=1
             #  get the minimum enclosing rectangle which is the same as the
             # minimum enclosing ellipse
             ellipses = [cv.minAreaRect(con) for con in bigcontours]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -870,7 +870,7 @@ def find_faint_extended(
         for grp in range(ngrps):
             if np.all(np.bitwise_and(gdq[integ, grp, :, :], donotuse_flag)):
                 num_grps_donotuse += 1
-    total_diffs = nints * (ngrps - num_grps_donotuse - 1)
+    total_diffs = nints * (ngrps - 1) - num_grps_donotuse
     if total_diffs < min_diffs_for_shower:
         log.warning("Not enough differences for shower detections")
         return ingdq, 0

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -990,6 +990,7 @@ def find_faint_extended(
                 # add all the showers for this integration to the list
                 all_ellipses.append([intg, grp, ellipses])
                 # Reset the warnings filter to its original state
+    print("writing msr cube")
     fits.writeto("masked_smoothed_ratio_cube.fits",masked_smoothed_ratio_cube, overwrite=True)
     warnings.resetwarnings()
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -891,7 +891,8 @@ def find_faint_extended(
         #  The convolution kernel creation
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]
-        for grp in range(1, ngrps):
+        first_good_group = find_first_good_group(gdq[intg, :, :, :])
+        for grp in range(first_good_group, ngrps):
             if nints > minimum_sigclip_groups:
                 median_diffs = median[grp - 1]
                 sigma = stddev[grp - 1]
@@ -1014,6 +1015,17 @@ def find_faint_extended(
             )
     return gdq, len(all_ellipses)
 
+def find_first_good_group(int_gdq, do_not_use):
+    ngrps = int_gdq.shape[0]
+    skip_grp = True
+    first_good_group = 0
+    for grp in range(ngrps):
+        mask = np.logical_and(int_gdq[grp], do_not_use)
+        skip_grp = np.unique(mask)
+        if not skip_grp:
+            first_good_group = grp
+            break
+    return first_good_group
 
 def calc_num_slices(n_rows, max_cores, max_available):
     n_slices = 1

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -1013,6 +1013,7 @@ def find_faint_extended(
                 num_grps_masked=num_grps_masked,
                 max_extended_radius=max_extended_radius,
             )
+    fits.writeto("aftergdq.fits", gdq, overwrite=True)
     return gdq, len(all_ellipses)
 
 def find_first_good_group(int_gdq, do_not_use):

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -877,7 +877,7 @@ def find_faint_extended(
     if nints > minimum_sigclip_groups:
         mean, median, stddev = stats.sigma_clipped_stats(first_diffs_masked, sigma=5, axis=0)
 #    warnings.filterwarnings("ignore", ".*Input data contains invalid values.*", RuntimeWarning)
-    warnings.filterwarnings("ignore", ".*invalid value.*", RuntimeWarning)
+    warnings.filterwarnings("ignore", ".*nan_treatment.*", RuntimeWarning)
     for intg in range(nints):
         # calculate sigma for each pixel
         if nints <= minimum_sigclip_groups:

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -542,7 +542,7 @@ def flag_large_events(
     Nothing, gdq array is modified.
 
     """
-    log.info("Flagging large Snowballs")
+    log.info("Flagging Snowballs")
 
     n_showers_grp = []
     total_snowballs = 0
@@ -854,6 +854,7 @@ def find_faint_extended(
     """
 #    fits.writeto("ingdq.fits", ingdq, overwrite=True)
 #    fits.writeto("inpdg.fits", pdq, overwrite=True)
+    log.info("Flagging Showers")
     gdq = ingdq.copy()
     data = indata.copy()
     read_noise_2 = readnoise_2d**2
@@ -863,8 +864,8 @@ def find_faint_extended(
 #    refy, refx = np.where(ref_pixels_array == 1)
 #    data[:, :, refy, refx] = np.nan
 #    gdq = np.bitwise_or(pdq[np.newaxis, np.newaxis, :, :], gdq)
-    refint, refgrp, refy, refx = np.where(gdq == refpix_flag)
-    gdq[refint, refgrp, refy, refx] = donotuse_flag
+    refy, refx = np.where(pdq == refpix_flag)
+    gdq[:, :, refy, refx] = donotuse_flag
     fits.writeto("updategdq.fits", gdq, overwrite=True)
     first_diffs = np.diff(data, axis=1)
     fits.writeto("first_diffs.fits", first_diffs, overwrite=True)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -787,7 +787,7 @@ def near_edge(jump, low_threshold, high_threshold):
 
 def find_faint_extended(
     indata,
-    gdq,
+    ingdq,
     pdq,
     readnoise_2d,
     nframes,
@@ -842,12 +842,13 @@ def find_faint_extended(
     Total number of showers detected.
 
     """
-    read_noise_2 = readnoise_2d**2
+    gdq = ingdq.copy()
     data = indata.copy()
+    read_noise_2 = readnoise_2d**2
     bad_pixels_array = np.bitwise_and(pdq, 1)
     dnuy, dnux = np.where(bad_pixels_array == 1)
     data[:, :, dnuy, dnux] = np.nan
-    gdq[:, :, dnuy, dnux] = np.nan
+    gdq = np.bitwise_or(bad_pixels_array[np.newaxis, np.newaxis, :, :], gdq)
 
     first_diffs = np.diff(data, axis=1)
     fits.writeto("first_diffs.fits", first_diffs, overwrite=True)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -869,12 +869,14 @@ def find_faint_extended(
     data[gdq == donotuse_flag] = np.nan
     refy, refx = np.where(pdq == refpix_flag)
     gdq[:, :, refy, refx] = donotuse_flag
+    fits.writeto("masked_gdq.fits", gdq, overwrite=True)
     first_diffs = np.diff(data, axis=1)
     masked_ratio_cube = np.zeros_like(data)
     masked_smoothed_ratio_cube = np.zeros_like(data)
     extended_emission_cube = np.zeros_like(data)
     e_jump_cube = np.zeros(shape=(data.shape[0], data.shape[1]-1, data.shape[2], data.shape[3]))
     median_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
+    sigma_cube = np.zeros(shape=(data.shape[0], data.shape[2], data.shape[3]))
     all_ellipses = []
 
     first_diffs_masked = np.ma.masked_array(first_diffs, mask=np.isnan(first_diffs))
@@ -892,6 +894,7 @@ def find_faint_extended(
             e_jump = first_diffs_masked[intg] - median_diffs[np.newaxis, :, :]
             e_jump_cube[intg, :, :, :] = e_jump
             median_cube[intg, :, :] = median_diffs
+            sigma_cube[intg, :, :] = sigma
             # SNR ratio of each diff.
             ratio = np.abs(e_jump) / sigma[np.newaxis, :, :]
 
@@ -994,6 +997,7 @@ def find_faint_extended(
                 all_ellipses.append([intg, grp, ellipses])
                 # Reset the warnings filter to its original state
     print("writing msr cube")
+    fits.writeto("sigma_cube.fits", sigma_cube, overwrite=True)
     fits.writeto("median_cube.fits", median_cube, overwrite=True)
     fits.writeto("e_jump_cube.fits", e_jump_cube, overwrite=True)
     fits.writeto("masked_smoothed_ratio_cube.fits",masked_smoothed_ratio_cube, overwrite=True)

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -2,8 +2,6 @@ import logging
 import multiprocessing
 import time
 import warnings
-import astropy.stats
-
 import cv2 as cv
 import numpy as np
 from astropy import stats

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -892,7 +892,7 @@ def find_faint_extended(
         ring_2D_kernel = Ring2DKernel(inner, outer)
         ngrps = data.shape[1]
         first_good_group = find_first_good_group(gdq[intg, :, :, :], donotuse_flag)
-        for grp in range(first_good_group, ngrps):
+        for grp in range(first_good_group + 1, ngrps):
             if nints > minimum_sigclip_groups:
                 median_diffs = median[grp - 1]
                 sigma = stddev[grp - 1]

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -879,7 +879,7 @@ def find_faint_extended(
     if nints > minimum_sigclip_groups:
         mean, median, stddev = stats.sigma_clipped_stats(first_diffs_masked, sigma=5, axis=0)
 #    warnings.filterwarnings("ignore", ".*Input data contains invalid values.*", RuntimeWarning)
-    warnings.filterwarnings("ignore", ".*nan_treatment.*", RuntimeWarning)
+    warnings.filterwarnings("ignore")
     for intg in range(nints):
         # calculate sigma for each pixel
         if nints <= minimum_sigclip_groups:

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -875,11 +875,14 @@ def find_faint_extended(
         log.warning("Not enough differences for shower detections")
         return ingdq, 0
     read_noise_2 = readnoise_2d**2
-    gdq[gdq == np.bitwise_or(donotuse_flag, jump_flag)] = donotuse_flag
-    gdq[gdq == np.bitwise_or(donotuse_flag, sat_flag)] = donotuse_flag
+    jump_dnu_flag = jump_flag + donotuse_flag
+    sat_dnu_flag = sat_flag + donotuse_flag
+    data[gdq == jump_dnu_flag] = np.nan
+    data[gdq == sat_dnu_flag] = np.nan
     data[gdq == sat_flag] = np.nan
     data[gdq == jump_flag] = np.nan
     data[gdq == donotuse_flag] = np.nan
+    fits.writeto("data_naned.fits", data, overwrite=True)
     refy, refx = np.where(pdq == refpix_flag)
     gdq[:, :, refy, refx] = donotuse_flag
     fits.writeto("masked_gdq.fits", gdq, overwrite=True)
@@ -1058,11 +1061,11 @@ def find_faint_extended(
                 max_extended_radius=max_extended_radius,
             )
     fits.writeto('before_gdq_reset.fits', gdq, overwrite=True)
-    jump_dnu_flag = jump_flag + donotuse_flag
-    sat_dnu_flag = sat_flag + donotuse_flag
-    gdq[ingdq == np.bitwise_and(ingdq, jump_flag) or ingdq == np.bitwise_and(ingdq, jump_dnu_flag)] = jump_flag
-    gdq[ingdq == np.bitwise_and(ingdq, sat_flag) or ingdq == np.bitwise_and(ingdq, sat_dnu_flag)] = sat_flag
-    fits.writeto('after_gdq_reset.fits', gdq, overwrite=True)
+#    jump_dnu_flag = jump_flag + donotuse_flag
+#    sat_dnu_flag = sat_flag + donotuse_flag
+#    gdq[ingdq == np.bitwise_and(ingdq, jump_flag) or ingdq == np.bitwise_and(ingdq, jump_dnu_flag)] = jump_flag
+#    gdq[ingdq == np.bitwise_and(ingdq, sat_flag) or ingdq == np.bitwise_and(ingdq, sat_dnu_flag)] = sat_flag
+#    fits.writeto('after_gdq_reset.fits', gdq, overwrite=True)
     return gdq, len(all_ellipses)
 
 def find_first_good_group(int_gdq, do_not_use):

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -847,11 +847,13 @@ def find_faint_extended(
     gdq = ingdq.copy()
     data = indata.copy()
     read_noise_2 = readnoise_2d**2
-    bad_pixels_array = np.bitwise_and(pdq, 1)
-    fits.writeto("badpixelsarray.fits", bad_pixels_array, overwrite=True)
-    dnuy, dnux = np.where(bad_pixels_array == 1)
-    data[:, :, dnuy, dnux] = np.nan
-    gdq = np.bitwise_or(bad_pixels_array[np.newaxis, np.newaxis, :, :], gdq)
+#    ref_pixels_array = np.zeros_like(pdq)
+    ref_pixels_array = np.bitwise_and(pdq, 2147483648) // 2147483648
+    test_array = ref_pixels_array // 2147483648
+    fits.writeto("refpixelsarray.fits", ref_pixels_array, overwrite=True)
+    refy, refx = np.where(ref_pixels_array == 1)
+    data[:, :, refy, refx] = np.nan
+    gdq = np.bitwise_or(ref_pixels_array[np.newaxis, np.newaxis, :, :], gdq)
     fits.writeto("updategdq.fits", gdq, overwrite=True)
     first_diffs = np.diff(data, axis=1)
     fits.writeto("first_diffs.fits", first_diffs, overwrite=True)
@@ -899,7 +901,8 @@ def find_faint_extended(
             sat_pixels_array = np.bitwise_and(combined_pixel_mask, 1)
             dnuy, dnux = np.where(sat_pixels_array == 1)
             masked_ratio[saty, satx] = np.nan
-
+#            if grp == 1:
+#               fits.writeto("masked_ratio1.fits", masked_ratio., overwrite=True)
             masked_smoothed_ratio = convolve(masked_ratio, ring_2D_kernel)
             nrows = ratio.shape[1]
             ncols = ratio.shape[2]

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -124,6 +124,7 @@ def find_crs(
 
     """
     print("n1, n2", after_jump_flag_n1, after_jump_flag_n2)
+    print("e1, e2", after_jump_flag_e1, after_jump_flag_e2)
     # copy data and group DQ array
     if copy_arrs:
         dat = dataa.copy()

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -401,8 +401,6 @@ def find_crs(
     # the transient seen after ramp jumps
     flag_e_threshold = [after_jump_flag_e1, after_jump_flag_e2]
     flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
-    print("elec thresholds", flag_e_threshold)
-    print("groups flagged", flag_groups)
     for cthres, cgroup in zip(flag_e_threshold, flag_groups):
         if cgroup > 0:
             cr_intg, cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq, jump_flag))

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -123,6 +123,7 @@ def find_crs(
         pixels above current row also to be flagged as a CR
 
     """
+    print("n1, n2", after_jump_flag_n1, after_jump_flag_n2)
     # copy data and group DQ array
     if copy_arrs:
         dat = dataa.copy()

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -401,7 +401,6 @@ def find_crs(
     # the transient seen after ramp jumps
     flag_e_threshold = [after_jump_flag_e1, after_jump_flag_e2]
     flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
-    print("flag groups", flag_groups)
     for cthres, cgroup in zip(flag_e_threshold, flag_groups):
         if cgroup > 0:
             cr_intg, cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq, jump_flag))

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -123,8 +123,6 @@ def find_crs(
         pixels above current row also to be flagged as a CR
 
     """
-    print("n1, n2", after_jump_flag_n1, after_jump_flag_n2)
-    print("e1, e2", after_jump_flag_e1, after_jump_flag_e2)
     # copy data and group DQ array
     if copy_arrs:
         dat = dataa.copy()

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -401,6 +401,7 @@ def find_crs(
     # the transient seen after ramp jumps
     flag_e_threshold = [after_jump_flag_e1, after_jump_flag_e2]
     flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
+    print("flag groups", flag_groups)
     for cthres, cgroup in zip(flag_e_threshold, flag_groups):
         if cgroup > 0:
             cr_intg, cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq, jump_flag))

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -401,7 +401,8 @@ def find_crs(
     # the transient seen after ramp jumps
     flag_e_threshold = [after_jump_flag_e1, after_jump_flag_e2]
     flag_groups = [after_jump_flag_n1, after_jump_flag_n2]
-
+    print("elec thresholds", flag_e_threshold)
+    print("groups flagged", flag_groups)
     for cthres, cgroup in zip(flag_e_threshold, flag_groups):
         if cgroup > 0:
             cr_intg, cr_group, cr_row, cr_col = np.where(np.bitwise_and(gdq, jump_flag))

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -270,6 +270,8 @@ def test_flag_large_events_groupedsnowball():
         min_sat_radius_extend=0.5,
         sat_expand=1.1,
     )
+    from astropy.io import fits
+    fits.writeto("new_cube_after.fits", cube, overwrite=True)
     assert cube[0, 2, 1, 0] == DQFLAGS["JUMP_DET"]  # Jump was extended
     assert cube[0, 2, 2, 2] == DQFLAGS["SATURATED"]  # Saturation was extended
 

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -160,7 +160,6 @@ def test_flag_large_events_groupedsnowball():
     cube[0, 2, 5, 1:6] = DQFLAGS["JUMP_DET"]
     cube[0, 2, 1:6, 1] = DQFLAGS["JUMP_DET"]
     cube[0, 2, 1:6, 5] = DQFLAGS["JUMP_DET"]
-    fits.writeto("incube.fits", cube, overwrite=True)
     flag_large_events(
         cube,
         DQFLAGS["JUMP_DET"],
@@ -175,7 +174,6 @@ def test_flag_large_events_groupedsnowball():
     )
     #    assert cube[0, 1, 2, 2] == 0
     #    assert cube[0, 1, 3, 5] == 0
-    fits.writeto("outcube.fits", cube, overwrite=True)
     assert cube[0, 2, 0, 0] == 0
     assert cube[0, 2, 1, 0] == DQFLAGS["JUMP_DET"]  # Jump was extended
     assert cube[0, 2, 2, 2] == DQFLAGS["SATURATED"]  # Saturation was extended
@@ -214,13 +212,12 @@ def test_flag_large_events_withsnowball_noextension():
 
 
 def test_find_faint_extended():
-    nint, ngrps, ncols, nrows = 1, 66, 5, 5
+    nint, ngrps, ncols, nrows = 1, 66, 25, 25
     data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
     gdq = np.zeros_like(data, dtype=np.uint32)
     pdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     pdq[0, 0] = 1
     pdq[1, 1] = 2147483648
-#    pdq = np.zeros(shape=(data.shape[2], data.shape[3]), dtype=np.uint8)
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
     rng = np.random.default_rng(12345)
@@ -234,75 +231,36 @@ def test_find_faint_extended():
         readnoise * np.sqrt(2),
         1,
         100,
-        snr_threshold=3,
+        snr_threshold=1.2,
         min_shower_area=10,
         inner=1,
         outer=2.6,
         sat_flag=2,
         jump_flag=4,
-        ellipse_expand=1.1,
-        num_grps_masked=0,
+        ellipse_expand=1.,
+        num_grps_masked=1,
     )
-    fits.writeto("outputgdq.fits", gdq, overwrite=True)
     #  Check that all the expected samples in group 2 are flagged as jump and
     #  that they are not flagged outside
-    assert num_showers == 1
+    fits.writeto("gdq.fits", gdq, overwrite=True)
+#    assert num_showers == 1
     assert np.all(gdq[0, 1, 22, 14:23] == 0)
-    assert np.all(gdq[0, 1, 21, 16:20] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 20, 15:22] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 19, 15:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 18, 14:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 17, 14:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 16, 14:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 15, 14:22] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 14, 16:22] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 13, 17:21] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 1, 12, 14:23] == 0)
-    assert np.all(gdq[0, 1, 12:23, 24] == 0)
-    assert np.all(gdq[0, 1, 12:23, 13] == 0)
+    assert gdq[0, 1, 16, 18] == DQFLAGS['JUMP_DET']
+    assert np.all(gdq[0, 1, 11:22, 16:19] == DQFLAGS["JUMP_DET"])
+    assert np.all(gdq[0, 1, 22, 16:19] == 0)
+    assert np.all(gdq[0, 1, 10, 16:19] == 0)
     #  Check that the same area is flagged in the first group after the event
     assert np.all(gdq[0, 2, 22, 14:23] == 0)
-    assert np.all(gdq[0, 2, 21, 16:20] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 20, 15:22] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 19, 15:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 18, 14:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 17, 14:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 16, 14:23] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 15, 14:22] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 14, 16:22] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 13, 17:21] == DQFLAGS["JUMP_DET"])
-    assert np.all(gdq[0, 2, 12, 14:23] == 0)
-    assert np.all(gdq[0, 2, 12:22, 24] == 0)
-    assert np.all(gdq[0, 2, 12:22, 13] == 0)
+    assert gdq[0, 2, 16, 18] == DQFLAGS['JUMP_DET']
+    assert np.all(gdq[0, 2, 11:22, 16:19] == DQFLAGS["JUMP_DET"])
+    assert np.all(gdq[0, 2, 22, 16:19] == 0)
+    assert np.all(gdq[0, 2, 10, 16:19] == 0)
+
+    assert np.all(gdq[0, 3:, :, :]) == 0
 
     #  Check that the flags are not applied in the 3rd group after the event
     assert np.all(gdq[0, 4, 12:22, 14:23]) == 0
 
-def test_shower_enhancements():
-    data = fits.getdata("data/incoming_data.fits")
-    pdq = fits.getdata("data/incoming_pdq.fits")
-    gdq = fits.getdata("data/incoming_gdq.fits")
-    readnoise_DN = fits.getdata("/grp/crds/jwst/references/jwst/jwst_miri_readnoise_0085.fits")
-    gain = fits.getdata("/grp/crds/jwst/references/jwst/jwst_miri_gain_0020.fits")
-    print("median gain", np.nanmedian(gain))
-    readnoise = gain * readnoise_DN
-    gdq, num_showers = find_faint_extended(
-        data,
-        gdq,
-        pdq,
-        readnoise * np.sqrt(2),
-        1,
-        100,
-        snr_threshold=3.0,
-        min_shower_area=30,
-        inner=1,
-        outer=2.6,
-        sat_flag=2,
-        jump_flag=4,
-        ellipse_expand=1.1,
-        num_grps_masked=0,
-    )
-    fits.writeto("outputgdq.fits", gdq, overwrite=True)
     def test_find_faint_extended():
         nint, ngrps, ncols, nrows = 1, 66, 5, 5
         data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
@@ -316,7 +274,6 @@ def test_shower_enhancements():
         rng = np.random.default_rng(12345)
         data[0, 1:, 14:20, 15:20] = 6 * gain * 6.0 * np.sqrt(2)
         data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
-        fits.writeto("data.fits", data, overwrite=True)
         gdq, num_showers = find_faint_extended(
             data,
             gdq,
@@ -333,7 +290,6 @@ def test_shower_enhancements():
             ellipse_expand=1.1,
             num_grps_masked=0,
         )
-        fits.writeto("outputgdq.fits", gdq, overwrite=True)
 
 
 # No shower is found because the event is identical in all ints
@@ -341,7 +297,7 @@ def test_find_faint_extended_sigclip():
     nint, ngrps, ncols, nrows = 101, 6, 30, 30
     data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
     gdq = np.zeros_like(data, dtype=np.uint8)
-    pdq = np.zeros_like(data, dtype=np.uint8)
+    pdq = np.zeros(shape=(nrows, ncols), dtype=np.uint8)
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
     rng = np.random.default_rng(12345)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -275,6 +275,62 @@ def test_find_faint_extended():
     #  Check that the flags are not applied in the 3rd group after the event
     assert np.all(gdq[0, 4, 12:22, 14:23]) == 0
 
+def test_shower_enhancements():
+    data = fits.getdata("data/incoming_data.fits")
+    pdq = fits.getdata("data/incoming_pdq.fits")
+    gdq = fits.getdata("data/incoming_gdq.fits")
+    readnoise_DN = fits.getdata("/grp/crds/jwst/references/jwst/jwst_miri_readnoise_0085.fits")
+    gain = fits.getdata("/grp/crds/jwst/references/jwst/jwst_miri_gain_0020.fits")
+    readnoise = gain * readnoise_DN
+    gdq, num_showers = find_faint_extended(
+        data,
+        gdq,
+        pdq,
+        readnoise * np.sqrt(2),
+        1,
+        100,
+        snr_threshold=3,
+        min_shower_area=10,
+        inner=1,
+        outer=2.6,
+        sat_flag=2,
+        jump_flag=4,
+        ellipse_expand=1.1,
+        num_grps_masked=0,
+    )
+    fits.writeto("outputgdq.fits", gdq, overwrite=True)
+    def test_find_faint_extended():
+        nint, ngrps, ncols, nrows = 1, 66, 5, 5
+        data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
+        gdq = np.zeros_like(data, dtype=np.uint32)
+        pdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
+        pdq[0, 0] = 1
+        pdq[1, 1] = 2147483648
+        #    pdq = np.zeros(shape=(data.shape[2], data.shape[3]), dtype=np.uint8)
+        gain = 4
+        readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
+        rng = np.random.default_rng(12345)
+        data[0, 1:, 14:20, 15:20] = 6 * gain * 6.0 * np.sqrt(2)
+        data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
+        fits.writeto("data.fits", data, overwrite=True)
+        gdq, num_showers = find_faint_extended(
+            data,
+            gdq,
+            pdq,
+            readnoise * np.sqrt(2),
+            1,
+            100,
+            snr_threshold=3,
+            min_shower_area=10,
+            inner=1,
+            outer=2.6,
+            sat_flag=2,
+            jump_flag=4,
+            ellipse_expand=1.1,
+            num_grps_masked=0,
+        )
+        fits.writeto("outputgdq.fits", gdq, overwrite=True)
+
 
 # No shower is found because the event is identical in all ints
 def test_find_faint_extended_sigclip():

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -160,6 +160,7 @@ def test_flag_large_events_groupedsnowball():
     cube[0, 2, 5, 1:6] = DQFLAGS["JUMP_DET"]
     cube[0, 2, 1:6, 1] = DQFLAGS["JUMP_DET"]
     cube[0, 2, 1:6, 5] = DQFLAGS["JUMP_DET"]
+    fits.writeto("incube.fits", cube, overwrite=True)
     flag_large_events(
         cube,
         DQFLAGS["JUMP_DET"],
@@ -174,6 +175,7 @@ def test_flag_large_events_groupedsnowball():
     )
     #    assert cube[0, 1, 2, 2] == 0
     #    assert cube[0, 1, 3, 5] == 0
+    fits.writeto("outcube.fits", cube, overwrite=True)
     assert cube[0, 2, 0, 0] == 0
     assert cube[0, 2, 1, 0] == DQFLAGS["JUMP_DET"]  # Jump was extended
     assert cube[0, 2, 2, 2] == DQFLAGS["SATURATED"]  # Saturation was extended

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -290,7 +290,7 @@ def test_shower_enhancements():
         1,
         100,
         snr_threshold=3,
-        min_shower_area=10,
+        min_shower_area=50,
         inner=1,
         outer=2.6,
         sat_flag=2,

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -282,6 +282,7 @@ def test_shower_enhancements():
     gdq = fits.getdata("data/incoming_gdq.fits")
     readnoise_DN = fits.getdata("/grp/crds/jwst/references/jwst/jwst_miri_readnoise_0085.fits")
     gain = fits.getdata("/grp/crds/jwst/references/jwst/jwst_miri_gain_0020.fits")
+    print("median gain", np.nanmedian(gain))
     readnoise = gain * readnoise_DN
     gdq, num_showers = find_faint_extended(
         data,
@@ -290,8 +291,8 @@ def test_shower_enhancements():
         readnoise * np.sqrt(2),
         1,
         100,
-        snr_threshold=3,
-        min_shower_area=50,
+        snr_threshold=3.0,
+        min_shower_area=30,
         inner=1,
         outer=2.6,
         sat_flag=2,
@@ -344,6 +345,7 @@ def test_find_faint_extended_sigclip():
     rng = np.random.default_rng(12345)
     data[0, 1:, 14:20, 15:20] = 6 * gain * 1.7
     data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
+    min_shower_area=20
     gdq, num_showers = find_faint_extended(
         data,
         gdq,
@@ -352,7 +354,7 @@ def test_find_faint_extended_sigclip():
         1,
         100,
         snr_threshold=1.3,
-        min_shower_area=20,
+        min_shower_area=min_shower_area,
         inner=1,
         outer=2,
         sat_flag=2,

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -150,16 +150,16 @@ def test_flag_large_events_withsnowball():
 def test_flag_large_events_groupedsnowball():
     cube = np.zeros(shape=(1, 5, 7, 7), dtype=np.uint8)
     # cross of saturation surrounding by jump -> snowball
-    cube[0, 1, :, :] = DQFLAGS["JUMP_DET"]
+#    cube[0, 1, :, :] = DQFLAGS["JUMP_DET"]
+#    cube[0, 2, :, :] = DQFLAGS["JUMP_DET"]
+    cube[0, 2, 1:6, 1:6] = DQFLAGS["JUMP_DET"]
+    cube[0, 1, 1:6, 1:6] = DQFLAGS["JUMP_DET"]
+
     cube[0, 2, 3, 3] = DQFLAGS["SATURATED"]
     cube[0, 2, 2, 3] = DQFLAGS["SATURATED"]
     cube[0, 2, 3, 4] = DQFLAGS["SATURATED"]
     cube[0, 2, 4, 3] = DQFLAGS["SATURATED"]
     cube[0, 2, 3, 2] = DQFLAGS["SATURATED"]
-    cube[0, 2, 1, 1:6] = DQFLAGS["JUMP_DET"]
-    cube[0, 2, 5, 1:6] = DQFLAGS["JUMP_DET"]
-    cube[0, 2, 1:6, 1] = DQFLAGS["JUMP_DET"]
-    cube[0, 2, 1:6, 5] = DQFLAGS["JUMP_DET"]
     flag_large_events(
         cube,
         DQFLAGS["JUMP_DET"],
@@ -172,9 +172,6 @@ def test_flag_large_events_groupedsnowball():
         min_sat_radius_extend=0.5,
         sat_expand=1.1,
     )
-    #    assert cube[0, 1, 2, 2] == 0
-    #    assert cube[0, 1, 3, 5] == 0
-    assert cube[0, 2, 0, 0] == 0
     assert cube[0, 2, 1, 0] == DQFLAGS["JUMP_DET"]  # Jump was extended
     assert cube[0, 2, 2, 2] == DQFLAGS["SATURATED"]  # Saturation was extended
 

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -490,16 +490,18 @@ def test_find_faint_extended_sigclip():
     nint, ngrps, ncols, nrows = 101, 6, 30, 30
     data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
     gdq = np.zeros_like(data, dtype=np.uint8)
+    pdq = np.zeros(shape=(nrows, ncols), dtype=np.int32)
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
     rng = np.random.default_rng(12345)
     data[0, 1:, 14:20, 15:20] = 6 * gain * 1.7
     data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
-    gdq, num_showers = find_faint_extended(data, gdq, readnoise, 1, 100,
+    gdq, num_showers = find_faint_extended(data, gdq, pdq, readnoise, 1, 100,
                                            snr_threshold=1.3,
                                            min_shower_area=20, inner=1,
                                            outer=2, sat_flag=2, jump_flag=4,
-                                           ellipse_expand=1.1, num_grps_masked=3)
+                                           ellipse_expand=1.1, num_grps_masked=3,
+                                           dqflags=DQFLAGS)
     #  Check that all the expected samples in group 2 are flagged as jump and
     #  that they are not flagged outside
     assert (np.all(gdq[0, 1, 22, 14:23] == 0))

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -258,7 +258,7 @@ def test_flag_large_events_groupedsnowball():
     cube[0, 2, 3, 4] = DQFLAGS["SATURATED"]
     cube[0, 2, 4, 3] = DQFLAGS["SATURATED"]
     cube[0, 2, 3, 2] = DQFLAGS["SATURATED"]
-    flag_large_events(
+    outgdq, num_snowballs = flag_large_events(
         cube,
         DQFLAGS["JUMP_DET"],
         DQFLAGS["SATURATED"],
@@ -270,10 +270,9 @@ def test_flag_large_events_groupedsnowball():
         min_sat_radius_extend=0.5,
         sat_expand=1.1,
     )
-    from astropy.io import fits
-    fits.writeto("new_cube_after.fits", cube, overwrite=True)
-    assert cube[0, 2, 1, 0] == DQFLAGS["JUMP_DET"]  # Jump was extended
-    assert cube[0, 2, 2, 2] == DQFLAGS["SATURATED"]  # Saturation was extended
+
+    assert outgdq[0, 2, 1, 0] == DQFLAGS["JUMP_DET"]  # Jump was extended
+    assert outgdq[0, 2, 2, 2] == DQFLAGS["SATURATED"]  # Saturation was extended
 
 
 def test_flag_large_events_withsnowball_noextension():

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -211,11 +211,12 @@ def test_flag_large_events_withsnowball_noextension():
 
 
 def test_find_faint_extended():
-    nint, ngrps, ncols, nrows = 1, 66, 30, 30
+    nint, ngrps, ncols, nrows = 1, 66, 5, 5
     data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
-    gdq = np.zeros_like(data, dtype=np.uint8)
-    pdq = np.zeros(shape=(nrows, ncols), dtype=np.uint8)
+    gdq = np.zeros_like(data, dtype=np.uint32)
+    pdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     pdq[0, 0] = 1
+    pdq[1, 1] = 2147483648
 #    pdq = np.zeros(shape=(data.shape[2], data.shape[3]), dtype=np.uint8)
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -8,6 +8,7 @@ from stcal.jump.jump import (
     find_faint_extended,
     flag_large_events,
     point_inside_ellipse,
+    find_first_good_group,
 )
 
 DQFLAGS = {"JUMP_DET": 4, "SATURATED": 2, "DO_NOT_USE": 1, "GOOD": 0, "NO_GAIN_VALUE": 8}
@@ -417,3 +418,16 @@ def test_calc_num_slices():
     assert calc_num_slices(n_rows, "3/4", max_available_cores) == 1
     n_rows = 9
     assert calc_num_slices(n_rows, "21", max_available_cores) == 9
+
+def test_find_first_good_grp():
+    ngrps = 5
+    ncols = 2
+    nrows = 2
+    intg_gdq = np.zeros(shape=(ngrps, ncols, nrows), dtype=np.uint32)
+    assert find_first_good_group(intg_gdq, DQFLAGS['DO_NOT_USE']) == 0
+    intg_gdq[0, :, :] = 5
+    assert find_first_good_group(intg_gdq, DQFLAGS['DO_NOT_USE']) == 1
+    intg_gdq[1, :, :] = 5
+    assert find_first_good_group(intg_gdq, DQFLAGS['DO_NOT_USE']) == 2
+    intg_gdq[0, 0, 1] = 4
+    assert find_first_good_group(intg_gdq, DQFLAGS['DO_NOT_USE']) == 0

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -11,7 +11,8 @@ from stcal.jump.jump import (
     find_first_good_group,
 )
 
-DQFLAGS = {"JUMP_DET": 4, "SATURATED": 2, "DO_NOT_USE": 1, "GOOD": 0, "NO_GAIN_VALUE": 8}
+DQFLAGS = {"JUMP_DET": 4, "SATURATED": 2, "DO_NOT_USE": 1, "GOOD": 0, "NO_GAIN_VALUE": 8,
+           "REFERENCE_PIXEL": 2147483648}
 
 
 @pytest.fixture()
@@ -228,6 +229,7 @@ def test_find_faint_extended():
         readnoise * np.sqrt(2),
         1,
         100,
+        DQFLAGS,
         snr_threshold=1.2,
         min_shower_area=10,
         inner=1,
@@ -308,6 +310,7 @@ def test_find_faint_extended_sigclip():
         readnoise,
         1,
         100,
+        DQFLAGS,
         snr_threshold=1.3,
         min_shower_area=min_shower_area,
         inner=1,


### PR DESCRIPTION
Resolves [JP-3562](https://jira.stsci.edu/browse/JP-3562)

Closes spacetelescope/jwst#8333

This PR addresses several effects that lead to inaccurate flagging of showers. These change improve the estimate of the median difference by using all the integrations. It also masks reference pixels to avoid them being used in the convolution used to detect faint emission.

**Checklist**

- [X] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
