### PR TITLE
JP-3623: Catch Runtime warnings in jump step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Changes to API
 Bug Fixes
 ---------
 
+jump
+~~~~
+
+- Catch some additional warnings about all-NaN slices. [#258]
+
 ramp_fitting
 ~~~~~~~~~~~~
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -973,13 +973,13 @@ def find_faint_extended(
     all_ellipses = []
 
     first_diffs_masked = np.ma.masked_array(first_diffs, mask=np.isnan(first_diffs))
+    warnings.filterwarnings("ignore")
     if nints > minimum_sigclip_groups:
         mean, median, stddev = stats.sigma_clipped_stats(first_diffs_masked, sigma=5, axis=0)
     else:
         median_diffs = np.nanmedian(first_diffs_masked, axis=(0, 1))
         sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
 
-    warnings.filterwarnings("ignore")
     for intg in range(nints):
         # calculate sigma for each pixel
         if nints < minimum_sigclip_groups:

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -240,7 +240,9 @@ def find_crs(
                 first_diffs = np.diff(dat, axis=1)
 
                 if total_usable_diffs >= min_diffs_single_pass:
+                    warnings.filterwarnings("ignore", ".*All-NaN slice encountered.*", RuntimeWarning)
                     median_diffs = np.nanmedian(first_diffs, axis=(0, 1))
+                    warnings.resetwarnings()
                     # calculate sigma for each pixel
                     sigma = np.sqrt(np.abs(median_diffs) + read_noise_2 / nframes)
                     # reset sigma so pixels with 0 read noise are not flagged as jumps


### PR DESCRIPTION
Resolves [JP-3623](https://jira.stsci.edu/browse/JP-3623) by catching a few runtime warnings in the jump step that were no longer caught after recent updates.

Closes spacetelescope/jwst#8483

**Checklist**

- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
