### PR TITLE
AL-852: GWCS should respect the bounding box on inverse transforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "numpy >=1.21.2",
     "opencv-python-headless >=4.6.0.66",
     "asdf >=2.15.0",
-    "gwcs >= 0.18.1",
+    "gwcs @ git+https://github.com/nden/gwcs.git@inverse-bbox",
 ]
 dynamic = [
     "version",

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -269,7 +269,7 @@ def _calculate_new_wcs(ref_model, shape, wcs_list, fiducial, crpix=None, transfo
     ----------
     ref_model :
         The reference model to be used when extracting metadata.
-bp
+
     shape : list
         The shape of the new WCS's pixel grid. If `None`, then the output bounding box
         will be used to determine it.
@@ -785,18 +785,30 @@ def reproject(wcs1, wcs2):
         tuple
             Tuple of np.ndarrays including reprojected x and y coordinates.
         """
-        sky = forward_transform(x, y)
-        flat_sky = []
-        for axis in sky:
-            flat_sky.append(axis.flatten())
+        # sky = forward_transform(x, y)
+        # flat_sky = []
+        # for axis in sky:
+        #     flat_sky.append(axis.flatten())
+        # # Filter out RuntimeWarnings due to computed NaNs in the WCS
+        # with warnings.catch_warnings():
+        #     warnings.simplefilter("ignore", RuntimeWarning)
+        #     det = backward_transform(*tuple(flat_sky))
+        # det_reshaped = []
+        # for axis in det:
+        #     det_reshaped.append(axis.reshape(x.shape))
+
+        # return tuple(det_reshaped)
+        shape = np.array(x).shape
+        sky = forward_transform(x, y)   
+        flat_sky = [axis.flatten() for axis in sky]
+        
         # Filter out RuntimeWarnings due to computed NaNs in the WCS
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
-            det = backward_transform(*tuple(flat_sky))
-        det_reshaped = []
-        for axis in det:
-            det_reshaped.append(axis.reshape(x.shape))
+            detector = backward_transform(*tuple(flat_sky))
 
-        return tuple(det_reshaped)
+        if shape == ():
+            return tuple([axis.item() for axis in detector])
+        return tuple([axis.reshape(shape) for axis in detector])
 
     return _reproject

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -253,7 +253,7 @@ def get_fake_wcs():
     [
         (1000, 2000, np.array(2000), np.array(4000)),  # string input test
         ([1000], [2000], np.array(2000), np.array(4000)),  # array input test
-        pytest.param(1, 2, 3, 4, marks=pytest.mark.xfail),  # expected failure test
+        (1, 2, 2, 4),
     ],
 )
 def test_reproject(x_inp, y_inp, x_expected, y_expected):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #

<!-- describe the changes comprising this PR here -->

The GWCS PR is https://github.com/spacetelescope/gwcs/pull/498
The changes here use the WCS API in order to pick up the bounding box.

**Checklist**

- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
