### PR TITLE
JP-3669: Updating the C Extension to do CHARGELOSS Read Noise Recalculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ __pycache__/
 *$py.class
 *~
 
+# Temp files
+*.*.swp
+
 # C extensions
 *.so
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ General
 
 - Add TweakReg submodule. [#267]
 
+ramp_fitting
+~~~~~~~~~~~~
+
+- Move the CHARGELOSS read noise variance recalculation from the JWST step
+  code to the C extension to simply the code and improve performance.[#275]
+
 Changes to API
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ ramp_fitting
 ~~~~~~~~~~~~
 
 - Move the CHARGELOSS read noise variance recalculation from the JWST step
-  code to the C extension to simply the code and improve performance.[#275]
+  code to the C extension to simplify the code and improve performance.[#275]
 
 Changes to API
 --------------

--- a/changes/275.general.rst
+++ b/changes/275.general.rst
@@ -1,0 +1,2 @@
+[ramp_fitting] Moving the read noise recalculation due to CHARGELOSS flagging from
+the JWST ramp fit step code into the STCAL ramp fit C-extension.

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -665,6 +665,7 @@ def ols_ramp_fit_single(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, we
         The tuple of computed optional results arrays for fitting.
     """
     use_c = ramp_data.run_c_code
+    # use_c = True
     if use_c:
         c_start = time.time()
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -665,7 +665,6 @@ def ols_ramp_fit_single(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, we
         The tuple of computed optional results arrays for fitting.
     """
     use_c = ramp_data.run_c_code
-    use_c = True
     if use_c:
         c_start = time.time()
 

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -665,7 +665,7 @@ def ols_ramp_fit_single(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, we
         The tuple of computed optional results arrays for fitting.
     """
     use_c = ramp_data.run_c_code
-    # use_c = True
+    use_c = True
     if use_c:
         c_start = time.time()
 
@@ -921,6 +921,7 @@ def discard_miri_groups(ramp_data):
     data = ramp_data.data
     err = ramp_data.err
     groupdq = ramp_data.groupdq
+    orig_gdq = ramp_data.orig_gdq
 
     n_int, ngroups, nrows, ncols = data.shape
 
@@ -950,6 +951,8 @@ def discard_miri_groups(ramp_data):
     if num_bad_slices > 0:
         data = data[:, num_bad_slices:, :, :]
         err = err[:, num_bad_slices:, :, :]
+        if orig_gdq is not None:
+            orig_gdq = orig_gdq[:, num_bad_slices:, :, :]
 
     log.info("Number of leading groups that are flagged as DO_NOT_USE: %s", num_bad_slices)
 
@@ -969,6 +972,8 @@ def discard_miri_groups(ramp_data):
         data = data[:, :-1, :, :]
         err = err[:, :-1, :, :]
         groupdq = groupdq[:, :-1, :, :]
+        if orig_gdq is not None:
+            orig_gdq = orig_gdq[:, :-1, :, :]
 
         log.info("MIRI dataset has all pixels in the final group flagged as DO_NOT_USE.")
 
@@ -982,6 +987,8 @@ def discard_miri_groups(ramp_data):
     ramp_data.data = data
     ramp_data.err = err
     ramp_data.groupdq = groupdq
+    if orig_gdq is not None:
+        ramp_data.orig_gdq = orig_gdq
 
     return True
 

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -30,7 +30,7 @@ log.setLevel(logging.DEBUG)
 BUFSIZE = 1024 * 300000  # 300Mb cache size for data section
 
 
-def create_ramp_fit_class(model, dqflags=None, suppress_one_group=False):
+def create_ramp_fit_class(model, algorithm, dqflags=None, suppress_one_group=False):
     """
     Create an internal ramp fit class from a data model.
 
@@ -59,10 +59,11 @@ def create_ramp_fit_class(model, dqflags=None, suppress_one_group=False):
         dark_current_array = model.average_dark_current
 
     orig_gdq = None
-    wh_chargeloss = np.where(np.bitwise_and(model.groupdq.astype(np.uint32), dqflags['CHARGELOSS']))
-    if len(wh_chargeloss[0]) > 0:
-        orig_gdq = model.groupdq.copy()
-    del wh_chargeloss
+    if algorithm.upper() == "OLS_C":
+        wh_chargeloss = np.where(np.bitwise_and(model.groupdq.astype(np.uint32), dqflags['CHARGELOSS']))
+        if len(wh_chargeloss[0]) > 0:
+            orig_gdq = model.groupdq.copy()
+        del wh_chargeloss
 
     if isinstance(model.data, u.Quantity):
         ramp_data.set_arrays(model.data.value, model.err.value, model.groupdq,
@@ -182,7 +183,7 @@ def ramp_fit(
     # Create an instance of the internal ramp class, using only values needed
     # for ramp fitting from the to remove further ramp fitting dependence on
     # data models.
-    ramp_data = create_ramp_fit_class(model, dqflags, suppress_one_group)
+    ramp_data = create_ramp_fit_class(model, algorithm, dqflags, suppress_one_group)
 
     if algorithm.upper() == "OLS_C":
         ramp_data.run_c_code = True

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -91,6 +91,7 @@ def create_ramp_fit_class(model, algorithm, dqflags=None, suppress_one_group=Fal
     if "zero_frame" in model.meta.exposure and model.meta.exposure.zero_frame:
         ramp_data.zeroframe = model.zeroframe
 
+    ramp_data.algorithm = algorithm
     ramp_data.set_dqflags(dqflags)
     ramp_data.start_row = 0
     ramp_data.num_rows = ramp_data.data.shape[2]

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -58,11 +58,22 @@ def create_ramp_fit_class(model, dqflags=None, suppress_one_group=False):
     else:
         dark_current_array = model.average_dark_current
 
+    orig_gdq = None
+    wh_chargeloss = np.where(np.bitwise_and(model.groupdq.astype(np.uint32), dqflags.group['CHARGELOSS']))
+    if len(wh_chargeloss[0]) > 0:
+        orig_gdq = model.groupdq.copy()
+
     if isinstance(model.data, u.Quantity):
         ramp_data.set_arrays(model.data.value, model.err.value, model.groupdq,
                              model.pixeldq, dark_current_array)
     else:
-        ramp_data.set_arrays(model.data, model.err, model.groupdq, model.pixeldq, dark_current_array)
+        ramp_data.set_arrays(
+            model.data,
+            model.err,
+            model.groupdq,
+            model.pixeldq,
+            dark_current_array,
+            orig_gdq)
 
     # Attribute may not be supported by all pipelines.  Default is NoneType.
     drop_frames1 = model.meta.exposure.drop_frames1 if hasattr(model, "drop_frames1") else None

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -59,9 +59,10 @@ def create_ramp_fit_class(model, dqflags=None, suppress_one_group=False):
         dark_current_array = model.average_dark_current
 
     orig_gdq = None
-    wh_chargeloss = np.where(np.bitwise_and(model.groupdq.astype(np.uint32), dqflags.group['CHARGELOSS']))
+    wh_chargeloss = np.where(np.bitwise_and(model.groupdq.astype(np.uint32), dqflags['CHARGELOSS']))
     if len(wh_chargeloss[0]) > 0:
         orig_gdq = model.groupdq.copy()
+    del wh_chargeloss
 
     if isinstance(model.data, u.Quantity):
         ramp_data.set_arrays(model.data.value, model.err.value, model.groupdq,

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -78,6 +78,11 @@ class RampData:
         average_dark_current : ndarray (float32)
             2-D array containing the average dark current. It has
             dimensions (nrows, ncols)
+
+        orig_gdq : ndarray
+            4-D array containing a copy of the original group DQ array.  Since
+            the group DQ array can be modified during ramp fitting, this keeps
+            around the original group DQ flags passed to ramp fitting.
         """
         # Get arrays from the data model
         self.data = data

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -12,6 +12,7 @@ class RampData:
 
         # Needed for CHARGELOSS recomputation
         self.orig_gdq = None
+        self.algorithm = None
 
         # Meta information
         self.instrument_name = None
@@ -144,7 +145,8 @@ class RampData:
         self.flags_saturated = dqflags["SATURATED"]
         self.flags_no_gain_val = dqflags["NO_GAIN_VALUE"]
         self.flags_unreliable_slope = dqflags["UNRELIABLE_SLOPE"]
-        self.flags_chargeloss = dqflags["CHARGELOSS"]
+        if self.algorithm is not None and self.algorithm.upper() == "OLS_C":
+            self.flags_chargeloss = dqflags["CHARGELOSS"]
 
     def dbg_print_types(self):
         # Arrays from the data model

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -25,6 +25,7 @@ class RampData:
         self.flags_saturated = None
         self.flags_no_gain_val = None
         self.flags_unreliable_slope = None
+        self.flags_chargeloss = None
 
         # ZEROFRAME
         self.zframe_mat = None
@@ -131,6 +132,7 @@ class RampData:
         self.flags_saturated = dqflags["SATURATED"]
         self.flags_no_gain_val = dqflags["NO_GAIN_VALUE"]
         self.flags_unreliable_slope = dqflags["UNRELIABLE_SLOPE"]
+        self.flags_chargeloss = dqflags["CHARGELOSS"]
 
     def dbg_print_types(self):
         # Arrays from the data model
@@ -199,6 +201,16 @@ class RampData:
             print(f"[{integ}] {self.groupdq[integ, :, row, col]}")
         # print(f"    err :\n{self.err[:, :, row, col]}")
         # print(f"    pixeldq :\n{self.pixeldq[row, col]}")
+
+    def dbg_print_info(self):
+        print(" ")
+        nints, ngroups, nrows, ncols = self.data.shape
+        for row in range(nrows):
+            for col in range(ncols):
+                print("=" * 80)
+                print(f"**** Pixel ({row}, {col}) ****")
+                self.dbg_print_pixel_info(row, col)
+        print("=" * 80)
 
     def dbg_write_ramp_data_pix_pre(self, fname, row, col, fd):
         fd.write("def create_ramp_data_pixel():\n")

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -10,6 +10,9 @@ class RampData:
         self.pixeldq = None
         self.average_dark_current = None
 
+        # Needed for CHARGELOSS recomputation
+        self.orig_gdq = None
+
         # Meta information
         self.instrument_name = None
 
@@ -42,13 +45,15 @@ class RampData:
 
         # C code debugging switch.
         self.run_c_code = False
+        self.run_chargeloss = True
+        # self.run_chargeloss = False
 
         self.one_groups_locs = None  # One good group locations.
         self.one_groups_time = None  # Time to use for one good group ramps.
 
         self.current_integ = -1
 
-    def set_arrays(self, data, err, groupdq, pixeldq, average_dark_current):
+    def set_arrays(self, data, err, groupdq, pixeldq, average_dark_current, orig_gdq=None):
         """
         Set the arrays needed for ramp fitting.
 
@@ -80,6 +85,8 @@ class RampData:
         self.groupdq = groupdq
         self.pixeldq = pixeldq
         self.average_dark_current = average_dark_current
+
+        self.orig_gdq = orig_gdq
 
     def set_meta(self, name, frame_time, group_time, groupgap, nframes, drop_frames1=None):
         """

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -2255,17 +2255,8 @@ ols_slope_fit_pixels(
             }
 
             if (rd->run_chargeloss) {
-                if (is_pix_in_list(pr)) {
-                    print_delim();
-                    dbg_ols_print("    Pixel: (%ld, %ld)\n", pr->row, pr->col);
-                    dbg_ols_print("var_rnoise = %.12f\n", pr->rate.var_rnoise);
-                }
                 if (ramp_fit_pixel_rnoise_chargeloss(rd, pr)) {
                     return 1;
-                }
-                if (is_pix_in_list(pr)) {
-                    dbg_ols_print("var_rnoise = %.12f\n", pr->rate.var_rnoise);
-                    print_delim();
                 }
             }
 
@@ -2574,15 +2565,8 @@ ramp_fit_pixel_rnoise_chargeloss(
     /* Remove any left over junk in the memory, just in case */
     memset(&segs, 0, sizeof(segs));
 
-    if (is_pix_in_list(pr)) {
-        print_delim();
-    }
-
     for (integ=0; integ < pr->nints; ++integ) {
         if (0 == pr->stats[integ].chargeloss) {
-            if (is_pix_in_list(pr)) {
-                dbg_ols_print("Integ %ld, var_rnoise = %.12f\n", integ, pr->rateints[integ].var_rnoise);
-            }
             /* No CHARGELOSS flag in integration */
             if (pr->rateints[integ].var_rnoise > 0.) {
                 invvar_r = 1. / pr->rateints[integ].var_rnoise;
@@ -2602,9 +2586,6 @@ ramp_fit_pixel_rnoise_chargeloss(
             goto END;
         }
         /*  Compute integration read noise */
-        if (is_pix_in_list(pr)) {
-            dbg_ols_print("Integ %ld, var_rnoise = %.12f\n", integ, pr->rateints[integ].var_rnoise);
-        }
         invvar_r = ramp_fit_pixel_rnoise_chargeloss_segs(rd, pr, &segs, integ);
         evar_r += invvar_r; /* Exposure level read noise */
 
@@ -2619,10 +2600,6 @@ ramp_fit_pixel_rnoise_chargeloss(
     /* Capture recomputed exposure level read noise variance */
     if (evar_r > 0.) {
         pr->rate.var_rnoise = 1. / evar_r;
-    }
-    if (is_pix_in_list(pr)) {
-        dbg_ols_print("var_rnoise = %.12f\n", pr->rate.var_rnoise);
-        print_delim();
     }
     if (pr->rate.var_rnoise >= LARGE_VARIANCE_THRESHOLD) {
         pr->rate.var_rnoise = 0.;
@@ -2649,9 +2626,6 @@ ramp_fit_pixel_rnoise_chargeloss_segs(
 
     /* Compute readnoise for new segments */
     for (current = segs->head; current; current = current->flink) {
-        if (is_pix_in_list(pr)) {
-            dbg_ols_print("    Length %zd\n", current->length);
-        }
         if (1==current->length) {
             timing = segment_len1_timing(rd, pr, integ);
             svar_r = segment_rnoise_len1(rd, pr, timing);
@@ -2660,9 +2634,6 @@ ramp_fit_pixel_rnoise_chargeloss_segs(
         } else {
             seglen = (real_t)current->length;
             svar_r = segment_rnoise_default(rd, pr, seglen);
-        }
-        if (is_pix_in_list(pr)) {
-            dbg_ols_print("    (s:%ld, e%ld) svar_r = %.12f\n", current->start, current->end, svar_r);
         }
         if (svar_r > 0.) {
             invvar_r += (1. / svar_r);
@@ -3018,16 +2989,6 @@ ramp_fit_pixel_integration_fit_slope_seg_len2(
     /* Segment total variance */
     // seg->var_e = 2. * pr->rnoise * pr->rnoise;  /* XXX Is this right? */
     seg->var_e = seg->var_p + seg->var_r;
-#if 0
-    if (is_pix_in_list(pr)) {
-        tmp = sqrt2 * pr->rnoise;
-        dbg_ols_print("rnoise     = %.10f\n", pr->rnoise);
-        dbg_ols_print("seg->var_s = %.10f\n", tmp);
-        dbg_ols_print("seg->var_p = %.10f\n", seg->var_p);
-        dbg_ols_print("seg->var_r = %.10f\n", seg->var_r);
-        dbg_ols_print("seg->var_e = %.10f\n", seg->var_e);
-    }
-#endif
 
     if (rd->save_opt) {
         seg->sigslope = sqrt2 * pr->rnoise;

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -2242,8 +2242,6 @@ ols_slope_fit_pixels(
 {
     npy_intp row, col;
 
-    // dbg_ols_print("run_chargeloss = %d\n", rd->run_chargeloss);
-
     for (row = 0; row < rd->nrows; ++row) {
         for (col = 0; col < rd->ncols; ++col) {
 
@@ -2568,25 +2566,12 @@ ramp_fit_pixel_rnoise_chargeloss(
     /* Remove any left over junk in the memory, just in case */
     memset(&segs, 0, sizeof(segs));
 
-    if (is_pix_in_list(pr)) {
-        print_delim();
-        dbg_ols_print("    Pixel (%ld, %ld) [Beginning]\n", pr->row, pr->col);
-    }
-
     for (integ=0; integ < pr->nints; ++integ) {
-        if (is_pix_in_list(pr)) {
-            dbg_ols_print(" ---- Integration %ld ----\n", integ);
-        }
         if (0 == pr->stats[integ].chargeloss) {
             /* No CHARGELOSS flag in integration */
             if (pr->rateints[integ].var_rnoise > 0.) {
                 invvar_r = 1. / pr->rateints[integ].var_rnoise;
                 evar_r += invvar_r; /* Exposure level read noise */
-            }
-            if (is_pix_in_list(pr)) {
-                dbg_ols_print("pr->rateints[%ld].var_rnoise %.12f\n", integ, pr->rateints[integ].var_rnoise);
-                dbg_ols_print("invvar_r = %.12f\n", invvar_r);
-                dbg_ols_print("evar_r = %.12f\n", evar_r);
             }
             continue;
         }
@@ -2611,12 +2596,6 @@ ramp_fit_pixel_rnoise_chargeloss(
         invvar_r = ramp_fit_pixel_rnoise_chargeloss_segs(rd, pr, &segs, integ);
         evar_r += invvar_r; /* Exposure level read noise */
 
-        if (is_pix_in_list(pr)) {
-            dbg_ols_print("pr->rateints[%ld].var_rnoise %.12f\n", integ, pr->rateints[integ].var_rnoise);
-            dbg_ols_print("invvar_r = %.12f\n", invvar_r);
-            dbg_ols_print("evar_r = %.12f\n", evar_r);
-        }
-
         /*  Clean segment list */
         clean_segment_list_basic(&segs);
     }
@@ -2629,18 +2608,11 @@ ramp_fit_pixel_rnoise_chargeloss(
     if (evar_r > 0.) {
         pr->rate.var_rnoise = 1. / evar_r;
     }
-    if (is_pix_in_list(pr)) {
-        dbg_ols_print("Recomputed pr->rate.var_rnoise = %.12f\n", pr->rate.var_rnoise);
-    }
     if (pr->rate.var_rnoise >= LARGE_VARIANCE_THRESHOLD) {
         pr->rate.var_rnoise = 0.;
     }
 
 END:
-    if (is_pix_in_list(pr)) {
-        dbg_ols_print("    Chargeloss Ending\n");
-        print_delim();
-    }
     clean_segment_list_basic(&segs); /* Just in case */
     return ret;
 }

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1050,6 +1050,7 @@ compute_integration_segments(
     uint32_t * groupdq = pr->groupdq + integ * pr->ngroups;
     npy_intp idx, start, end;
     int in_seg=0;
+    struct segment_list * segs = &(pr->segs[integ]);
 
     /* If the whole integration is saturated, then no valid slope. */
     if (groupdq[0] & rd->sat) {
@@ -1076,7 +1077,7 @@ compute_integration_segments(
             if (in_seg) {
                 /* The end of a segment is detected. */
                 end = idx;
-                if (add_segment_to_list(&(pr->segs[integ]), start, end)) {
+                if (add_segment_to_list(segs, start, end)) {
                     return 1;
                 }
                 in_seg = 0;
@@ -1086,7 +1087,7 @@ compute_integration_segments(
     /* The last segment of the integration is at the end of the integration */
     if (in_seg) {
         end = idx;
-        if (add_segment_to_list(&(pr->segs[integ]), start, end)) {
+        if (add_segment_to_list(segs, start, end)) {
             return 1;
         }
     }
@@ -1097,7 +1098,7 @@ compute_integration_segments(
      * the first first one group segment is used and all subsequent
      * one group segments are discarded.
      */
-    prune_segment_list(&(pr->segs[integ]));
+    prune_segment_list(segs);
 
     return ret;
 }

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -403,7 +403,8 @@ clean_segment_list(npy_intp nints, struct segment_list * segs);
 
 static int
 compute_integration_segments(
-    struct ramp_data * rd, struct pixel_ramp * pr, npy_intp integ);
+    struct ramp_data * rd, struct pixel_ramp * pr, struct segment_list * segs,
+    npy_intp integ);
 
 static int
 create_opt_res(struct opt_res_product * opt_res, struct ramp_data * rd);
@@ -1044,13 +1045,13 @@ static int
 compute_integration_segments(
         struct ramp_data * rd,  /* Ramp fitting data */
         struct pixel_ramp * pr, /* Pixel ramp fitting data */
+        struct segment_list * segs,
         npy_intp integ)         /* Current integration */
 {
     int ret = 0;
     uint32_t * groupdq = pr->groupdq + integ * pr->ngroups;
     npy_intp idx, start, end;
     int in_seg=0;
-    struct segment_list * segs = &(pr->segs[integ]);
 
     /* If the whole integration is saturated, then no valid slope. */
     if (groupdq[0] & rd->sat) {
@@ -2493,7 +2494,7 @@ ramp_fit_pixel_integration(
 {
     int ret = 0;
 
-    if (compute_integration_segments(rd, pr, integ)) {
+    if (compute_integration_segments(rd, pr, &(pr->segs[integ]), integ)) {
         ret = 1;
         goto END;
     }

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1616,17 +1616,17 @@ def test_cext_chargeloss():
 
     sdata, sdq, svp, svr, serr = slopes
 
-    # Comopare slopes
+    # Compare slopes
     assert sdata[0, 1] == sdata[0, 0]
     assert sdata[0, 1] == sdata[0, 2]
     assert sdata[0, 1] == sdata[0, 3]
 
-    # Comopare Poisson variances
+    # Compare Poisson variances
     assert svp[0, 1] != svp[0, 0]
     assert svp[0, 1] == svp[0, 2]
     assert svp[0, 1] != svp[0, 3]
 
-    # Comopare total variances
+    # Compare total variances
     assert serr[0, 1] != serr[0, 0]
     assert serr[0, 1] == serr[0, 2]
     assert serr[0, 1] != serr[0, 3]

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1616,20 +1616,6 @@ def test_cext_chargeloss():
 
     sdata, sdq, svp, svr, serr = slopes
 
-    print(" ")
-    print(DELIM)
-    print("test_cext_chargeloss")
-    print(DELIM)
-    print("Slopes")
-    print(sdata)
-    print(DELIM)
-    print("Read Noise")
-    print(svr)
-    print(DELIM)
-    print("Poisson")
-    print(svp)
-    print(DELIM)
-
     # Comopare slopes
     assert sdata[0, 1] == sdata[0, 0]
     assert sdata[0, 1] == sdata[0, 2]

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1607,6 +1607,8 @@ def test_cext_chargeloss():
     ramp.data[0, :, 0, 3] = np.array(arr)
     ramp.groupdq[0, 3, 0, 3] = JUMP
 
+    ramp.orig_gdq = ramp.groupdq.copy()
+
     save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1563,7 +1563,6 @@ def test_refcounter():
     assert b_dc == a_dc
 
 
-#@pytest.mark.skip("Not ready, yet")
 def test_cext_chargeloss():
     """
     Testing the recomputation of read noise due to CHARGELOSS.  Wherever

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1577,15 +1577,17 @@ def test_cext_chargeloss():
     2. A jump at group 3 (zero based) and SATURATED starting at group 7.
     3. A jump at group 3 (zero based).
 
-    Except for the read hoise all values in pixel 1 should be equal to  pixel
-    2, but the read noise should be equal to pixel 3.
-    The slope should be the same for all pixels.
+    The slope should be the same for all pixels.  Variances differ.
     """
     nints, ngroups, nrows, ncols = 1, 10, 1, 4
     rnval, gval = 0.7071, 1.
     # frame_time, nframes, groupgap = 1., 1, 0
     frame_time, nframes, groupgap = 10.6, 1, 0
     group_time = 10.6
+
+    dims = nints, ngroups, nrows, ncols
+    var = rnval, gval
+    tm = frame_time, nframes, groupgap
     ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
 
     ramp.run_c_code = True  # Need to make this default in future

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1614,14 +1614,31 @@ def test_cext_chargeloss():
 
     sdata, sdq, svp, svr, serr = slopes
 
+    print(" ")
+    print(DELIM)
+    print("test_cext_chargeloss")
+    print(DELIM)
+    print("Slopes")
+    print(sdata)
+    print(DELIM)
+    print("Read Noise")
+    print(svr)
+    print(DELIM)
+    print("Poisson")
+    print(svp)
+    print(DELIM)
+
+    # Comopare slopes
     assert sdata[0, 1] == sdata[0, 0]
     assert sdata[0, 1] == sdata[0, 2]
     assert sdata[0, 1] == sdata[0, 3]
 
+    # Comopare Poisson variances
     assert svp[0, 1] != svp[0, 0]
     assert svp[0, 1] == svp[0, 2]
     assert svp[0, 1] != svp[0, 3]
 
+    # Comopare total variances
     assert serr[0, 1] != serr[0, 0]
     assert serr[0, 1] == serr[0, 2]
     assert serr[0, 1] != serr[0, 3]

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1610,8 +1610,9 @@ def test_cext_chargeloss():
     ramp.groupdq[0, 3, 0, 3] = JUMP
 
     ramp.orig_gdq = ramp.groupdq.copy()
+    ramp.flags_chargeloss = dqflags["CHARGELOSS"]
 
-    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS_C"
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -21,7 +21,7 @@ dqflags = {
     "DO_NOT_USE": 2**0,  # Bad pixel. Do not use.
     "SATURATED": 2**1,  # Pixel saturated during exposure.
     "JUMP_DET": 2**2,  # Jump detected during exposure.
-    "CHARGELOSS":       2**7,   # Charge migration (was RESERVED_4)
+    "CHARGELOSS": 2**7,   # Charge migration (was RESERVED_4)
     "NO_GAIN_VALUE": 2**19,  # Gain cannot be measured.
     "UNRELIABLE_SLOPE": 2**24,  # Slope variance large (i.e., noisy pixel).
 }
@@ -1563,6 +1563,7 @@ def test_refcounter():
     assert b_dc == a_dc
 
 
+@pytest.mark.skip("Not ready, yet")
 def test_chargeloss():
     nints, ngroups, nrows, ncols = 1, 10, 1, 4
     rnval, gval = 0.7071, 1.

--- a/tests/test_ramp_fitting_cases.py
+++ b/tests/test_ramp_fitting_cases.py
@@ -32,6 +32,7 @@ dqflags = {
     "DO_NOT_USE": 2**0,  # Bad pixel. Do not use.
     "SATURATED": 2**1,  # Pixel saturated during exposure.
     "JUMP_DET": 2**2,  # Jump detected during exposure.
+    "CHARGELOSS": 2**7,   # Charge migration (was RESERVED_4)
     "NO_GAIN_VALUE": 2**19,  # Gain cannot be measured.
     "UNRELIABLE_SLOPE": 2**24,  # Slope variance large (i.e., noisy pixel).
 }
@@ -40,6 +41,7 @@ GOOD = dqflags["GOOD"]
 DNU = dqflags["DO_NOT_USE"]
 SAT = dqflags["SATURATED"]
 JUMP = dqflags["JUMP_DET"]
+CHRGL = dqflags["CHARGELOSS"]
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_ramp_fitting_gls_fit.py
+++ b/tests/test_ramp_fitting_gls_fit.py
@@ -4,12 +4,13 @@ import pytest
 from stcal.ramp_fitting.ramp_fit import ramp_fit_class, ramp_fit_data
 
 test_dq_flags = {
-    "GOOD": 0,
-    "DO_NOT_USE": 1,
-    "SATURATED": 2,
-    "JUMP_DET": 4,
-    "NO_GAIN_VALUE": 8,
-    "UNRELIABLE_SLOPE": 16,
+    "GOOD": 0,  # Good pixel.
+    "DO_NOT_USE": 2**0,  # Bad pixel. Do not use.
+    "SATURATED": 2**1,  # Pixel saturated during exposure.
+    "JUMP_DET": 2**2,  # Jump detected during exposure.
+    "CHARGELOSS": 2**7,   # Charge migration (was RESERVED_4)
+    "NO_GAIN_VALUE": 2**19,  # Gain cannot be measured.
+    "UNRELIABLE_SLOPE": 2**24,  # Slope variance large (i.e., noisy pixel).
 }
 
 GOOD = test_dq_flags["GOOD"]
@@ -18,6 +19,7 @@ JUMP_DET = test_dq_flags["JUMP_DET"]
 SATURATED = test_dq_flags["SATURATED"]
 NO_GAIN_VALUE = test_dq_flags["NO_GAIN_VALUE"]
 UNRELIABLE_SLOPE = test_dq_flags["UNRELIABLE_SLOPE"]
+CHRGL = test_dq_flags["CHARGELOSS"]
 
 DELIM = "-" * 70
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3669](https://jira.stsci.edu/browse/JP-3669)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #8601

<!-- describe the changes comprising this PR here -->

This PR addresses the read noise variance recalculation based on the CHARGELOSS flag.  This recalculation was in the JWST ramp fit step code, but that came with a performance hit and was unnecessarily complicated.  The recalculation has been implemented in the C extension code, simplifying the ramp fitting, as well as improving performance.

There is a corresponding JWST PR that removes the CHARGELOSS recalculation from the step code, as well as removes the corresponding test. https://github.com/spacetelescope/jwst/pull/8678

The regression tests pass, except for one test.  The test failure has been confirmed to be incorrect.  The regression test truth file for this test needs to be updated:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1623/

**Checklist**

- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
