### PR TITLE
JP-3664: Numpy 2.0 incompatibility with existing use of newbyteorder

### DIFF
--- a/changes/282.bugfix.rst
+++ b/changes/282.bugfix.rst
@@ -1,0 +1,1 @@
+Implement byteorder swap method that is forward-compatible with numpy 2.0 in jwst ramp_fitting.

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -731,7 +731,7 @@ def handle_array_endianness(arr, sys_order):
     arr_order = arr.dtype.byteorder
     bswap = False
     if (arr_order == ">" and sys_order == "<") or (arr_order == "<" and sys_order == ">"):
-        arr.newbyteorder('S').byteswap(inplace=True)
+        arr.view(arr.dtype.newbyteorder('S')).byteswap(inplace=True)
         bswap = True
 
     return arr, bswap

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -687,9 +687,9 @@ def ols_ramp_fit_single(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, we
         # ramp fitting.
         rn_bswap, gain_bswap = bswap
         if rn_bswap:
-            readnoise_2d.newbyteorder('S').byteswap(inplace=True)
+            readnoise_2d.view(readnoise_2d.dtype.newbyteorder('S')).byteswap(inplace=True)
         if gain_bswap:
-            gain_2d.newbyteorder('S').byteswap(inplace=True)
+            gain_2d.view(gain_2d.dtype.newbyteorder('S')).byteswap(inplace=True)
 
         c_diff = c_end - c_start
         log.info(f"Ramp Fitting C Time: {c_diff}")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3664](https://jira.stsci.edu/browse/JP-3664)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Partially closes [jwst/#8580](https://github.com/spacetelescope/jwst/issues/8580)

<!-- describe the changes comprising this PR here -->

This PR addresses a change in behavior for numpy 2.0: 

> arr.newbyteorder('S').byteswap(inplace=True)
> \>\>\> AttributeError: `newbyteorder` was removed from the ndarray class in NumPy 2.0. Use arr.view(arr.dtype.newbyteorder(order))' instead.


This PR implements the dtype method.

**Checklist**

- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
