### PR TITLE
JP-3689: Fix logic operator

### DIFF
--- a/changes/285.bugfix.rst
+++ b/changes/285.bugfix.rst
@@ -1,0 +1,1 @@
+[jump] Fix a logical bug in the jump step for usage of > vs >= per JP-3689.

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -972,7 +972,7 @@ def find_faint_extended(
 
     first_diffs_masked = np.ma.masked_array(first_diffs, mask=np.isnan(first_diffs))
     warnings.filterwarnings("ignore")
-    if nints > minimum_sigclip_groups:
+    if nints >= minimum_sigclip_groups:
         mean, median, stddev = stats.sigma_clipped_stats(first_diffs_masked, sigma=5, axis=0)
     else:
         median_diffs = np.nanmedian(first_diffs_masked, axis=(0, 1))


### PR DESCRIPTION
This PR fixes the mismatch in > vs >= operators described in the jump step by JP-3689.

**Checklist**

- [ ] for a public change, added a towncrier news fragment in `changes/`: <details><summary>`echo "changed something" > changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.apichange.rst``: change to public API
    - ``changes/<PR#>.bugfix.rst``: fixes an issue
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
