### PR TITLE
[SCSB-155] build with Numpy 2.0 release candidate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 1.7.2 (unreleased)
 ==================
 
+General
+-------
+
+- build with Numpy 2.0 release candidate [#260]
+
 Changes to API
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ requires = [
     "setuptools >=61",
     "setuptools_scm[toml] >=3.4",
     "Cython >=0.29.21",
-    "numpy >=1.18",
+    "numpy >=2.0.0rc2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -3486,7 +3486,7 @@ print_npy_types() {
     printf("NPY_DOUBLE = %d\n",NPY_DOUBLE);
 
     printf("NPY_VOID = %d\n",NPY_VOID);
-    printf("NPY_NTYPES = %d\n",NPY_NTYPES);
+    printf("NPY_NTYPES_LEGACY = %d\n",NPY_NTYPES_LEGACY);
     printf("NPY_NOTYPE = %d\n",NPY_NOTYPE);
     /*
     NPY_SHORT


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

resolves [SCSB-155](https://jira.stsci.edu/browse/SCSB-155)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

Numpy 2.0 is scheduled for release on June 19th. Due to the C ABI updates, Python projects that build C extensions are required to build against Numpy 2.0 in order to use Numpy 2.0 in runtime.
This is backwards-compatible with Numpy versions in runtime as far back as `1.26`

this PR pins `numpy>=2.0.0rc2` in `build-system.requires`
> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot:

**Checklist**

- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
