### PR TITLE
JP-3583: Long integrations truncation in ramp fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,13 @@ ramp_fitting
 
 Bug Fixes
 ---------
+ramp_fitting
+~~~~~~~~~~~~
 
+-- Changed the data type of three variables that are used in measuring
+   the jump free segments of integrations. The variables were uint8 and
+   they would yield wrong results for integrations with more than 256
+   groups. [#251]
 Other
 -----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,13 +16,14 @@ ramp_fitting
 
 Bug Fixes
 ---------
+
 ramp_fitting
 ~~~~~~~~~~~~
 
--- Changed the data type of three variables that are used in measuring
-   the jump free segments of integrations. The variables were uint8 and
-   they would yield wrong results for integrations with more than 256
-   groups. [#251]
+- Changed the data type of three variables that are used in measuring
+  the jump free segments of integrations. The variables were uint8 and
+  they would yield wrong results for integrations with more than 256
+  groups. [#251]
 Other
 -----
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -520,10 +520,10 @@ def calc_slope_vars(ramp_data, rn_sect, gain_sect, gdq_sect, group_time, max_seg
     gdq_2d_nan[np.bitwise_and(gdq_2d, ramp_data.flags_saturated).astype(bool)] = np.nan
 
     # Get lengths of semiramps for all pix [number_of_semiramps, number_of_pix]
-    segs = np.zeros_like(gdq_2d)
+    segs = np.zeros_like(gdq_2d).astype(np.int16)
 
     # Counter of semiramp for each pixel
-    sr_index = np.zeros(npix, dtype=np.uint8)
+    sr_index = np.zeros(npix, dtype=np.uint16)
     pix_not_done = np.ones(npix, dtype=bool)  # initialize to True
 
     i_read = 0
@@ -558,7 +558,7 @@ def calc_slope_vars(ramp_data, rn_sect, gain_sect, gdq_sect, group_time, max_seg
 
         i_read += 1
 
-    segs = segs.astype(np.uint8)
+    segs = segs.astype(np.uint16)
     segs_beg = segs[:max_seg, :]  # the leading nonzero lengths
 
     # Create reshaped version [ segs, y, x ] to simplify computation

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -520,7 +520,7 @@ def calc_slope_vars(ramp_data, rn_sect, gain_sect, gdq_sect, group_time, max_seg
     gdq_2d_nan[np.bitwise_and(gdq_2d, ramp_data.flags_saturated).astype(bool)] = np.nan
 
     # Get lengths of semiramps for all pix [number_of_semiramps, number_of_pix]
-    segs = np.zeros_like(gdq_2d).astype(np.int16)
+    segs = np.zeros_like(gdq_2d).astype(np.uint16)
 
     # Counter of semiramp for each pixel
     sr_index = np.zeros(npix, dtype=np.uint16)

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -27,22 +27,23 @@ JUMP = dqflags["JUMP_DET"]
 
 # -----------------------------------------------------------------------------
 #                           Test Suite
-def test_Poisson_variance():
+
+def test_long_integration():
     nints, nrows, ncols = 1, 1, 1
-    rnoise_val, gain_val = 1.0, 40.0
+    rnoise_val, gain_val = 0.1, 40.0
     nframes, gtime, ftime = 1, 3, 3
     tm = (nframes, gtime, ftime)
-    num_grps1 = 300
-    num_grps2 = 0
+    num_grps1 = 301
+    num_grps2 = 20
     ramp_data, rnoise_array, gain_array = create_test_2seg_obs(rnoise_val, nints, num_grps1, num_grps2, ncols,
                                                                nrows, tm, rate=0, Poisson=True, grptime=gtime,
                                                                gain=gain_val, bias=0)
-    ramp_data.data[0, 280:, 0, 0] = 300 * 3
+    ramp_data.data[0, 291:, 0, 0] = 320 * 3
     # Run ramp fit on RampData
     buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
     ramp_data, buffsize, save_opt, rnoise_array, gain_array, algo, wt, ncores, dqflags)
-    np.testing.assert_almost_equal(slopes[0], .9, 2)
+    np.testing.assert_almost_equal(slopes[0], .65, 2)
 
 
 def base_neg_med_rates_single_integration():


### PR DESCRIPTION
Resolves [JP-3583](https://jira.stsci.edu/browse/JP-3583)

Closes spacetelescope/jwst#8373

This PR addresses an issue in the ramp_fitting routine where when finding the cosmic ray free segments of integrations. The code accumulates the non-CR groups using a counter. The problem is that this counter is a uint8 data type. Thus, once we get above 256 groups, it rolls over leading to only using a subset of the groups in the slope fit.

The solution was to change three variables from UINT8 to UINT16. This is big enough given the overall limit on the number of frames.

**Checklist**

- [X] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [X] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
