### PR TITLE
update checklist for new pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ This PR addresses ...
 ## Tasks
 - [ ] update or add relevant tests
 - [ ] update relevant docstrings and / or `docs/` page
-- [ ] Does this PR change the public API? (if not, label with `no-changelog-entry-needed`)
+- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
   - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
   - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
     - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 


### PR DESCRIPTION
restructure the pull request checklist to be more useful and less clunky

# old checklist

**Checklist**

- [ ] for a public change, added a towncrier news fragment in `changes/`: <details><summary>`echo "changed something" > changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.apichange.rst``: change to public API
    - ``changes/<PR#>.bugfix.rst``: fixes an issue
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- [ ] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)

# new checklist

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>