### PR TITLE
JP-3708: Adding the CRMAG Array to the Optional Results Product

### DIFF
--- a/changes/304.bugfix.rst
+++ b/changes/304.bugfix.rst
@@ -1,0 +1,1 @@
+Added the ``crmag`` array to the optional results product in ``ramp_fitting``.

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1352,7 +1352,7 @@ create_opt_res(
 
     /* cr_mag has different dimensions */
     dims[1] = rd->max_num_crs;
-    opt_res->cr_mag = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->cr_mag = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->cr_mag) {
         goto FAILED_ALLOC;
     }

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1557,7 +1557,7 @@ get_pixel_ramp(
 {
     npy_intp integ, group;
     ssize_t idx = 0, integ_idx;
-    real_t zframe;
+    real_t zframe, crmag;
 
     get_pixel_ramp_zero(pr);
     get_pixel_ramp_meta(pr, rd, row, col);
@@ -1569,6 +1569,10 @@ get_pixel_ramp(
         integ_idx = idx;
         for (group = 0; group < pr->ngroups; ++group) {
             get_pixel_ramp_integration(pr, rd, row, col, integ, group, idx);
+            if ((group>0) && (pr->groupdq[idx] & rd->jump)) {
+                crmag = pr->data[idx] - pr->data[idx-1];
+                dbg_ols_print("Row: %ld, Group: %ld, crmag = %.4f\n", row, group, crmag);
+            }
             idx++;
         }
         /* Check for 0th group and ZEROFRAME */

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1637,7 +1637,10 @@ def test_cext_chargeloss():
 
 def test_crmag():
     """
-    Do something with the crmag from the optional results product.
+    A basic test with two ramps, one with jumps and one without, then
+    test to make sure the ramp with jumps has non-zero entries in the
+    'crmag' array in the optional results product, while the ramp with
+    no jumps is all zeros.
     """
     nints, ngroups, nrows, ncols = 1, 10, 1, 2
     rnval, gval = 0.7071, 1.

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1635,6 +1635,49 @@ def test_cext_chargeloss():
     assert svr[0, 1] == svr[0, 3]
 
 
+def test_crmag():
+    """
+    Do something with the crmag from the optional results product.
+    """
+    nints, ngroups, nrows, ncols = 1, 10, 1, 2
+    rnval, gval = 0.7071, 1.
+    frame_time, nframes, groupgap = 10.6, 1, 0
+    group_time = 10.6
+
+    dims = nints, ngroups, nrows, ncols
+    var = rnval, gval
+    tm = frame_time, nframes, groupgap
+
+    ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
+
+    # Define data
+    base = 13.67
+    arr = np.array([(k+1) * base for k in range(ngroups)])
+    ramp.data[0, :, 0, 0] = arr
+    ramp.data[0, :, 0, 1] = arr * 1.34
+
+    # Add jumps
+    ramp.data[0, 3:, 0, 0] += 165.855
+    ramp.data[0, 7:, 0, 0] += 430.543
+    ramp.groupdq[0, 3, 0, 0] = JUMP
+    ramp.groupdq[0, 7, 0, 0] = JUMP
+
+    algo = DEFAULT_OLS
+    save_opt, ncores, bufsize = True, "none", 1024 * 30000
+    slopes, cube, ols_opt, gls_opt = ramp_fit_data(
+        ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
+    )
+
+    oslope, osigslope, ovp, ovr, oyint, osigyint, opedestal, oweights, ocrmag = ols_opt
+
+    tol = 1.e-4
+    check = np.array([179.52501, 444.213], dtype=np.float32)
+    np.testing.assert_allclose(ocrmag[0, :, 0, 0], check, tol)
+
+    check = np.array([0., 0.], dtype=np.float32)
+    np.testing.assert_allclose(ocrmag[0, :, 0, 1], check, tol)
+
+
 # -----------------------------------------------------------------------------
 #                           Set up functions
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3708](https://jira.stsci.edu/browse/JP-3708)

<!-- describe the changes comprising this PR here -->

This PR addresses a crash that occurs when running multiprocessing for ramp fitting with the C extension while choosing to save the optional results product.  This is because the CRMAG array was not implemented in the C extension, so the C extension returns a `NoneType`, so when the data slices attempt to reassemble an exception is thrown because there is no CRMAG to reassemble.

The CRMAG array is a 4-D array, with dimensions `(nints, max_num_crs, nrows, ncols)`.  For each integration ramp there is some number of cosmic ray jumps, including 0.  The dimension `max_num_crs` is the maximum number of jumps found over all integrations and all pixels.  For ramps that have fewer than the max number of jumps the last elements in that pixel ramp are 0.  For example, if the maximum number of jumps found was 5, but a ramp has only two jumps, the first two elements of the CRMAG array for that integration, row, and column are non-zero, while the last three are 0.  The non-zero elements of the ramp array are the magnitude of the jump, which is the difference between the two groups where a jump was detected.

The CRMAG is now implemented in the C extension and functions properly with multiprocessing.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
