### PR TITLE
JP-3734: Making OLS_C Default for CI Tests

### DIFF
--- a/changes/289.general.rst
+++ b/changes/289.general.rst
@@ -1,0 +1,1 @@
+[ramp_fitting] Changing the default algorithm for ramp fitting to be ``OLS_C`` for CI tests.

--- a/changes/289.general.rst
+++ b/changes/289.general.rst
@@ -1,1 +1,3 @@
 [ramp_fitting] Changing the default algorithm for ramp fitting to be ``OLS_C`` for CI tests.
+               It also fixes a bug related to ``RampData.run_chargeloss`` defaulting to 
+               ``True``.  That parameter now defaults to ``False``.

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -64,6 +64,9 @@ def create_ramp_fit_class(model, algorithm, dqflags=None, suppress_one_group=Fal
         wh_chargeloss = np.where(np.bitwise_and(model.groupdq.astype(np.uint32), dqflags['CHARGELOSS']))
         if len(wh_chargeloss[0]) > 0:
             orig_gdq = model.groupdq.copy()
+            ramp_data.run_chargeloss = True
+        else:
+            ramp_data.run_chargeloss = False
         del wh_chargeloss
 
     if isinstance(model.data, u.Quantity):

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -49,7 +49,6 @@ class RampData:
         # C code debugging switch.
         self.run_c_code = True
         self.run_chargeloss = False
-        # self.run_chargeloss = False
 
         self.one_groups_locs = None  # One good group locations.
         self.one_groups_time = None  # Time to use for one good group ramps.

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -47,8 +47,8 @@ class RampData:
         self.suppress_one_group_ramps = False
 
         # C code debugging switch.
-        self.run_c_code = False
-        self.run_chargeloss = True
+        self.run_c_code = True
+        self.run_chargeloss = False
         # self.run_chargeloss = False
 
         self.one_groups_locs = None  # One good group locations.

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -32,6 +32,8 @@ SAT = dqflags["SATURATED"]
 JUMP = dqflags["JUMP_DET"]
 CHRGL = dqflags["CHARGELOSS"]
 
+DEFAULT_ALGO = "OLS_C"
+
 
 # -----------------------------------------------------------------------------
 #                           Test Suite
@@ -52,7 +54,7 @@ def test_long_integration():
 
     ramp_data.data[0, 291:, 0, 0] = 320 * 3
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise_array, gain_array,
         algo, wt, ncores, dqflags)
@@ -80,7 +82,7 @@ def base_neg_med_rates_single_integration():
     ramp_data.data[0, :, 0, 0] = neg_ramp
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -163,7 +165,7 @@ def base_neg_med_rates_multi_integrations():
         ramp_data.data[k, :, 0, 0] = neg_ramp * n
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -249,7 +251,7 @@ def base_neg_med_rates_single_integration_multi_segment():
     ramp_data.groupdq[0, 10, 1, 0] = dqflags["JUMP_DET"]
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -296,7 +298,7 @@ def test_neg_with_avgdark():
     ramp_data.average_dark_current[:] = 1.0
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
         )
@@ -345,7 +347,7 @@ def test_utils_dq_compress_final():
     ramp_data.groupdq[0, :, 0, 1] = np.array([dqflags["SATURATED"]] * ngroups)
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, False, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, False, DEFAULT_ALGO, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -424,7 +426,7 @@ def test_miri_ramp_dnu_at_ramp_beginning():
     ramp_data.groupdq[0, 1, 0, 0] = dqflags["DO_NOT_USE"]
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes1, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -446,7 +448,7 @@ def test_miri_ramp_dnu_and_jump_at_ramp_beginning():
     ramp_data.groupdq[0, 1, 0, 0] = dqflags["JUMP_DET"]
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes2, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -519,7 +521,7 @@ def test_2_group_cases():
     ramp_data.set_dqflags(dqflags)
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_ALGO, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -593,7 +595,7 @@ def run_one_group_ramp_suppression(nints, suppress):
 
     ramp_data.suppress_one_group_ramps = suppress
 
-    algo = "OLS"
+    algo = DEFAULT_ALGO
     save_opt, ncores, bufsize = False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise2d, gain2d, algo, "optimal", ncores, dqflags
@@ -870,7 +872,7 @@ def test_zeroframe():
     """
     ramp_data, gain, rnoise = create_zero_frame_data()
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_ALGO, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -989,7 +991,7 @@ def test_only_good_0th_group():
     # Dimensions are (1, 5, 1, 3)
     ramp_data, gain, rnoise = create_only_good_0th_group_data()
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_ALGO, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1038,7 +1040,7 @@ def test_all_sat():
     ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
     ramp.groupdq[:, 0, :, :] = ramp.flags_saturated
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_ALGO, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1068,7 +1070,7 @@ def test_dq_multi_int_dnu():
     ramp.data[1, :, 0, 0] = np.array(base_arr)
     ramp.groupdq[0, :, 0, 0] = np.array(dq_arr)
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_ALGO, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1165,7 +1167,7 @@ def test_multi_more_cores_than_rows():
                 ramp.data[integ, :, row, col] = bramp
                 bramp = bramp * factor
 
-    bufsize, algo, save_opt, ncores = 512, "OLS", False, "all"
+    bufsize, algo, save_opt, ncores = 512, DEFAULT_ALGO, False, "all"
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1316,7 +1318,7 @@ def test_new_saturation():
     """
     ramp, gain, rnoise = get_new_saturation()
 
-    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, DEFAULT_ALGO
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1408,7 +1410,7 @@ def test_invalid_integrations():
 
     ramp.suppress_one_group_ramps = True
 
-    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, DEFAULT_ALGO
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1472,7 +1474,7 @@ def test_one_group():
 
     ramp.data[0, 0, 0, 0] = 105.31459
 
-    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, DEFAULT_ALGO
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1590,7 +1592,8 @@ def test_cext_chargeloss():
     tm = frame_time, nframes, groupgap
     ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
 
-    ramp.run_c_code = True  # Need to make this default in future
+    ramp.run_chargeloss = True
+    ramp.run_c_code = True
     base = 15.
     arr = [(k+1) * base for k in range(ngroups)]
 
@@ -1671,6 +1674,7 @@ def create_blank_ramp_data(dims, var, tm):
         drop_frames1=None,
     )
     ramp_data.set_dqflags(dqflags)
+    ramp_data.run_chargeloss = False
 
     gain = np.ones(shape=(nrows, ncols), dtype=np.float32) * gval
     rnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * rnval


### PR DESCRIPTION
…ith CHARGELOSS.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3734](https://jira.stsci.edu/browse/JP-3734)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #

<!-- describe the changes comprising this PR here -->

The JWST default algorithm was changed to be OLS_C for ramp fitting.  The STCAL ramp fit testing has been changed to reflect this change in default algorithm.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
