### PR TITLE
JP-3678: Ensure C extension works with multiprocessing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,13 @@ Changes to API
 Bug Fixes
 ---------
 
-- 
+
+ramp_fitting
+~~~~~~~~~~~~
+
+- When OLS_C was selected as the ramp fitting algorithm with multiprocessing, the C
+  extension was not called.  The old python code was called.  This bug has been fixed,
+  so the C extension is properly run when selecting multiprocessing. [#268]
 
 1.7.2 (2024-06-12)
 ==================

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -672,11 +672,11 @@ def ols_ramp_fit_single(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, we
 
         if ramp_data.drop_frames1 is None:
             ramp_data.drop_frames1 = 0
-        log.info("Entering C extension")
+        log.debug("Entering C extension")
         image_info, integ_info, opt_info = ols_slope_fitter(
                 ramp_data, gain_2d, readnoise_2d, weighting, save_opt)
 
-        log.info("Returning from C extension")
+        log.debug("Returning from C extension")
 
         c_end = time.time()
 
@@ -698,10 +698,10 @@ def ols_ramp_fit_single(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, we
 
     p_start = time.time()
 
-    log.info("Entering python code")
+    log.debug("Entering python code")
     image_info, integ_info, opt_info = ols_ramp_fit_single_python(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, weighting)
-    log.info("Returning from python ")
+    log.debug("Returning from python ")
 
     p_end = time.time()
     p_diff = p_end - p_start

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -173,7 +173,7 @@ def ramp_fit(
     ramp_data = create_ramp_fit_class(model, dqflags, suppress_one_group)
 
     if algorithm.upper() == "OLS_C":
-        ramp_data.dbg_run_c_code = True
+        ramp_data.run_c_code = True
 
     return ramp_fit_data(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, algorithm, weighting, max_cores, dqflags

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -40,7 +40,7 @@ class RampData:
         self.suppress_one_group_ramps = False
 
         # C code debugging switch.
-        self.dbg_run_c_code = False
+        self.run_c_code = False
 
         self.one_groups_locs = None  # One good group locations.
         self.one_groups_time = None  # Time to use for one good group ramps.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3678](https://jira.stsci.edu/browse/JP-3678)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #8618

<!-- describe the changes comprising this PR here -->

This PR addresses an error in multiprocessing with the selection of the OLS_C algorithm.  The C extension flag was not properly passed to the sliced data when prepared for multiprocessing, so the old python code ran, even the the C extension was selected.  The C extension selection is now properly passed to the sliced data, so the C extension will be run when multiprocessing is selected.

**Checklist**

- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
