### PR TITLE
Isolate jwst/romancal pytest configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,4 @@ jobs:
       envs: |
         - linux: py311-jwst-cov-xdist
         - linux: py311-romancal-cov-xdist
+      coverage: codecov

--- a/changes/297.general.rst
+++ b/changes/297.general.rst
@@ -1,0 +1,1 @@
+Update downstream tests for jwst and romancal to fix pytest configurations.

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     check-{style,build,types}
     test{,-warnings,-cov}-xdist
     test-numpy{120,121,122}
-    test-{jwst,romancal}-xdist
+    test-{jwst,romancal}{,-xdist}{,-cov}
     build-{docs,dist}
 
 # tox environments are constructed with so-called 'factors' (or terms)
@@ -45,18 +45,19 @@ commands =
 [testenv]
 description =
     run tests
-    jwst: of JWST pipeline
-    romancal: of Romancal pipeline
     oldestdeps: with the oldest supported version of key dependencies
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
+change_dir =
+    jwst,romancal: {env_tmp_dir}
 extras =
     test
+allowlist_externals =
+    git
+    jwst,romancal: bash
 deps =
     xdist: pytest-xdist
-    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
-    romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
@@ -71,25 +72,31 @@ deps =
 use_develop = true
 pass_env =
     CI
-    WEBBPSF_PATH
+    romancal: WEBBPSF_PATH
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
-    romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
-    jwst,romancal: CRDS_PATH={package_root}/crds_cache
-    jwst,romancal: CRDS_CLIENT_RETRY_COUNT=3
-    jwst,romancal: CRDS_CLIENT_RETRY_DELAY_SECONDS=20
+    romancal: CRDS_SERVER_URL = https://roman-crds.stsci.edu
+    jwst: CRDS_SERVER_URL = https://jwst-crds.stsci.edu
+    jwst,romancal: CRDS_PATH = {package_root}/crds_cache
+    jwst,romancal: CRDS_CLIENT_RETRY_COUNT = 3
+    jwst,romancal: CRDS_CLIENT_RETRY_DELAY_SECONDS = 20
 commands_pre =
     oldestdeps: minimum_dependencies stcal --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
+    jwst,romancal: bash -c "pip freeze -q | grep 'stcal @' > {env_tmp_dir}/requirements.txt"
+    jwst: git clone https://github.com/spacetelescope/jwst.git
+    romancal: git clone https://github.com/spacetelescope/romancal.git
+    jwst: pip install -e jwst[test]
+    romancal: pip install -e romancal[test]
+    jwst,romancal: pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
     pytest \
     warnings: -W error \
     xdist: -n auto \
-    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=*/scripts/* \
-    romancal: --pyargs romancal \
-    cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
+    jwst: jwst \
+    romancal: romancal \
+    cov: --cov={package_root} --cov-config={package_root}/pyproject.toml --cov-report=term-missing --cov-report=xml \
     {posargs}
 
 [testenv:build-docs]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     check-{style,build,types}
     test{,-warnings,-cov}-xdist
-    test-numpy{120,121,122}
     test-{jwst,romancal}{,-xdist}{,-cov}
     build-{docs,dist}
 


### PR DESCRIPTION
Currently downstream testing of jwst and romancal end up using the pyproject.toml in this repository for determining pytest configuration.
https://github.com/spacetelescope/stcal/actions/runs/11142379456/job/30965215790#step:10:107
This ends up with pytest using options in these downstream tests that differ from the options used by the downstream packages in their tests (when run in their own CI). This in turn results in lots of false failures in our downstream testing.

This PR changes how the jwst and romancal downstream tests to use the pytest options defined in the respective repositories.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
