### PR TITLE
Add optional parameter to alignment methods and handle catalog web service connection issues.

### DIFF
--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -46,6 +46,7 @@ def relative_align(correctors: list,
                    fitgeometry: str = "rshift",
                    nclip: int = 3,
                    sigma: float = 3.0,
+                   clip_accum: bool = False,
                    ) -> list:
 
     if separation <= _SQRT2 * tolerance:
@@ -73,7 +74,8 @@ def relative_align(correctors: list,
             match=xyxymatch,
             fitgeom=fitgeometry,
             nclip=nclip,
-            sigma=(sigma, "rmse")
+            sigma=(sigma, "rmse"),
+            clip_accum=clip_accum,
         )
 
     except ValueError as e:
@@ -124,7 +126,8 @@ def absolute_align(correctors: list,
                    abs_minobj: int = 15,
                    abs_fitgeometry: str = "rshift",
                    abs_nclip: int = 3,
-                   abs_sigma: float = 3.0,) -> list:
+                   abs_sigma: float = 3.0,
+                   clip_accum: bool = False,) -> list:
 
     if abs_separation <= _SQRT2 * abs_tolerance:
         msg = ("Parameter 'abs_separation' must be larger than "
@@ -183,7 +186,8 @@ def absolute_align(correctors: list,
             match=xyxymatch_gaia,
             fitgeom=abs_fitgeometry,
             nclip=abs_nclip,
-            sigma=(abs_sigma, "rmse")
+            sigma=(abs_sigma, "rmse"),
+            clip_accum=clip_accum,
         )
     except ValueError as e:
         msg = e.args[0]


### PR DESCRIPTION
Resolves [RCAL-908](https://jira.stsci.edu/browse/RCAL-908)

This PR add an optional parameter -- `clip_accum` -- to the alignment methods in `stcal.tweakreg`. This is necessary because JWST and Roman do not use the same value when it comes to that parameter. The default value for that parameter in `align_wcs()` is False, which is what JWST uses. However, `clip_accum=True` seems to significantly improve the fitting results for Roman (as compared with `clip_accum=False`).

This PR also adds the ability to better handle catalog web services connectivity issues.

**Checklist**

- [ ] for a public change, added a towncrier news fragment in `changes/`: <details><summary>`echo "changed something" > changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.apichange.rst``: change to public API
    - ``changes/<PR#>.bugfix.rst``: fixes an issue
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
