### PR TITLE
Removed redundant calculations, unneeded array allocations from jump step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,8 +76,7 @@ General
   <https://github.com/spacetelescope/stcal/issues/286>`_)
 - Improve handling of catalog web service connectivity issues. (`#286
   <https://github.com/spacetelescope/stcal/issues/286>`_)
-- [jump] Remove redundant calculations and unneeded array allocations.
-  (`JP-3697<https://jira.stsci.edu/browse/JP-3697>`_)
+
 
 1.8.2 (2024-09-10)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,8 @@ General
   <https://github.com/spacetelescope/stcal/issues/286>`_)
 - Improve handling of catalog web service connectivity issues. (`#286
   <https://github.com/spacetelescope/stcal/issues/286>`_)
-
+- [jump] Remove redundant calculations and unneeded array allocations.
+  (`JP-3697<https://jira.stsci.edu/browse/JP-3697>`_)
 
 1.8.2 (2024-09-10)
 ==================

--- a/changes/302.general.rst
+++ b/changes/302.general.rst
@@ -1,0 +1,1 @@
+Remove redundant calculations and unneeded array allocations.

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -173,7 +173,7 @@ def find_crs(
         return gdq, row_below_gdq, row_above_gdq, 0, dummy
     else:
         # set 'saturated' or 'do not use' pixels to nan in data
-        dat[np.where(np.bitwise_and(gdq, dnu_flag + sat_flag))] = np.nan
+        dat[np.where(np.bitwise_and(gdq, dnu_flag | sat_flag))] = np.nan
 
         # calculate the differences between adjacent groups (first diffs)
         # use mask on data, so the results will have sat/donotuse groups masked
@@ -210,7 +210,7 @@ def find_crs(
             jump_mask = np.logical_and(clipped_diffs.mask, np.logical_not(first_diffs_masked.mask))
             jump_mask[np.bitwise_and(jump_mask, gdq[:, 1:, :, :] == sat_flag)] = False
             jump_mask[np.bitwise_and(jump_mask, gdq[:, 1:, :, :] == dnu_flag)] = False
-            jump_mask[np.bitwise_and(jump_mask, gdq[:, 1:, :, :] == (dnu_flag + sat_flag))] = False
+            jump_mask[np.bitwise_and(jump_mask, gdq[:, 1:, :, :] == (dnu_flag | sat_flag))] = False
             gdq[:, 1:, :, :] = np.bitwise_or(gdq[:, 1:, :, :], jump_mask *
                                              np.uint8(dqflags["JUMP_DET"]))
             # if grp is all jump set to do not use


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3697](https://jira.stsci.edu/browse/JP-3697)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #

<!-- describe the changes comprising this PR here -->

This PR affects the two-point-difference jump step only.  It removes duplicate and redundant calculations and unneeded array allocations, which make a significant difference for large uncal files.  Masked array median is also changed to nanmedian, and a few variables are renamed to avoid overwriting a quantity that is needed at the end of the routine.  

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
