### PR TITLE
Adjust style checks to align with jwst

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+exclude: ".*\\.asdf$"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -15,49 +17,20 @@ repos:
       # - id: end-of-file-fixer
       # - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: rst-directive-colons
-      - id: rst-inline-touching-normal
-      - id: text-unicode-replacement-char
-
-  # - repo: https://github.com/codespell-project/codespell
-  #   rev: v2.2.5
-  #   hooks:
-  #     - id: codespell
-  #       args: ["--write-changes"]
-  #       additional_dependencies:
-  #         - tomli
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.5"
+    rev: 'v0.5.2'
     hooks:
       - id: ruff
-        args: ["--fix", "--show-fixes"]
+        args: ["--fix"]
       # - id: ruff-format
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        args: ["-r", "-ll", "src", "tests"]
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.15.0
     hooks:
       - id: cython-lint
-      # - id: double-quote-cython-strings
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (cython)
-        types: [cython]
-
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies:
-          - black==22.12.0
-
-  # - repo: https://github.com/pre-commit/mirrors-prettier
-  #   rev: "v3.0.1"
-  #   hooks:
-  #     - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: ".*\\.asdf$"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -18,19 +18,19 @@ repos:
       # - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.5.2'
+    rev: 'v0.6.8'
     hooks:
       - id: ruff
         args: ["--fix"]
       # - id: ruff-format
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.9
+    rev: 1.7.10
     hooks:
       - id: bandit
         args: ["-r", "-ll", "src", "tests"]
 
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.15.0
+    rev: v0.16.2
     hooks:
       - id: cython-lint

--- a/changes/295.general.rst
+++ b/changes/295.general.rst
@@ -1,0 +1,1 @@
+Adjust code style checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,69 +120,12 @@ src = [
 ]
 
 [tool.ruff.lint]
-select = [
-    #"F",      # Pyflakes (part of default flake8)
-    #"W", "E", # pycodestyle (part of default flake8)
-    #"I",      # isort (import sorting)
-    # "N",      # pep8-naming
-    #"D",      # pydocstyle (docstring style guide)
-    #"UP",     # pyupgrade (upgrade code to modern python)
-    "YTT",    # flake8-2020 (system version info)
-    "ANN",    # flake8-annotations (best practices for type annotations)
-    #"S",      # flake8-bandit (security checks)
-    "BLE",    # flake8-blind-except (prevent blind except statements)
-    #"B",      # flake8-bugbear (prevent common gotcha bugs)
-    "A",      # flake8-builtins (prevent shadowing of builtins)
-    "C4",     # flake8-comprehensions (best practices for comprehensions)
-    "T10",    # flake8-debugger (prevent debugger statements in code)
-    #"EM",     # flake8-errormessages (best practices for error messages)
-    "FA",     # flake8-future-annotations (correct usage future annotations)
-    "ISC",    # flake8-implicit-str-concat (prevent implicit string concat)
-    "ICN",    # flake8-import-conventions (enforce import conventions)
-    #"G",      # flake8-logging-format (best practices for logging)
-    "INP",    # flake8-no-pep420 (prevent use of PEP420, i.e. implicit name spaces)
-    #"PIE",    # flake8-pie (misc suggested improvement linting)
-    # "T20",    # flake8-print (prevent print statements in code)
-    #"PT",     # flake8-pytest-style (best practices for pytest)
-    #"Q",      # flake8-quotes (best practices for quotes)
-    "RSE",    # flake8-raise (best practices for raising exceptions)
-    #"RET",    # flake8-return (best practices for return statements)
-    #"SLF",    # flake8-self (prevent private member access)
-    "SLOT",   # flake8-slots (require __slots__ for immutable classes)
-    #"SIM",    # flake8-simplify (suggest simplifications to code where possible)
-    "TID",    # flake8-tidy-imports (prevent banned api and best import practices)
-    "TCH",    # flake8-type-checking (move type checking imports into type checking blocks)
-    "INT",    # flake8-gettext (when to use printf style strings)
-    # "ARG",    # flake8-unused-arguments (prevent unused arguments)
-    #"PTH",    # flake8-use-pathlib (prefer pathlib over os.path)
-    # "ERA",    # eradicate (remove commented out code)
-    "PGH",    # pygrep (simple grep checks)
-    #"PL",     # pylint (general linting, flake8 alternative)
-    #"TRY",    # tryceratops (linting for try/except blocks)
-    "FLY",    # flynt (f-string conversion where possible)
-    #"NPY",    # NumPy-specific checks (recommendations from NumPy)
-    #"PERF",   # Perflint (performance linting)
-    "LOG",
-    #"RUF",    # ruff specific checks
+extend-select = [
+    "I",  # isort
 ]
 ignore = [
-    "ISC001", # interferes with formatter
-    "PLR0912", # Too many branches
-    "PLR0913", # Too many arguments
-    "PLR0915", # Too many statements
-    "PLR2004", # Magic value used in comparison
-    "ANN101", # Missing type annotation for self in method
-    "ANN102", # Missing type annotation for cls in classmethod
-
-    # Pydocstyle (to fix over time
-    "D100", # Undocumented public module
-    "D101", # Undocumented public class
-    "D102", # Undocumented public method
-    "D103", # Undocumented public function
-    "D104", # Undocumented public package
-    "D205", # 1 blank line required between summary line and description
-    "D401", # First line of docstring should be in imperative mood
-    "D404", # First word of docstring should not be This
+    # "E741", # ambiguous variable name (O/0, l/I, etc.)
+    # "E722", # Do not use bare `except`
 ]
 exclude = [
     "docs",
@@ -191,18 +134,6 @@ exclude = [
     ".tox",
     ".eggs",
 ]
-
-[tool.ruff.lint.extend-per-file-ignores]
-"tests/*.py" = [
-    "S101",
-    "D",
-]
-
-[tool.ruff.lint.pydocstyle]
-convention = "numpy"
-
-[tool.ruff.lint.flake8-annotations]
-ignore-fully-untyped = true  # Turn of annotation checking for fully untyped code
 
 [tool.mypy]
 python_version = "3.12"

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import functools
 import logging
 import re
-from typing import TYPE_CHECKING
 import warnings
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -758,7 +758,6 @@ def extend_ellipses(
             saty, satx = np.where(sat_pix == sat_flag)
             jump_ellipse[saty, satx] = 0
             out_gdq_cube[intg, flg_grp, :, :] = np.bitwise_or(gdq_cube[intg, flg_grp, :, :], jump_ellipse)
-    diff_cube = out_gdq_cube - gdq_cube
     return out_gdq_cube, num_ellipses
 
 def find_last_grp(grp, ngrps, num_grps_masked):

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -3,12 +3,10 @@ import multiprocessing
 import time
 import warnings
 
-import numpy as np
-import cv2 as cv
 import astropy.stats as stats
-
-from astropy.convolution import Ring2DKernel
-from astropy.convolution import convolve
+import cv2 as cv
+import numpy as np
+from astropy.convolution import Ring2DKernel, convolve
 
 from . import constants
 from . import twopoint_difference as twopt

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 
 import numpy as np
-import warnings
 from astropy import stats
 
 log = logging.getLogger(__name__)

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -489,7 +489,6 @@ def calc_med_first_diffs(in_first_diffs):
         return np.nan
 
     if first_diffs.ndim == 2:  # in the case where input is a single pixel
-        nansum = np.sum(np.isnan(first_diffs), axis=(0, 1))
         num_usable_diffs = first_diffs.size - np.sum(np.isnan(first_diffs), axis=(0, 1))
         if num_usable_diffs >= 4:  # if 4+, clip largest and return median
             mask = np.ones_like(first_diffs).astype(bool)
@@ -499,7 +498,6 @@ def calc_med_first_diffs(in_first_diffs):
         elif num_usable_diffs == 3:  # if 3, no clipping just return median
             return np.nanmedian(first_diffs)
         elif num_usable_diffs == 2:  # if 2, return diff with minimum abs
-            TEST = np.nanargmin(np.abs(first_diffs))
             diff_min_idx = np.nanargmin(first_diffs)
             location = np.unravel_index(diff_min_idx, first_diffs.shape)
             return first_diffs[location]

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -1,18 +1,18 @@
 """
 Utility functions for outlier detection routines
 """
-import warnings
 
+import logging
+
+import gwcs
 import numpy as np
 from astropy.stats import sigma_clip
 from drizzle.cdrizzle import tblot
 from scipy import ndimage
 from skimage.util import view_as_windows
-import gwcs
 
 from stcal.alignment.util import wcs_bbox_from_shape
 
-import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/src/stcal/ramp_fitting/likely_algo_classes.py
+++ b/src/stcal/ramp_fitting/likely_algo_classes.py
@@ -291,8 +291,6 @@ class Covar:
         # try to avoid problems with roundoff error
         da_incr = da * (countrates[np.newaxis, :] + sig**2)
 
-        dalpha = da_incr * self.alpha_phnoise[:, np.newaxis]
-        dbeta = da_incr * self.beta_phnoise[:, np.newaxis]
         result_high_a = fit_ramps(z, self, sig, countrateguess=countrates + da_incr)
         # finite difference approximation to dw/da
 

--- a/src/stcal/ramp_fitting/likely_algo_classes.py
+++ b/src/stcal/ramp_fitting/likely_algo_classes.py
@@ -278,6 +278,9 @@ class Covar:
             Bias of the best-fit count rate from using cvec plus the observed
             resultants to estimate the covariance matrix.
         """
+
+        from .likely_fit import fit_ramps
+
         alpha = countrates[np.newaxis, :] * self.alpha_phnoise[:, np.newaxis]
         alpha += sig**2 * self.alpha_readnoise[:, np.newaxis]
         beta = countrates[np.newaxis, :] * self.beta_phnoise[:, np.newaxis]

--- a/src/stcal/ramp_fitting/likely_fit.py
+++ b/src/stcal/ramp_fitting/likely_fit.py
@@ -1,20 +1,13 @@
 #! /usr/bin/env python
 
 import logging
-import multiprocessing
-import time
-import scipy
-import sys
 import warnings
 
-from multiprocessing import cpu_count
-from pprint import pprint
-
 import numpy as np
+import scipy
 
-from . import ramp_fit_class, utils
-from .likely_algo_classes import IntegInfo, RampResult, Covar
-
+from . import utils
+from .likely_algo_classes import Covar, IntegInfo, RampResult
 
 DELIM = "=" * 80
 SQRT2 = np.sqrt(2)

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -2,16 +2,15 @@
 
 import logging
 import multiprocessing
+import sys
 import time
 import warnings
 from multiprocessing import cpu_count
-import sys
 
 import numpy as np
 
-from .slope_fitter import ols_slope_fitter  # c extension
 from . import ramp_fit_class, utils
-
+from .slope_fitter import ols_slope_fitter  # c extension
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -262,8 +262,8 @@ def ramp_fit_data(
     ngroups = ramp_data.data.shape[1]
     if algorithm.upper() == "LIKELY" and ngroups < likely_fit.LIKELY_MIN_NGROUPS:
         log.info("When selecting the LIKELY ramp fitting algorithm the"
-                  " ngroups needs to be a minimum of {likely_fit.LIKELY_MIN_NGROUPS},"
-                  " but ngroups = {ngroups}.  Due to this, the ramp fitting algorithm"
+                  f" ngroups needs to be a minimum of {likely_fit.LIKELY_MIN_NGROUPS},"
+                  f" but ngroups = {ngroups}.  Due to this, the ramp fitting algorithm"
                   " is being changed to OLS_C")
         algorithm = "OLS_C"
 

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -19,9 +19,9 @@ import numpy as np
 from astropy import units as u
 
 from . import (
-    gls_fit,    # used only if algorithm is "GLS"
-    likely_fit, # used only if algorithm is "LIKELY"
-    ols_fit,    # used only if algorithm is "OLS"
+    gls_fit,  # used only if algorithm is "GLS"
+    likely_fit,  # used only if algorithm is "LIKELY"
+    ols_fit,  # used only if algorithm is "OLS"
     ramp_fit_class,
 )
 
@@ -261,7 +261,7 @@ def ramp_fit_data(
     # a minimum of a four group ramp is needed.
     ngroups = ramp_data.data.shape[1]
     if algorithm.upper() == "LIKELY" and ngroups < likely_fit.LIKELY_MIN_NGROUPS:
-        log.info(f"When selecting the LIKELY ramp fitting algorithm the"
+        log.info("When selecting the LIKELY ramp fitting algorithm the"
                   " ngroups needs to be a minimum of {likely_fit.LIKELY_MIN_NGROUPS},"
                   " but ngroups = {ngroups}.  Due to this, the ramp fitting algorithm"
                   " is being changed to OLS_C")

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -209,10 +209,10 @@ class RampData:
 
     def dbg_print_pixel_info(self, row, col):
         print("-" * 80)
-        print(f"    data")
+        print("    data")
         for integ in range(self.data.shape[0]):
             print(f"[{integ}] {self.data[integ, :, row, col]}")
-        print(f"    groupdq")
+        print("    groupdq")
         for integ in range(self.data.shape[0]):
             print(f"[{integ}] {self.groupdq[integ, :, row, col]}")
         # print(f"    err :\n{self.err[:, :, row, col]}")
@@ -280,8 +280,8 @@ class RampData:
 
         # XXX Make this a separate function
         delimiter = "-" * 40
-        fd.write(f"{indent}# {delimiter}\n\n");
-        fd.write(f"{indent}# ({row}, {col})\n\n");
+        fd.write(f"{indent}# {delimiter}\n\n")
+        fd.write(f"{indent}# ({row}, {col})\n\n")
 
         nints = self.data.shape[0]
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -6,7 +6,6 @@ import warnings
 
 import numpy as np
 
-
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/tests/outlier_detection/test_utils.py
+++ b/tests/outlier_detection/test_utils.py
@@ -1,20 +1,20 @@
 import warnings
 
 import gwcs
-import pytest
 import numpy as np
+import pytest
 import scipy.signal
 from astropy.modeling import models
 
 from stcal.outlier_detection.utils import (
     _abs_deriv,
+    calc_gwcs_pixmap,
     compute_weight_threshold,
     flag_crs,
     flag_resampled_crs,
     gwcs_blot,
-    calc_gwcs_pixmap,
-    reproject,
     medfilt,
+    reproject,
 )
 
 

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -10,17 +10,17 @@ from gwcs import coordinate_frames as cf
 
 from stcal.alignment import resample_utils
 from stcal.alignment.util import (
+    _compute_fiducial_from_footprints,
+    _sregion_to_footprint,
     _validate_wcs_list,
     compute_fiducial,
-    _compute_fiducial_from_footprints,
     compute_s_region_imaging,
     compute_s_region_keyword,
     compute_scale,
     reproject,
-    _sregion_to_footprint,
     wcs_bbox_from_shape,
     wcs_from_footprints,
-    wcs_from_sregions
+    wcs_from_sregions,
 )
 
 

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,16 +1,17 @@
 """Tests of custom testing infrastructure"""
 
-import pytest
 import numpy as np
+import pytest
+
 from stcal.testing_helpers import MemoryThreshold, MemoryThresholdExceeded
 
 
 def test_memory_threshold():
     with MemoryThreshold("10 KB"):
-        buff = np.ones(1000, dtype=np.uint8)
+        buff = np.ones(1000, dtype=np.uint8)  # noqa: F841
 
 
 def test_memory_threshold_exceeded():
     with pytest.raises(MemoryThresholdExceeded):
         with MemoryThreshold("500. B"):
-            buff = np.ones(10000, dtype=np.uint8)
+            buff = np.ones(10000, dtype=np.uint8)  # noqa: F841

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -1,16 +1,16 @@
 import numpy as np
 import pytest
 from astropy.io import fits
+
 from stcal.jump.jump import (
     calc_num_slices,
+    detect_jumps,
     extend_saturation,
     find_ellipses,
     find_faint_extended,
+    find_last_grp,
     flag_large_events,
     point_inside_ellipse,
-    find_first_good_group,
-    detect_jumps,
-    find_last_grp
 )
 
 DQFLAGS = {"JUMP_DET": 4, "SATURATED": 2, "DO_NOT_USE": 1, "GOOD": 0, "NO_GAIN_VALUE": 8,

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -207,7 +207,6 @@ def test_extend_saturation_simple():
     cube = np.zeros(shape=(5, 7, 7), dtype=np.uint8)
     persist_jumps = np.zeros(shape=(7, 7), dtype=np.uint8)
     grp = 1
-    min_sat_radius_extend = 1
     cube[1, 3, 3] = DQFLAGS["SATURATED"]
     cube[1, 2, 3] = DQFLAGS["SATURATED"]
     cube[1, 3, 4] = DQFLAGS["SATURATED"]
@@ -484,42 +483,6 @@ def test_find_faint_extended_sigclip():
 
     #  Check that the flags are not applied in the 3rd group after the event
     assert np.all(gdq[0, 4, 12:22, 14:23]) == 0
-
-# No shower is found because the event is identical in all ints
-def test_find_faint_extended_sigclip():
-    nint, ngrps, ncols, nrows = 101, 6, 30, 30
-    data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
-    gdq = np.zeros_like(data, dtype=np.uint8)
-    pdq = np.zeros(shape=(nrows, ncols), dtype=np.int32)
-    gain = 4
-    readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
-    rng = np.random.default_rng(12345)
-    data[0, 1:, 14:20, 15:20] = 6 * gain * 1.7
-    data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
-    gdq, num_showers = find_faint_extended(data, gdq, pdq, readnoise, 1, 100,
-                                           snr_threshold=1.3,
-                                           min_shower_area=20, inner=1,
-                                           outer=2, sat_flag=2, jump_flag=4,
-                                           ellipse_expand=1.1, num_grps_masked=3,
-                                           dqflags=DQFLAGS)
-    #  Check that all the expected samples in group 2 are flagged as jump and
-    #  that they are not flagged outside
-    assert (np.all(gdq[0, 1, 22, 14:23] == 0))
-    assert (np.all(gdq[0, 1, 21, 16:20] == 0))
-    assert (np.all(gdq[0, 1, 20, 15:22] == 0))
-    assert (np.all(gdq[0, 1, 19, 15:23] == 0))
-    assert (np.all(gdq[0, 1, 18, 14:23] == 0))
-    assert (np.all(gdq[0, 1, 17, 14:23] == 0))
-    assert (np.all(gdq[0, 1, 16, 14:23] == 0))
-    assert (np.all(gdq[0, 1, 15, 14:22] == 0))
-    assert (np.all(gdq[0, 1, 14, 16:22] == 0))
-    assert (np.all(gdq[0, 1, 13, 17:21] == 0))
-    assert (np.all(gdq[0, 1, 12, 14:23] == 0))
-    assert (np.all(gdq[0, 1, 12:23, 24] == 0))
-    assert (np.all(gdq[0, 1, 12:23, 13] == 0))
-
-    #  Check that the flags are not applied in the 3rd group after the event
-    assert (np.all(gdq[0, 4, 12:22, 14:23]) == 0)
 
 
 def test_inside_ellipse5():

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1838,7 +1838,8 @@ def dbg_print(string):
     """
     Print string with line number and filename.
     """
-    import inspect, os
+    import inspect
+    import os
     cf = inspect.currentframe()
     line_number = cf.f_back.f_lineno
     finfo = inspect.getframeinfo(cf.f_back)

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1,13 +1,11 @@
-import pytest
-import numpy as np
-
 import sys
+
+import numpy as np
 
 from stcal.ramp_fitting.ramp_fit import ramp_fit_data
 from stcal.ramp_fitting.ramp_fit_class import RampData
 from stcal.ramp_fitting.slope_fitter import ols_slope_fitter  # c extension
 from stcal.ramp_fitting.utils import compute_num_slices
-
 
 DELIM = "=" * 70
 

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1474,7 +1474,6 @@ def test_one_group():
     sdata, sdq, svp, svr, serr = slopes
 
     # XXX JP-3121: this is the value from python, which may not be correct
-    chk_data = 1.9618962  
     chk_dq = 0
     chk_var_p = 0.02923839
     chk_var_r = 0.03470363
@@ -1482,7 +1481,6 @@ def test_one_group():
 
 
     # XXX Investigate.  Now python may be wrong.
-    # assert abs(sdata[0, 0] - chk_data) < tol
     assert sdq[0, 0] == chk_dq
     assert abs(svp[0, 0] - chk_var_p) < tol
     assert abs(svr[0, 0] - chk_var_r) < tol
@@ -1576,7 +1574,6 @@ def test_cext_chargeloss():
     rnval, gval = 0.7071, 1.
     # frame_time, nframes, groupgap = 1., 1, 0
     frame_time, nframes, groupgap = 10.6, 1, 0
-    group_time = 10.6
 
     dims = nints, ngroups, nrows, ncols
     var = rnval, gval

--- a/tests/test_ramp_fitting_cases.py
+++ b/tests/test_ramp_fitting_cases.py
@@ -1,7 +1,6 @@
 import inspect
 from pathlib import Path
 
-import pytest
 import numpy as np
 import numpy.testing as npt
 

--- a/tests/test_ramp_fitting_likely_fit.py
+++ b/tests/test_ramp_fitting_likely_fit.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pytest
 
-from stcal.ramp_fitting.ramp_fit import ramp_fit_class, ramp_fit_data
-from stcal.ramp_fitting.ramp_fit_class import RampData
 from stcal.ramp_fitting.likely_fit import likely_ramp_fit
-
+from stcal.ramp_fitting.ramp_fit import ramp_fit_data
+from stcal.ramp_fitting.ramp_fit_class import RampData
 
 test_dq_flags = {
     "GOOD": 0,

--- a/tests/test_ramp_fitting_likely_fit.py
+++ b/tests/test_ramp_fitting_likely_fit.py
@@ -610,7 +610,7 @@ def dbg_print_slopes(slope, pix=(0, 0), label=None):
 
 def dbg_print_cube(cube, pix=(0, 0), label=None):
     data, dq, vp, vr, err = cube
-    data1, dq1, vp1, vr1, err1 = cube1
+    data1, dq1, vp1, vr1, err1 = cube1  # noqa: F821
     row, col = pix
     nints = data1.shape[0]
 

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -1,13 +1,14 @@
 """Test astrometric utility functions for alignment"""
 
+import contextlib
 import copy
 from copy import deepcopy
 from pathlib import Path
 
 import asdf
-import contextlib
 import numpy as np
 import pytest
+import requests
 from astropy.modeling.models import Shift
 from astropy.table import Table
 from astropy.time import Time
@@ -23,7 +24,6 @@ from stcal.tweakreg.tweakreg import (
     relative_align,
 )
 from stcal.tweakreg.utils import _wcsinfo_from_wcs_transform
-import requests
 
 # Define input GWCS specification to be used for these tests
 WCS_NAME = "mosaic_long_i2d_gwcs.asdf"  # Derived using B7.5 Level 3 product

--- a/tests/test_twopoint_difference.py
+++ b/tests/test_twopoint_difference.py
@@ -1,6 +1,6 @@
 import numpy as np
-from astropy.io import fits
 import pytest
+from astropy.io import fits
 
 from stcal.jump.twopoint_difference import calc_med_first_diffs, find_crs
 

--- a/tests/test_twopoint_difference.py
+++ b/tests/test_twopoint_difference.py
@@ -645,7 +645,6 @@ def test_5grps_satat4_crat3(setup_cube):
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS)
     # assert(4 == np.max(out_gdq))  # no CR was found
-    result = out_gdq[0, :, 1, 1]
     assert np.array_equal(
         [0, 0, DQFLAGS['JUMP_DET'], DQFLAGS['SATURATED'], DQFLAGS['SATURATED']],
         out_gdq[0, :, 1, 1])
@@ -758,7 +757,6 @@ def test_median_with_saturation(setup_cube):
     out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(data, gdq, read_noise, rej_threshold,
                                                      rej_threshold, rej_threshold, nframes,
                                                      False, 200, 10, DQFLAGS)
-    gdq_value = out_gdq[0, :, 1, 1]
     assert (np.array_equal([0, 0, 0, 0, 0, 4, 0, 2, 2, 2], out_gdq[0, :, 1, 1]))
 
 


### PR DESCRIPTION
This PR adjusts the style checks to roughly align with jwst (with a few adjustments for things like this package using cython).

For reference the ruff checks and pre-commit hooks for jwst are as follows:
https://github.com/spacetelescope/jwst/blob/e5c73fa23d157f4aa65416b4070c2b838e978494/pyproject.toml#L254
https://github.com/spacetelescope/jwst/blob/dd76184e82c1e863bce22d02de093f9bfe12f16f/.github/workflows/ci.yml

This PR sets the checks in this repo to roughly align:
- use default ruff rules
- extend ruff rules to include isort (which was previously a pre-commit hook in this repo)
- run bandit (like jwst does)
- enable cython-lint (as this package uses cython)

I applied auto-fixes in:
https://github.com/spacetelescope/stcal/pull/295/commits/a85bd00a2ceb5c9f1a26ea5992e04afd28c7741f
These are largely import sorting but I think it's worth a second set of eyes on these changes as I did notice one log message formatting change that likely indicates a bug in the log message (where it's currently not formatting the expected variable):
https://github.com/spacetelescope/stcal/pull/295/commits/a85bd00a2ceb5c9f1a26ea5992e04afd28c7741f#diff-c04284467dcbe86296aa89b83fd434e0dde8a32d790d157a9588ba3c7d169484R264

I then did some manual fixes removing unused variables and a duplicate test in:
https://github.com/spacetelescope/stcal/pull/295/commits/3c59de9a3fecca54438291c716a68e65e89939fa

There are still failures with this PR that I'm not sure how to address.
```

src/stcal/ramp_fitting/likely_algo_classes.py:289:24: F821 Undefined name `fit_ramps`
    |
287 |         n = alpha.shape[0]
288 |         z = np.zeros((len(cvec), len(countrates)))
289 |         result_low_a = fit_ramps(z, self, sig, countrateguess=countrates)
    |                        ^^^^^^^^^ F821
290 | 
291 |         # try to avoid problems with roundoff error
    |

src/stcal/ramp_fitting/likely_algo_classes.py:294:25: F821 Undefined name `fit_ramps`
    |
292 |         da_incr = da * (countrates[np.newaxis, :] + sig**2)
293 | 
294 |         result_high_a = fit_ramps(z, self, sig, countrateguess=countrates + da_incr)
    |                         ^^^^^^^^^ F821
295 |         # finite difference approximation to dw/da
    |

tests/test_ramp_fitting_likely_fit.py:613:34: F821 Undefined name `cube1`
    |
611 | def dbg_print_cube(cube, pix=(0, 0), label=None):
612 |     data, dq, vp, vr, err = cube
613 |     data1, dq1, vp1, vr1, err1 = cube1
    |                                  ^^^^^ F821
614 |     row, col = pix
615 |     nints = data1.shape[0]
```

2 are uses of an undefined `fit_ramps` in `likely_algo_classes.py`:
https://github.com/spacetelescope/stcal/blob/787aa81a6719bb0c72be8972171c7f3f88c8adf0/src/stcal/ramp_fitting/likely_algo_classes.py#L289
These would crash if anything tried to execute that code.

The last one is the use of an undefined `cube` in `dbg_print_cube` (which is unused). Calling this function would crash.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
