### PR TITLE
AL-875: Add memory saving options to compute_weight_threshold sigma_clip call

### DIFF
--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -77,7 +77,11 @@ def compute_weight_threshold(weight, maskpt):
     weight_masked = np.ma.array(weight, mask=np.logical_or(
         mask_zero_weight, mask_nans))
     # Sigma-clip the unmasked data
-    weight_masked = sigma_clip(weight_masked, sigma=3, maxiters=5)
+    weight_masked = sigma_clip(weight_masked,
+                               sigma=3,
+                               maxiters=5,
+                               masked=False,
+                               copy=False)
     mean_weight = np.mean(weight_masked)
     # Mask pixels where weight falls below maskpt percent
     weight_threshold = mean_weight * maskpt

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -81,7 +81,8 @@ def compute_weight_threshold(weight, maskpt):
                                sigma=3,
                                maxiters=5,
                                masked=False,
-                               copy=False)
+                               copy=False,
+                               )
     mean_weight = np.mean(weight_masked)
     # Mask pixels where weight falls below maskpt percent
     weight_threshold = mean_weight * maskpt

--- a/tests/outlier_detection/test_utils.py
+++ b/tests/outlier_detection/test_utils.py
@@ -81,7 +81,9 @@ def test_compute_weight_threshold_memory():
     arr[10,10] = 0
     arr[-10,-10] = np.nan
 
-    fractional_memory_buffer = 1.5
+    # buffer to account for memory overhead needs to be small enough
+    # to ensure that the array was not copied
+    fractional_memory_buffer = 1.9
     expected_mem = int(arr.nbytes*fractional_memory_buffer)
     with MemoryThreshold(str(expected_mem) + " B"):
         result = compute_weight_threshold(arr, 0.5)

--- a/tests/outlier_detection/test_utils.py
+++ b/tests/outlier_detection/test_utils.py
@@ -16,6 +16,7 @@ from stcal.outlier_detection.utils import (
     reproject,
     medfilt,
 )
+from stcal.testing_helpers import MemoryThreshold
 
 
 @pytest.mark.parametrize("shape,diff", [
@@ -69,6 +70,21 @@ def test_compute_weight_threshold_zeros():
     arr = np.zeros([10, 10], dtype=np.float32)
     arr[:5, :5] = 42
     result = compute_weight_threshold(arr, 0.5)
+    np.testing.assert_allclose(result, 21)
+
+
+def test_compute_weight_threshold_memory():
+    """Test that weight threshold function modifies
+    the weight array in place"""
+    arr = np.zeros([500, 500], dtype=np.float32)
+    arr[:250, :250] = 42
+    arr[10,10] = 0
+    arr[-10,-10] = np.nan
+
+    fractional_memory_buffer = 1.5
+    expected_mem = int(arr.nbytes*fractional_memory_buffer)
+    with MemoryThreshold(str(expected_mem) + " B"):
+        result = compute_weight_threshold(arr, 0.5)
     np.testing.assert_allclose(result, 21)
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [AL-875](https://jira.stsci.edu/browse/AL-875)

<!-- describe the changes comprising this PR here -->

This PR adds memory-saving options to a call to astropy `sigma clip` within `compute_weight_threshold` in an attempt to decrease the overall memory usage of outlier detection step (see flamegraphs on [JP-3685](https://jira.stsci.edu/browse/JP-3685)), which cause that function to modify the input array in-place instead of copying it and allocating extra arrays for masks.  Since the output sigma-clipped array is immediately collapsed into its mean, there is no need to retain it as a masked array and the behavior is unchanged.

Note that the "masked=False" option to sigma_clip does not affect that function's processing of _input_ masked arrays, it only specifies whether the _output_ is a masked array with clipped pixels masked, or a simple np.array with clipped pixels removed.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
