### PR TITLE
Enable style checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: detect-private-key
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
+      # - id: end-of-file-fixer
+      # - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
@@ -22,26 +22,26 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
-    hooks:
-      - id: codespell
-        args: ["--write-changes"]
-        additional_dependencies:
-          - tomli
+  # - repo: https://github.com/codespell-project/codespell
+  #   rev: v2.2.5
+  #   hooks:
+  #     - id: codespell
+  #       args: ["--write-changes"]
+  #       additional_dependencies:
+  #         - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.1.5"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
-      - id: ruff-format
+      # - id: ruff-format
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.15.0
     hooks:
       - id: cython-lint
-      - id: double-quote-cython-strings
+      # - id: double-quote-cython-strings
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
@@ -57,7 +57,7 @@ repos:
         additional_dependencies:
           - black==22.12.0
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.1"
-    hooks:
-      - id: prettier
+  # - repo: https://github.com/pre-commit/mirrors-prettier
+  #   rev: "v3.0.1"
+  #   hooks:
+  #     - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,9 +61,3 @@ repos:
     rev: "v3.0.1"
     hooks:
       - id: prettier
-
-  - repo: https://github.com/scientific-python/cookie
-    rev: 2023.10.27
-    hooks:
-      - id: sp-repo-review
-        additional_dependencies: ["repo-review[cli]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,50 +120,50 @@ src = [
 ]
 
 [tool.ruff.lint]
-extend-select = [
-    "F",      # Pyflakes (part of default flake8)
-    "W", "E", # pycodestyle (part of default flake8)
-    "I",      # isort (import sorting)
+select = [
+    #"F",      # Pyflakes (part of default flake8)
+    #"W", "E", # pycodestyle (part of default flake8)
+    #"I",      # isort (import sorting)
     # "N",      # pep8-naming
-    "D",      # pydocstyle (docstring style guide)
-    "UP",     # pyupgrade (upgrade code to modern python)
+    #"D",      # pydocstyle (docstring style guide)
+    #"UP",     # pyupgrade (upgrade code to modern python)
     "YTT",    # flake8-2020 (system version info)
     "ANN",    # flake8-annotations (best practices for type annotations)
-    "S",      # flake8-bandit (security checks)
+    #"S",      # flake8-bandit (security checks)
     "BLE",    # flake8-blind-except (prevent blind except statements)
-    "B",      # flake8-bugbear (prevent common gotcha bugs)
+    #"B",      # flake8-bugbear (prevent common gotcha bugs)
     "A",      # flake8-builtins (prevent shadowing of builtins)
     "C4",     # flake8-comprehensions (best practices for comprehensions)
     "T10",    # flake8-debugger (prevent debugger statements in code)
-    "EM",     # flake8-errormessages (best practices for error messages)
+    #"EM",     # flake8-errormessages (best practices for error messages)
     "FA",     # flake8-future-annotations (correct usage future annotations)
     "ISC",    # flake8-implicit-str-concat (prevent implicit string concat)
     "ICN",    # flake8-import-conventions (enforce import conventions)
-    "G",      # flake8-logging-format (best practices for logging)
+    #"G",      # flake8-logging-format (best practices for logging)
     "INP",    # flake8-no-pep420 (prevent use of PEP420, i.e. implicit name spaces)
-    "PIE",    # flake8-pie (misc suggested improvement linting)
+    #"PIE",    # flake8-pie (misc suggested improvement linting)
     # "T20",    # flake8-print (prevent print statements in code)
-    "PT",     # flake8-pytest-style (best practices for pytest)
-    "Q",      # flake8-quotes (best practices for quotes)
+    #"PT",     # flake8-pytest-style (best practices for pytest)
+    #"Q",      # flake8-quotes (best practices for quotes)
     "RSE",    # flake8-raise (best practices for raising exceptions)
-    "RET",    # flake8-return (best practices for return statements)
-    "SLF",    # flake8-self (prevent private member access)
+    #"RET",    # flake8-return (best practices for return statements)
+    #"SLF",    # flake8-self (prevent private member access)
     "SLOT",   # flake8-slots (require __slots__ for immutable classes)
-    "SIM",    # flake8-simplify (suggest simplifications to code where possible)
+    #"SIM",    # flake8-simplify (suggest simplifications to code where possible)
     "TID",    # flake8-tidy-imports (prevent banned api and best import practices)
     "TCH",    # flake8-type-checking (move type checking imports into type checking blocks)
     "INT",    # flake8-gettext (when to use printf style strings)
     # "ARG",    # flake8-unused-arguments (prevent unused arguments)
-    "PTH",    # flake8-use-pathlib (prefer pathlib over os.path)
+    #"PTH",    # flake8-use-pathlib (prefer pathlib over os.path)
     # "ERA",    # eradicate (remove commented out code)
     "PGH",    # pygrep (simple grep checks)
-    "PL",     # pylint (general linting, flake8 alternative)
-    "TRY",    # tryceratops (linting for try/except blocks)
+    #"PL",     # pylint (general linting, flake8 alternative)
+    #"TRY",    # tryceratops (linting for try/except blocks)
     "FLY",    # flynt (f-string conversion where possible)
-    "NPY",    # NumPy-specific checks (recommendations from NumPy)
-    "PERF",   # Perflint (performance linting)
+    #"NPY",    # NumPy-specific checks (recommendations from NumPy)
+    #"PERF",   # Perflint (performance linting)
     "LOG",
-    "RUF",    # ruff specific checks
+    #"RUF",    # ruff specific checks
 ]
 ignore = [
     "ISC001", # interferes with formatter
@@ -235,14 +235,6 @@ line_length = 110
 
 [tool.codespell]
 skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
-
-[tool.repo-review]
-ignore = [
-    "GH200",  # Use dependabot
-    "PC140",  # add MyPy to pre-commit
-    "PC901",  # custom pre-comit.ci message
-    "MY100",  # Use MyPy
-]
 
 [tool.cibuildwheel.macos]
 archs = [

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     pre-commit
 commands =
     pre-commit install-hooks
-    pre-commit run {posargs:--color always --all-files --show-diff-on-failure}
+    pre-commit run --color always --all-files --show-diff-on-failure {posargs}
 
 [testenv:check-build]
 description = check build sdist/wheel and a strict twine check for metadata


### PR DESCRIPTION
Style checks (via pre-commit) have not been checking any files in this repo as part of the CI.
See this recent run on main:
https://github.com/spacetelescope/stcal/actions/runs/11017955113/job/30597119856#step:10:63
With all checks showing:
```
check for added large files..........................(no files to check)Skipped
```
If I run them locally I see a large number of automatic changes:
36 files changed, 1091 insertions(+), 942 deletions(-)
and even after these see 79 ruff errors, many from codespell and 6 from reporeview.

In an effort to check something this PR:
- fixes the `check-style` job to check files
- disables all failing ruff and pre-commit rules (maybe we can re-enable these one-by-one in follow-up PRs)

With this PR the checks run:
https://github.com/spacetelescope/stcal/actions/runs/11130795981/job/30930929199?pr=293#step:10:49

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
