### PR TITLE
use sqrtf to avoid cast to double

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,11 @@ ramp_fitting
   they would yield wrong results for integrations with more than 256
   groups. [#251]
 
+- Use ``sqrtf`` instead of ``sqrt`` in ols_cas22 ramp fitting with
+  jump detection to avoid small numerical errors on different systems
+  due to a cast to/from double. [#252]
+
+
 Other
 -----
 
@@ -47,6 +52,10 @@ jump
 - Enable the use of multiple integrations to find outliers. Also,
   when the number of groups is above a threshold, use single pass
   outlier flagging rather than the iterative flagging. [#242]
+
+- Use ``sqrtf`` instead of ``sqrt`` in ols_cas22 ramp fitting with
+  jump detection to avoid small numerical errors on different systems
+  due to a cast to/from double. [#252]
 
 1.6.1 (2024-02-29)
 ==================

--- a/src/stcal/ramp_fitting/ols_cas22/_jump.pyx
+++ b/src/stcal/ramp_fitting/ols_cas22/_jump.pyx
@@ -55,7 +55,7 @@ fit_jumps : function
 """
 
 from cython cimport boundscheck, cdivision, wraparound
-from libc.math cimport NAN, fmaxf, isnan, log10, sqrt
+from libc.math cimport NAN, fmaxf, isnan, log10, sqrtf
 from libcpp cimport bool
 
 from stcal.ramp_fitting.ols_cas22._jump cimport JUMP_DET, FixedOffsets, JumpFits, PixelOffsets, Thresh
@@ -291,7 +291,7 @@ cdef inline float _statstic(float local_slope,
     cdef float delta = local_slope - slope
     cdef float var = (var_read_noise + slope * var_slope_coeff) / t_bar_diff_sqr
 
-    return delta / sqrt(var + correct)
+    return delta / sqrtf(var + correct)
 
 
 @boundscheck(False)


### PR DESCRIPTION
The use of `sqrt` from libc results in a cast to/from `double` in the ols_cas22 ramp fitting (with jump detection). This can result in small numerical differences that lead to romancal regtests that passed on jenkins but failed locally (due to a single extra jump in one pixel).

This PR switches `sqrt` for `sqrtf` to keep the intermediate values as `float` which leads to (at the moment) the same failure locally and on jenkins (where `test_rampfit_step[spec_full]` fails with a single pixel difference):
```
    {'arrays_differ': {"root['roman']['data']": {'abs_diff': <Quantity 1.9270487 DN / s>,
                                                 'n_diffs': 1,
                                                 'worst_abs_diff': {'index': (2798,
                                                                              2758),
                                                                    'value': <Quantity 1.9270487 DN / s>},
```
Regtest run here: 
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/681/
The `test_resample` failure is unrelated and also occurs on main.

**Checklist**

- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
