### PR TITLE
JP-3734: Changed Default CI Test Algorithm to OLS_C

### DIFF
--- a/changes/298.general.rst
+++ b/changes/298.general.rst
@@ -1,0 +1,6 @@
+Changed the default `ramp fitting` CI test algorithm to ``OLS_C``.  This also revealed
+a bug in control flow that allowed for the CHARGELOSS recalculation in error, which
+resulted in a crash while attempting to dereference a ``NULL`` pointer.  Further, when
+creating the optional results product, the object creation was changed to `PyArray_ZEROS`
+to ensure invalid data was set to zero.  The use of `PyArray_EMPTY` does not initialize
+memory, so junk data could be in used array elements.

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -48,13 +48,13 @@ class RampData:
 
         # C code debugging switch.
         self.run_c_code = False
-        self.run_chargeloss = True
-        # self.run_chargeloss = False
 
         self.one_groups_locs = None  # One good group locations.
         self.one_groups_time = None  # Time to use for one good group ramps.
 
         self.current_integ = -1
+
+        self.debug = False
 
     def set_arrays(self, data, err, groupdq, pixeldq, average_dark_current, orig_gdq=None):
         """

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1194,37 +1194,37 @@ create_opt_res(
     dims[3] = rd->ncols;
 
     /* Note fortran = 0 */
-    opt_res->slope = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->slope = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->slope) {
         goto FAILED_ALLOC;
     }
 
-    opt_res->sigslope = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->sigslope = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->sigslope) {
         goto FAILED_ALLOC;
     }
 
-    opt_res->var_p = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->var_p = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->var_p) {
         goto FAILED_ALLOC;
     }
 
-    opt_res->var_r = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->var_r = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->var_r) {
         goto FAILED_ALLOC;
     }
 
-    opt_res->yint = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->yint = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->yint) {
         goto FAILED_ALLOC;
     }
 
-    opt_res->sigyint = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->sigyint = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->sigyint) {
         goto FAILED_ALLOC;
     }
 
-    opt_res->weights = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->weights = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->weights) {
         goto FAILED_ALLOC;
     }
@@ -1232,13 +1232,13 @@ create_opt_res(
     pdims[0] = rd->nints;
     pdims[1] = rd->nrows;
     pdims[2] = rd->ncols;
-    opt_res->pedestal = (PyArrayObject*)PyArray_EMPTY(pnd, pdims, NPY_FLOAT, fortran);
+    opt_res->pedestal = (PyArrayObject*)PyArray_ZEROS(pnd, pdims, NPY_FLOAT, fortran);
     if (!opt_res->pedestal) {
         goto FAILED_ALLOC;
     }
 
     /* XXX */
-    //->cr_mag = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    //->cr_mag = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     opt_res->cr_mag = (PyArrayObject*)Py_None;
 
     return 0;
@@ -2481,10 +2481,12 @@ ramp_fit_pixel(
         goto END;
     }
 #if 0
-    print_delim();
-    dbg_ols_print("Pixel (%ld, %ld)\n", pr->row, pr->col);
-    dbg_ols_print("Median Rate = %.10f\n", pr->median_rate);
-    print_delim();
+    if (rd->debug) {
+        print_delim();
+        dbg_ols_print("Pixel (%ld, %ld)\n", pr->row, pr->col);
+        dbg_ols_print("Median Rate = %.10f\n", pr->median_rate);
+        print_delim();
+    }
 #endif
 
     /* Clean up any thing from the last pixel ramp */
@@ -3228,6 +3230,7 @@ save_opt_res(
                 while(current) {
                     next = current->flink;
                     //print_segment_opt_res(current, rd, integ, segnum, __LINE__);
+                    /* XXX currentdev */
 
                     ptr = PyArray_GETPTR4(opt_res->slope, integ, segnum, row, col);
 #if REAL_IS_DOUBLE

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -223,7 +223,9 @@ struct ramp_data {
     real_t effintim;                /* Effective integration time */
     real_t one_group_time;          /* Time for ramps with only 0th good group */
     weight_t weight;                /* The weighting for OLS */
-    int run_chargeloss;             /* Boolean to run chargeloss */
+
+    /* Debug switch */
+    int debug;
 }; /* END: struct ramp_data */
 
 /*
@@ -1841,8 +1843,10 @@ get_ramp_data_meta(
     rd->ngval = py_ramp_data_get_int(Py_ramp_data, "flags_no_gain_val");
     rd->uslope = py_ramp_data_get_int(Py_ramp_data, "flags_unreliable_slope");
     rd->chargeloss = py_ramp_data_get_int(Py_ramp_data, "flags_chargeloss");
-    rd->run_chargeloss = py_ramp_data_get_int(Py_ramp_data, "run_chargeloss");
     rd->invalid = rd->dnu | rd->sat;
+
+    /* Debugging switch */
+    rd->debug = py_ramp_data_get_int(Py_ramp_data, "debug");
 
     /* Get float meta data */
     rd->group_time = (real_t)py_ramp_data_get_float(Py_ramp_data, "group_time");
@@ -2254,7 +2258,7 @@ ols_slope_fit_pixels(
                 return 1;
             }
 
-            if (rd->run_chargeloss) {
+            if (rd->orig_gdq != Py_None) {
                 if (ramp_fit_pixel_rnoise_chargeloss(rd, pr)) {
                     return 1;
                 }

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -225,7 +225,6 @@ def test_neg_med_rates_multi_integration_optional():
     np.testing.assert_allclose(ovp[:, 0, 0, 0], np.zeros(3), tol)
 
 
-# def base_neg_med_rates_single_integration_multi_segment():
 def test_neg_med_rates_single_integration_multi_segment_optional():
     """
     Test a ramp with multiple segments to make sure the right number of
@@ -255,8 +254,6 @@ def test_neg_med_rates_single_integration_multi_segment_optional():
     ramp_data.data[0, 10:, 1, 0] = ramp_data.data[0, 10:, 1, 0] + 50
     ramp_data.groupdq[0, 10, 1, 0] = dqflags["JUMP_DET"]
 
-    ramp_data.debug = True  # XXX debugging switch
-
     # Run ramp fit on RampData
     buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
@@ -264,10 +261,6 @@ def test_neg_med_rates_single_integration_multi_segment_optional():
     )
 
     oslope, osigslope, ovp, ovr, oyint, osigyint, opedestal, oweights, ocrmag = optional
-
-    print(f"{ovp[0, :, 0, 0] = }")
-    print(f"{ovp[0, :, 1, 0] = }")
-    return 
 
     neg_ramp_poisson = ovp[0, :, 0, 0]
     tol = 1e-6
@@ -1800,6 +1793,16 @@ def create_test_2seg_obs(
 # The functions below are only used for DEBUGGING tests and developing tests. #
 ###############################################################################
 
+def dbg_print(string):
+    """
+    Print string with line number and filename.
+    """
+    import inspect, os
+    cf = inspect.currentframe()
+    line_number = cf.f_back.f_lineno
+    finfo = inspect.getframeinfo(cf.f_back)
+    fname = os.path.basename(finfo.filename)
+    print(f"[{fname}:{line_number}] {string}")
 
 def print_real_check(real, check, label=None):
     import inspect

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -223,8 +223,13 @@ def test_neg_med_rates_multi_integration_optional():
     np.testing.assert_allclose(ovp[:, 0, 0, 0], np.zeros(3), tol)
 
 
-def base_neg_med_rates_single_integration_multi_segment():
+# def base_neg_med_rates_single_integration_multi_segment():
+def test_neg_med_rates_single_integration_multi_segment_optional():
     """
+    Test a ramp with multiple segments to make sure the right number of
+    segments are created and to make sure all Poisson segments are set to
+    zero.
+
     Creates single integration, multi-segment data for testing ensuring
     negative median rates.
     """
@@ -248,24 +253,19 @@ def base_neg_med_rates_single_integration_multi_segment():
     ramp_data.data[0, 10:, 1, 0] = ramp_data.data[0, 10:, 1, 0] + 50
     ramp_data.groupdq[0, 10, 1, 0] = dqflags["JUMP_DET"]
 
+    ramp_data.debug = True
+
     # Run ramp fit on RampData
     buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
 
-    return slopes, cube, optional, gls_dummy, dims
-
-
-def test_neg_med_rates_single_integration_multi_segment_optional():
-    """
-    Test a ramp with multiple segments to make sure the right number of
-    segments are created and to make sure all Poisson segments are set to
-    zero.
-    """
-    slopes, cube, optional, gls_dummy, dims = base_neg_med_rates_single_integration_multi_segment()
-
     oslope, osigslope, ovp, ovr, oyint, osigyint, opedestal, oweights, ocrmag = optional
+
+    print(f"{ovp[0, :, 0, 0] = }")
+    print(f"{ovp[0, :, 1, 0] = }")
+    return 
 
     neg_ramp_poisson = ovp[0, :, 0, 0]
     tol = 1e-6
@@ -1563,6 +1563,7 @@ def test_refcounter():
     assert b_dc == a_dc
 
 
+@pytest.mark.skip(reason="Debugging other tests.")
 def test_cext_chargeloss():
     """
     Testing the recomputation of read noise due to CHARGELOSS.  Wherever

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -32,6 +32,8 @@ SAT = dqflags["SATURATED"]
 JUMP = dqflags["JUMP_DET"]
 CHRGL = dqflags["CHARGELOSS"]
 
+DEFAULT_OLS = "OLS_C"
+
 
 # -----------------------------------------------------------------------------
 #                           Test Suite
@@ -52,7 +54,7 @@ def test_long_integration():
 
     ramp_data.data[0, 291:, 0, 0] = 320 * 3
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise_array, gain_array,
         algo, wt, ncores, dqflags)
@@ -80,7 +82,7 @@ def base_neg_med_rates_single_integration():
     ramp_data.data[0, :, 0, 0] = neg_ramp
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -163,7 +165,7 @@ def base_neg_med_rates_multi_integrations():
         ramp_data.data[k, :, 0, 0] = neg_ramp * n
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -253,10 +255,10 @@ def test_neg_med_rates_single_integration_multi_segment_optional():
     ramp_data.data[0, 10:, 1, 0] = ramp_data.data[0, 10:, 1, 0] + 50
     ramp_data.groupdq[0, 10, 1, 0] = dqflags["JUMP_DET"]
 
-    ramp_data.debug = True
+    ramp_data.debug = True  # XXX debugging switch
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -296,7 +298,7 @@ def test_neg_with_avgdark():
     ramp_data.average_dark_current[:] = 1.0
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
         )
@@ -345,7 +347,7 @@ def test_utils_dq_compress_final():
     ramp_data.groupdq[0, :, 0, 1] = np.array([dqflags["SATURATED"]] * ngroups)
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, False, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, False, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -424,7 +426,7 @@ def test_miri_ramp_dnu_at_ramp_beginning():
     ramp_data.groupdq[0, 1, 0, 0] = dqflags["DO_NOT_USE"]
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes1, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -446,7 +448,7 @@ def test_miri_ramp_dnu_and_jump_at_ramp_beginning():
     ramp_data.groupdq[0, 1, 0, 0] = dqflags["JUMP_DET"]
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes2, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -519,7 +521,7 @@ def test_2_group_cases():
     ramp_data.set_dqflags(dqflags)
 
     # Run ramp fit on RampData
-    buffsize, save_opt, algo, wt, ncores = 512, True, "OLS", "optimal", "none"
+    buffsize, save_opt, algo, wt, ncores = 512, True, DEFAULT_OLS, "optimal", "none"
     slopes, cube, optional, gls_dummy = ramp_fit_data(
         ramp_data, buffsize, save_opt, rnoise, gain, algo, wt, ncores, dqflags
     )
@@ -593,7 +595,7 @@ def run_one_group_ramp_suppression(nints, suppress):
 
     ramp_data.suppress_one_group_ramps = suppress
 
-    algo = "OLS"
+    algo = DEFAULT_OLS
     save_opt, ncores, bufsize = False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise2d, gain2d, algo, "optimal", ncores, dqflags
@@ -870,7 +872,7 @@ def test_zeroframe():
     """
     ramp_data, gain, rnoise = create_zero_frame_data()
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_OLS, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -989,7 +991,7 @@ def test_only_good_0th_group():
     # Dimensions are (1, 5, 1, 3)
     ramp_data, gain, rnoise = create_only_good_0th_group_data()
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_OLS, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1038,7 +1040,7 @@ def test_all_sat():
     ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
     ramp.groupdq[:, 0, :, :] = ramp.flags_saturated
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_OLS, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1068,7 +1070,7 @@ def test_dq_multi_int_dnu():
     ramp.data[1, :, 0, 0] = np.array(base_arr)
     ramp.groupdq[0, :, 0, 0] = np.array(dq_arr)
 
-    algo, save_opt, ncores, bufsize = "OLS", False, "none", 1024 * 30000
+    algo, save_opt, ncores, bufsize = DEFAULT_OLS, False, "none", 1024 * 30000
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1165,7 +1167,7 @@ def test_multi_more_cores_than_rows():
                 ramp.data[integ, :, row, col] = bramp
                 bramp = bramp * factor
 
-    bufsize, algo, save_opt, ncores = 512, "OLS", False, "all"
+    bufsize, algo, save_opt, ncores = 512, DEFAULT_OLS, False, "all"
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1316,7 +1318,7 @@ def test_new_saturation():
     """
     ramp, gain, rnoise = get_new_saturation()
 
-    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1408,7 +1410,7 @@ def test_invalid_integrations():
 
     ramp.suppress_one_group_ramps = True
 
-    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1472,7 +1474,7 @@ def test_one_group():
 
     ramp.data[0, 0, 0, 0] = 105.31459
 
-    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = False, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -1563,7 +1565,6 @@ def test_refcounter():
     assert b_dc == a_dc
 
 
-@pytest.mark.skip(reason="Debugging other tests.")
 def test_cext_chargeloss():
     """
     Testing the recomputation of read noise due to CHARGELOSS.  Wherever

--- a/tests/test_ramp_fitting_cases.py
+++ b/tests/test_ramp_fitting_cases.py
@@ -43,6 +43,8 @@ SAT = dqflags["SATURATED"]
 JUMP = dqflags["JUMP_DET"]
 CHRGL = dqflags["CHARGELOSS"]
 
+DEFAULT_OLS = "OLS_C"
+
 
 # -----------------------------------------------------------------------------
 #                           Test Suite
@@ -63,7 +65,7 @@ def test_pix_0():
     dq = [GOOD] * ngroups
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -104,7 +106,7 @@ def test_pix_1():
     dq[4:] = [SAT] * (ngroups - 4)
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -137,7 +139,7 @@ def test_pix_2():
     dq = [GOOD, GOOD, GOOD, JUMP, GOOD, JUMP, GOOD, JUMP, SAT, SAT]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -180,7 +182,7 @@ def test_pix_3():
     dq[-2] = JUMP
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -222,7 +224,7 @@ def test_pix_4():
     dq = [GOOD] + [SAT] * (ngroups - 1)
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -305,7 +307,7 @@ def test_pix_5():
     dq[4] = JUMP
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -349,7 +351,7 @@ def test_pix_6():
     dq[3] = JUMP
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -390,7 +392,7 @@ def test_pix_7():
     dq = [GOOD] * (ngroups - 2) + [JUMP, JUMP]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -423,7 +425,7 @@ def test_pix_8():
     dq = [GOOD, JUMP, GOOD, GOOD, GOOD, GOOD, GOOD, SAT, SAT, SAT]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -457,7 +459,7 @@ def test_pix_9():
     dq = [GOOD, GOOD, JUMP, JUMP, GOOD, GOOD, GOOD, GOOD, JUMP, GOOD]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -500,7 +502,7 @@ def test_pix_10():
     dq = [GOOD, GOOD, JUMP, GOOD, GOOD, JUMP, GOOD, GOOD, GOOD, GOOD]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -541,7 +543,7 @@ def test_pix_11():
     dq = [GOOD, GOOD] + [SAT] * (ngroups - 2)
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -577,7 +579,7 @@ def test_pix_12():
     ramp_data.data[0, :, 0, 1] = np.array([61000.0, 61000.0], dtype=np.float32)
     ramp_data.groupdq[0, :, 0, 1] = np.array([SAT, SAT])
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -631,7 +633,7 @@ def test_miri_0():
     dq = [DNU] + [GOOD] * (ngroups - 2) + [DNU]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -665,7 +667,7 @@ def test_miri_1():
     dq = [DNU | JUMP] + [GOOD] * (ngroups - 2) + [DNU]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -699,7 +701,7 @@ def test_miri_2():
     dq = [DNU | JUMP] + [GOOD] * (ngroups - 2) + [DNU | JUMP]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )
@@ -733,7 +735,7 @@ def test_miri_3():
     dq = [DNU] + [GOOD] * (ngroups - 2) + [DNU | JUMP]
     ramp_data.groupdq[0, :, 0, 0] = np.array(dq)
 
-    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, "OLS"
+    save_opt, ncores, bufsize, algo = True, "none", 1024 * 30000, DEFAULT_OLS
     slopes, cube, ols_opt, gls_opt = ramp_fit_data(
         ramp_data, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
     )


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3734](https://jira.stsci.edu/browse/JP-3734)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #

<!-- describe the changes comprising this PR here -->

This PR addresses default algorithm testing for ramp fitting.  The OLS_C algorithm is now the default algorithm for testing.

This PR also addresses a bug that resulted in incorrect attempts to do the CHARGELOSS recalculations when not needed, which would result in a crash when trying to dereference a `NULL` pointer for `rd->orig_gdq`.

The PR revealed another bug in the creation of the optional results product.  The arrays were being created using `PyArray_EMPTY`, which didn't initialize memory, so unused elements in some of the optional results product arrays were junk.  The creation function used now is `PyArray_ZEROS`, which initializes the array to zero.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
