### PR TITLE
JP-3463: Fix poisson variance calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,11 @@ Changes to API
 Bug Fixes
 ---------
 
-- 
+ramp_fitting
+~~~~~~~~~~~~
+
+- Fix a bug in Poisson variance calculation visible when providing an average
+  dark current value. [#255]
 
 1.7.0 (2024-03-25)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,11 @@ ramp_fitting
 ~~~~~~~~~~~~
 
 - Fix a bug in Poisson variance calculation visible when providing an average
-  dark current value. [#255]
+  dark current value in which the specified dark current was not converted to the
+  appropriate units for pixels with negative slopes.  This resulted in
+  incorrect SCI, ERR, and VAR_POISSON values. Also required revising the approach
+  for catching all-zero variance cases when average dark current was not
+  specified. [#255]
 
 1.7.0 (2024-03-25)
 ==================

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1140,7 +1140,7 @@ def ramp_fit_compute_variances(ramp_data, gain_2d, readnoise_2d, fit_slopes_ans)
             # Suppress harmless arithmetic warnings for now
             warnings.filterwarnings("ignore", ".*invalid value.*", RuntimeWarning)
             warnings.filterwarnings("ignore", ".*divide by zero.*", RuntimeWarning)
-            var_p4[num_int, :, rlo:rhi, :] = den_p3 * (med_rates[rlo:rhi, :] +
+            var_p4[num_int, :, rlo:rhi, :] = den_p3 * (np.maximum(med_rates[rlo:rhi, :], 0) +
                                              ramp_data.average_dark_current[rlo:rhi, :])
 
             # Find the segment variance due to read noise and convert back to DN
@@ -1178,11 +1178,8 @@ def ramp_fit_compute_variances(ramp_data, gain_2d, readnoise_2d, fit_slopes_ans)
         # Huge variances correspond to non-existing segments, so are reset to 0
         #  to nullify their contribution.
         var_p3[var_p3 > utils.LARGE_VARIANCE_THRESHOLD] = 0.0
-        med_rate_mask = med_rates <= 0.0
-        var_p3[:, med_rate_mask] = 0.0
         warnings.resetwarnings()
 
-        var_p4[num_int, :, med_rate_mask] = ramp_data.average_dark_current[med_rate_mask][..., np.newaxis]
         var_both4[num_int, :, :, :] = var_r4[num_int, :, :, :] + var_p4[num_int, :, :, :]
         inv_var_both4[num_int, :, :, :] = 1.0 / var_both4[num_int, :, :, :]
 
@@ -1498,7 +1495,6 @@ def ramp_fit_overall(
     # Some contributions to these vars may be NaN as they are from ramps
     # having PIXELDQ=DO_NOT_USE
     var_p2[np.isnan(var_p2)] = 0.0
-    var_p2[med_rates <= 0.0] = 0.0
     var_r2[np.isnan(var_r2)] = 0.0
 
     # Suppress, then re-enable, harmless arithmetic warning

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -1178,6 +1178,7 @@ def ramp_fit_compute_variances(ramp_data, gain_2d, readnoise_2d, fit_slopes_ans)
         # Huge variances correspond to non-existing segments, so are reset to 0
         #  to nullify their contribution.
         var_p3[var_p3 > utils.LARGE_VARIANCE_THRESHOLD] = 0.0
+        var_p4[var_p4 > utils.LARGE_VARIANCE_THRESHOLD] = 0.0
         warnings.resetwarnings()
 
         var_both4[num_int, :, :, :] = var_r4[num_int, :, :, :] + var_p4[num_int, :, :, :]


### PR DESCRIPTION
This PR addresses the issue in [JP-3463](https://jira.stsci.edu/browse/JP-3463) where the addition of an average dark current to the poisson variance calculation step results in incorrect SCI array values for NIRSpec.  This PR adjusts the method of dealing with negative slopes and all-zero variance special cases.  Tested against two sets of MIRI data and one set of NIRSpec, and is working as intended both with and without specifying the new parameter.

Resolves [JP-3463](https://jira.stsci.edu/browse/JP-3463)

**Checklist**

- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
