### PR TITLE
Use multiprocessing `get_context` and python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
         - linux: py39-oldestdeps-cov-xdist
         - linux: py39-xdist
         - linux: py310-xdist
-        - linux: py311-cov-xdist
+        - linux: py311-xdist
+        - linux: py312-cov-xdist
           coverage: codecov
         - macos: py311-xdist
   test_downstream:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@
 Changes to API
 --------------
 
+jump
+~~~~
+
+- Switch multiprocessing method to ``fork_server``. [#249]
+
+ramp_fitting
+~~~~~~~~~~~~
+
+- Switch multiprocessing method to ``fork_server``. [#249]
+
 Bug Fixes
 ---------
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -391,9 +391,10 @@ def detect_jumps(
             ),
         )
         log.info("Creating %d processes for jump detection ", n_slices)
-        pool = multiprocessing.Pool(processes=n_slices)
-######### JUST FOR DEBUGGING #########################
-#        pool = multiprocessing.Pool(processes=1)
+        ctx = multiprocessing.get_context("forkserver")
+        pool = ctx.Pool(processes=n_slices)
+        ######### JUST FOR DEBUGGING #########################
+        # pool = ctx.Pool(processes=1)
         # Starts each slice in its own process. Starmap allows more than one
         # parameter to be passed.
         real_result = pool.starmap(twopt.find_crs, slices)

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 
 import logging
+import multiprocessing
 import time
 import warnings
 from multiprocessing import cpu_count
-from multiprocessing.pool import Pool
 
 import numpy as np
 
@@ -160,7 +160,8 @@ def ols_ramp_fit_multiprocessing(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, weighting, number_slices
     )
 
-    pool = Pool(processes=number_slices)
+    ctx = multiprocessing.get_context("forkserver")
+    pool = ctx.Pool(processes=number_slices)
     pool_results = pool.starmap(ols_ramp_fit_single, slices)
     pool.close()
     pool.join()


### PR DESCRIPTION
Python 3.12 added a warning when the `fork` method (default of linux) was used for multiprocessing if a process contains threads:
```
    /opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=2229) is multi-threaded, use of fork() may lead to deadlocks in the child.
```
This warning can be seen in the logs for one of the `devdeps` jobs that uses python 3.12:
https://github.com/spacetelescope/stcal/actions/runs/8110832059/job/22168896740#step:10:169

This PR switches the method to `forkserver` using a `get_context` (to only effect the calls on the context).

This PR will allow jwst to remove the global calls to `set_start_method` which as noted in https://github.com/spacetelescope/jwst/issues/8306 can lead to unexpected behavior.
This PR for jwst removes `set_start_method` (and requires the source branch for this PR for sctal):
https://github.com/spacetelescope/jwst/pull/8343
The python 3.12 run shows no `DeprecationWarning` mentioning `fork`:
https://github.com/spacetelescope/jwst/actions/runs/8253314996/job/22574879663?pr=8343

Finally this PR adds a non-devdeps python 3.12 test job to the CI (which illustrates that the above changes remove the warning from the test suite).


**Checklist**

- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
