### PR TITLE
AL-837: Calculate output WCS for resample from already-known s_region

### DIFF
--- a/changes/307.apichange.0.rst
+++ b/changes/307.apichange.0.rst
@@ -1,0 +1,1 @@
+Add wcs_from_sregions function to compute a combined WCS from a list of s_regions.

--- a/changes/307.apichange.1.rst
+++ b/changes/307.apichange.1.rst
@@ -1,0 +1,1 @@
+Deprecate wcs_from_footprints. Use wcs_from_sregions instead.

--- a/changes/307.apichange.rst
+++ b/changes/307.apichange.rst
@@ -1,1 +1,0 @@
-Make wcs_from_footprints accept s_regions instead of wcs objects

--- a/changes/307.apichange.rst
+++ b/changes/307.apichange.rst
@@ -1,0 +1,1 @@
+Make wcs_from_footprints accept s_regions instead of wcs objects

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -596,6 +596,8 @@ def wcs_from_footprints(
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     _validate_wcs_list(wcs_list)
     footprints = [w.footprint() for w in wcs_list]
+    if ref_wcs is None:
+        ref_wcs = wcs_list[0]
     return wcs_from_sregions(
         footprints,
         ref_wcs,
@@ -717,7 +719,7 @@ def wcs_from_sregions(
 
     transform = _generate_tranform(
         ref_wcs,
-        ref_wcsinfo,
+        wcsinfo=ref_wcsinfo,
         pscale_ratio=pscale_ratio,
         pscale=pscale,
         rotation=rotation,

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -512,9 +512,8 @@ def wcs_from_footprints(
         containing (RA, Dec) vertices demarcating the footprint of the input WCSs.
 
     ref_wcs :
-        A valid datamodel whose WCS is used as reference for the creation of the output
+        A WCS used as reference for the creation of the output
         coordinate frame, projection, and scaling and rotation transforms.
-        If not supplied the first model in the list is used as ``refmodel``.
 
     ref_wcsinfo : dict
         A dictionary containing the WCS FITS keywords and corresponding values.
@@ -569,7 +568,7 @@ def wcs_from_footprints(
 
     transform = _generate_tranform(
         ref_wcs,
-        wcsinfo=ref_wcsinfo,
+        ref_wcsinfo,
         pscale_ratio=pscale_ratio,
         pscale=pscale,
         rotation=rotation,

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -259,7 +259,8 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
                        transform: astmodels.Model | None = None,
                        ) -> gwcs.wcs.WCS:
     """
-    Calculates a new WCS object based on the combined WCS objects provided.
+    Calculates a new WCS object based on the combined footprints
+    and reference WCS provided.
 
     Parameters
     ----------
@@ -560,7 +561,10 @@ def wcs_from_footprints(
         The WCS object corresponding to the combined input footprints.
 
     """
-    footprints = [_sregion_to_footprint(s_region) for s_region in footprints if isinstance(s_region, str)]
+
+    footprints = [_sregion_to_footprint(s_region) 
+                  if isinstance(s_region, str) else s_region 
+                  for s_region in footprints]
     fiducial = _calculate_fiducial(footprints, crval=crval)
 
     transform = _generate_tranform(

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -429,6 +429,7 @@ def compute_fiducial(wcslist: list,
     Calculates the world coordinates of the fiducial point of a list of WCS objects.
     For a celestial footprint this is the center. For a spectral footprint, it is the
     beginning of its range.
+
     Parameters
     ----------
     wcslist : list
@@ -440,11 +441,13 @@ def compute_fiducial(wcslist: list,
         (low, high) values. The bounding_box is in the order of the axes, axes_order.
         For two inputs and axes_order(0, 1) the bounding box can be either
         ((xlow, xhigh), (ylow, yhigh)) or [[xlow, xhigh], [ylow, yhigh]].
+    
     Returns
     -------
     fiducial : np.ndarray
         A two-elements array containing the world coordinates of the fiducial point
         in the combined output coordinate frame.
+
     Notes
     -----
     This function assumes all WCSs have the same output coordinate frame.

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -139,7 +139,7 @@ def create_astrometric_catalog(
 
 def compute_radius(wcs):
     """Compute the radius from the center to the furthest edge of the WCS."""
-    fiducial = compute_fiducial([wcs], wcs.bounding_box)
+    fiducial = compute_fiducial([wcs.footprint(),])
     img_center = SkyCoord(
         ra=fiducial[0] * u.degree,
         dec=fiducial[1] * u.degree)

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -139,7 +139,7 @@ def create_astrometric_catalog(
 
 def compute_radius(wcs):
     """Compute the radius from the center to the furthest edge of the WCS."""
-    fiducial = compute_fiducial([wcs.footprint(),])
+    fiducial = compute_fiducial([wcs,])
     img_center = SkyCoord(
         ra=fiducial[0] * u.degree,
         dec=fiducial[1] * u.degree)

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -17,7 +17,7 @@ from tweakwcs.correctors import JWSTWCSCorrector
 from tweakwcs.imalign import align_wcs
 from tweakwcs.matchutils import XYXYMatch
 
-from stcal.alignment import wcs_from_footprints
+from stcal.alignment import wcs_from_sregions
 
 from .astrometric_utils import create_astrometric_catalog
 
@@ -240,7 +240,7 @@ def _parse_refcat(abs_refcat: str | Path,
 
         # combine all aligned wcs to compute a new footprint to
         # filter the absolute catalog sources
-        combined_wcs = wcs_from_footprints(
+        combined_wcs = wcs_from_sregions(
                         [corrector.wcs.footprint() for corrector in correctors],
                         ref_wcs=wcs,
                         ref_wcsinfo=wcsinfo,

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -241,7 +241,7 @@ def _parse_refcat(abs_refcat: str | Path,
         # combine all aligned wcs to compute a new footprint to
         # filter the absolute catalog sources
         combined_wcs = wcs_from_footprints(
-                        [corrector.wcs for corrector in correctors],
+                        [corrector.wcs.footprint() for corrector in correctors],
                         ref_wcs=wcs,
                         ref_wcsinfo=wcsinfo,
         )

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -233,6 +233,23 @@ def test_validate_wcs_list():
     assert _validate_wcs_list(wcs_list)
 
 
+@pytest.mark.parametrize(
+    ("wcs_list", "expected_error"),
+    [
+        ([], TypeError),
+        ([1, 2, 3], TypeError),
+        (["1", "2", "3"], TypeError),
+        (["1", None, []], TypeError),
+        ("1", TypeError),
+        (1, ValueError),
+        (None, ValueError),
+    ],
+)
+def test_validate_wcs_list_invalid(wcs_list, expected_error):
+    with pytest.raises(expected_error, match=r".*"):
+        _validate_wcs_list(wcs_list)
+
+
 def get_fake_wcs():
     fake_wcs1 = fitswcs.WCS(
         fits.Header(

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -15,6 +15,7 @@ from stcal.alignment.util import (
     compute_s_region_keyword,
     compute_scale,
     reproject,
+    _sregion_to_footprint,
     wcs_bbox_from_shape,
     wcs_from_footprints,
 )
@@ -152,6 +153,19 @@ def test_compute_scale(pscales):
     computed_scale = compute_scale(wcs=wcs, fiducial=fiducial_world)
 
     assert np.isclose(expected_scale, computed_scale)
+
+
+def test_sregion_to_footprint():
+    """Test that util._sregion_to_footprint can properly convert an S_REGION
+    string to a list of vertices.
+    """
+    s_region = "POLYGON ICRS  1.000000000 2.000000000 3.000000000 4.000000000 5.000000000 6.000000000 7.000000000 8.000000000"
+    expected_footprint = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+
+    footprint = _sregion_to_footprint(s_region)
+
+    assert footprint.shape == (4,2)
+    assert np.allclose(footprint, expected_footprint)
 
 
 def test_wcs_from_footprints():

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -12,6 +12,7 @@ from stcal.alignment import resample_utils
 from stcal.alignment.util import (
     _validate_wcs_list,
     compute_fiducial,
+    _compute_fiducial_from_footprints,
     compute_s_region_imaging,
     compute_s_region_keyword,
     compute_scale,
@@ -124,7 +125,8 @@ class DataModel:
         self.meta = MetaData(ra_ref, dec_ref, roll_ref, v2_ref, v3_ref, v3yangle, wcs=wcs)
 
 
-def test_compute_fiducial():
+@pytest.mark.parametrize("footprint", [True, False])
+def test_compute_fiducial(footprint):
     """Test that util.compute_fiducial can properly determine the center of the
     WCS's footprint.
     """
@@ -134,8 +136,11 @@ def test_compute_fiducial():
     pscale = (0.000014, 0.000014)  # in deg/pixel
 
     wcs = _create_wcs_object_without_distortion(fiducial_world=fiducial_world, shape=shape, pscale=pscale)
-    footprint = wcs.footprint()
-    computed_fiducial = compute_fiducial([footprint])
+    if footprint:
+        footprint = wcs.footprint()
+        computed_fiducial = _compute_fiducial_from_footprints([footprint])
+    else:
+        computed_fiducial = compute_fiducial([wcs])
 
     assert all(np.isclose(wcs(1, 1), computed_fiducial))
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [AL-837](https://jira.stsci.edu/browse/AL-837)

<!-- describe the changes comprising this PR here -->

This PR simplifies the calculation of the output WCS for resample.  Previously, the `wcs_from_footprints` function accepted a list of WCS objects, one for each input model, and computed the footprints from those WCS objects to pass into `_calculate_new_wcs()`.  However, computing the footprints here is unnecessary because that information is already stored in the S_REGION keyword.  This PR makes `wcs_from_footprints` take in an actual footprint instead, in the form of either a numpy array or an S_REGION string.

This PR will require small changes to both jwst and romancal, both of which are using the `wcs_from_footprints` function.  I'm not sure there's a way to avoid that.  One other non-hidden function changed, `compute_fiducial`, but this is not used for JWST or Romancal - both repositories have their own copy of a function with that name.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
