### PR TITLE
JP-3683: fix abs_deriv handling of off-edge and nan values

### DIFF
--- a/changes/311.bugfix.rst
+++ b/changes/311.bugfix.rst
@@ -1,0 +1,1 @@
+Fix abs_deriv handling of off-edge and nan values.

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -93,21 +93,22 @@ def _abs_deriv(array):
         out[np.isnan(array)] = np.nan
 
     # compute row-wise absolute diffference
-    d = np.abs(np.diff(array, axis=0))
-    np.putmask(out[1:], np.isfinite(d), d)  # no need to do max yet
+    row_diff = np.abs(np.diff(array, axis=0))
+    np.putmask(out[1:], np.isfinite(row_diff), row_diff)  # no need to do max yet
 
     # since these are absolute differences |r0-r1| = |r1-r0|
     # make a view of the target portion of the array
-    v = out[:-1]
+    row_offset_view = out[:-1]
     # compute an in-place maximum
-    np.putmask(v, d > v, d)
+    np.putmask(row_offset_view, row_diff > row_offset_view, row_diff)
+    del row_diff
 
     # compute col-wise absolute difference
-    d = np.abs(np.diff(array, axis=1))
-    v = out[:, 1:]
-    np.putmask(v, d > v, d)
-    v = out[:, :-1]
-    np.putmask(v, d > v, d)
+    col_diff = np.abs(np.diff(array, axis=1))
+    col_offset_view = out[:, 1:]
+    np.putmask(col_offset_view, col_diff > col_offset_view, col_diff)
+    col_offset_view = out[:, :-1]
+    np.putmask(col_offset_view, col_diff > col_offset_view, col_diff)
     return out
 
 

--- a/tests/outlier_detection/test_utils.py
+++ b/tests/outlier_detection/test_utils.py
@@ -33,12 +33,21 @@ def test_abs_deriv_single_value(shape, diff):
     np.testing.assert_allclose(result, expected)
 
 
-@pytest.mark.skip(reason="_abs_deriv has edge effects due to treating off-edge pixels as 0: see JP-3683")
 @pytest.mark.parametrize("nrows,ncols", [(5, 5), (7, 11), (17, 13)])
 def test_abs_deriv_range(nrows, ncols):
     arr = np.arange(nrows * ncols).reshape(nrows, ncols)
     result = _abs_deriv(arr)
     np.testing.assert_allclose(result, ncols)
+
+
+def test_abs_deriv_nan():
+    arr = np.arange(25, dtype='f4').reshape(5, 5)
+    arr[2, 2] = np.nan
+    expect_nan = np.zeros_like(arr, dtype=bool)
+    expect_nan[2, 2] = True
+    result = _abs_deriv(arr)
+    assert np.isnan(result[expect_nan])
+    assert np.all(np.isfinite(result[~expect_nan]))
 
 
 @pytest.mark.parametrize("shape,mean,maskpt,expected", [


### PR DESCRIPTION
Resolves [JP-3683](https://jira.stsci.edu/browse/JP-3683)

As part of outlier detection an "absolute derivative" is computed. From the [outlier detection docs](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/outlier_detection_imaging.html):
```
The derivative of the blotted image gets created using the blotted median image to compute the absolute value of the difference between each pixel and its four surrounding neighbors with the largest value being the recorded derivative.
So in this case the "absolute derivative" is the maximum absolute difference between a pixel and it's neighbors.
```

This PR addresses 2 issues with `_abs_deriv` (used in outlier detection) where it:
- treated off-edge pixels as 0
- included `nan` values in the `max` used for combining differences between adjacent pixels (effectively dilating nan values)

With the previous code:
```python
>> arr = np.arange(25, dtype='f4').reshape((5, 5))
>> arr[2, 2] = np.nan
>> _abs_deriv(arr)
array([[ 5.,  5.,  5.,  5.,  5.],
       [ 5.,  5., nan,  5.,  9.],
       [10., nan, nan, nan, 14.],
       [15.,  5., nan,  5., 19.],
       [20., 21., 22., 23., 24.]])
```
Note that now instead of one nan at (2, 2) there are 5 nan pixels and that edge values are larger than expected. For example (1, 4) is 9 when the largest difference with all defined pixels is 5.

With this PR the result is:
```python
array([[ 5.,  5.,  5.,  5.,  5.],
       [ 5.,  5.,  5.,  5.,  5.],
       [ 5.,  5., nan,  5.,  5.],
       [ 5.,  5.,  5.,  5.,  5.],
       [ 5.,  5.,  5.,  5.,  5.]], dtype=float32)
``` 

Tests are added for both issues.

It is expected this will change regression tests for both jwst and romancal as `abs_deriv` is used to compute the outlier detection threshold. With this PR more outliers will be detected (since the threshold will be lower due to edge pixels having lower values and less nans in the blot images).

Romancal regtests running: https://github.com/spacetelescope/RegressionTests/actions/runs/11682867663
JWST regtests running: https://github.com/spacetelescope/RegressionTests/actions/runs/11682842450

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
