### PR TITLE
Add fillval option to gwcs_blot

### DIFF
--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -223,7 +223,7 @@ def flag_resampled_crs(
     return mask1_smoothed & mask2
 
 
-def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio):
+def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio, fillval=0.0):
     """
     Resample the median data to recreate an input image based on
     the blot wcs.
@@ -236,7 +236,7 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio):
     median_wcs : gwcs.wcs.WCS
         The wcs for the median data.
 
-    blot_shape : list of int
+    blot_shape : tuple of int
         The target blot data shape.
 
     blot_wcs : gwcs.wcs.WCS
@@ -244,6 +244,9 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio):
 
     pix_ratio : float
         Pixel ratio.
+
+    fillval : float, optional
+        Fill value for missing data.
 
     Returns
     -------
@@ -259,7 +262,7 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio):
     log.debug("Sci shape: {}".format(blot_shape))
     log.info('Blotting {} <-- {}'.format(blot_shape, median_data.shape))
 
-    outsci = np.zeros(blot_shape, dtype=np.float32)
+    outsci = np.full(blot_shape, fillval, dtype=np.float32)
 
     # Currently tblot cannot handle nans in the pixmap, so we need to give some
     # other value.  -1 is not optimal and may have side effects.  But this is
@@ -267,7 +270,7 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio):
     # before a change is made.  Preferably, fix tblot in drizzle.
     pixmap[np.isnan(pixmap)] = -1
     tblot(median_data, pixmap, outsci, scale=pix_ratio, kscale=1.0,
-          interp='linear', exptime=1.0, misval=0.0, sinscl=1.0)
+          interp='linear', exptime=1.0, misval=fillval, sinscl=1.0)
 
     return outsci
 

--- a/tests/outlier_detection/test_utils.py
+++ b/tests/outlier_detection/test_utils.py
@@ -118,6 +118,30 @@ def test_gwcs_blot():
     np.testing.assert_equal(blotted, median_data[:blot_shape[0], :blot_shape[1]])
 
 
+@pytest.mark.parametrize('fillval', [0.0, np.nan])
+def test_gwcs_blot_fillval(fillval):
+    # set up a very simple wcs that scales by 1x
+    output_frame = gwcs.Frame2D(name="world")
+    forward_transform = models.Scale(1) & models.Scale(1)
+
+    median_shape = (10, 10)
+    median_data = np.arange(100, dtype=np.float32).reshape((10, 10))
+    median_wcs = gwcs.WCS(forward_transform, output_frame=output_frame)
+    blot_shape = (20, 20)
+    blot_wcs = gwcs.WCS(forward_transform, output_frame=output_frame)
+    pix_ratio = 1.0
+
+    blotted = gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs,
+                        pix_ratio, fillval=fillval)
+
+    # since the blot data is larger and the wcs are equivalent the blot
+    # will contain the median data + some fill values
+    assert blotted.shape == blot_shape
+    np.testing.assert_equal(blotted[:median_shape[0], :median_shape[1]], median_data)
+    np.testing.assert_equal(blotted[median_shape[0]:, :], fillval)
+    np.testing.assert_equal(blotted[:, median_shape[1]:], fillval)
+
+
 def test_calc_gwcs_pixmap():
     # generate 2 wcses with different scales
     output_frame = gwcs.Frame2D(name="world")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->


<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->

Currently the `gwcs_blot` function always fills missing data with 0.0.  JWST data uses NaN as the missing value filler for resample by default, so it would be nice to be able to set NaN as the missing value for blotted images too.  This PR just adds the option, defaulting to the existing value of 0.0.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
