### PR TITLE
fix devdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,8 @@ deps =
     devdeps: scipy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
     devdeps: astropy>=0.0.dev0
-    devdeps: tweakreg>=0.0.dev0
     devdeps: requests>=0.0.dev0
+    devdeps: tweakwcs @ git+https://github.com/spacetelescope/tweakwcs.git
 use_develop = true
 pass_env =
     CI


### PR DESCRIPTION
The devdeps tests are failing due to a failure to find a `tweakreg` dependency:
https://github.com/spacetelescope/stcal/actions/runs/10099805963/job/27929757174

https://github.com/spacetelescope/stcal/blob/5fbabf672bc4f9a5c1eb522bc7b8896a6a5dfcc8/tox.ini#L65

This PR fixes the typo to use `tweakwcs` and installs it from git (as I don't believe pre-releases are common for `tweakwcs`).

**Checklist**

- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
