### PR TITLE
Python 3.13 preparation for ramp fitting.

### DIFF
--- a/changes/303.general.rst
+++ b/changes/303.general.rst
@@ -1,0 +1,4 @@
+Preparing ramp fitting for the upgrade to python 3.13.  In python 3.13, the C-API
+function ``PyLong_AsLong`` raises an exception if the object passed to it is
+``NoneType``.  There are two integer attributes for the ``RampData`` class that
+can be ``NoneType``, so a check for ``NoneType`` for these attributes was added.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "stcal"
 description = "STScI tools and algorithms used in calibration pipelines"
 readme = "README.md"
-requires-python = ">=3.10,<=3.13"
+requires-python = ">=3.10,<3.13"
 authors = [
     { name = "STScI", email = "help@stsci.edu" },
 ]
@@ -39,7 +39,7 @@ docs = [
     "sphinx-asdf",
     "sphinx-astropy",
     "sphinx-rtd-theme",
-    "tomli; python_version <=\"3.13\"",
+    "tomli; python_version <=\"3.11\"",
 ]
 test = [
     "psutil",
@@ -205,7 +205,7 @@ convention = "numpy"
 ignore-fully-untyped = true  # Turn of annotation checking for fully untyped code
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "stcal"
 description = "STScI tools and algorithms used in calibration pipelines"
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<=3.13"
 authors = [
     { name = "STScI", email = "help@stsci.edu" },
 ]
@@ -39,7 +39,7 @@ docs = [
     "sphinx-asdf",
     "sphinx-astropy",
     "sphinx-rtd-theme",
-    "tomli; python_version <=\"3.11\"",
+    "tomli; python_version <=\"3.13\"",
 ]
 test = [
     "psutil",
@@ -205,7 +205,7 @@ convention = "numpy"
 ignore-fully-untyped = true  # Turn of annotation checking for fully untyped code
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1846,7 +1846,7 @@ get_ramp_data_meta(
 
     test = PyObject_GetAttrString(Py_ramp_data, "drop_frames1");
     if (!test|| (test == Py_None)) {
-        rd->dropframes = 0.;
+        rd->dropframes = 0;
     } else {
         rd->dropframes = py_ramp_data_get_int(Py_ramp_data, "drop_frames1");
     }


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
<!-- describe the changes comprising this PR here -->

This PR prepares the ramp fitting C-extension for the upgrade to python 3.13.  This version of python added an exception to the `PyLong_AsLong` function if the `PyObject` passed to it is `NoneType`.  Now for two attributes of `RampData` that can be `NoneType` a check needs to be put in place guard against this exception.  The other attributes of `RampData` that are expected to be integer type should never be `NoneType`, so should raise an exception if they are.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
