### PR TITLE
JP-3771 and JP-3791: Ramp Fitting Multiprocessing Regression Testing and Read Noise Variance

### DIFF
--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -564,6 +564,13 @@ def slice_ramp_data(ramp_data, start_row, nrows):
         drop_frames1=ramp_data.drop_frames1,
     )
 
+    # For possible CHARGELOSS flagging.
+    if ramp_data.orig_gdq is not None:
+        ogdq = ramp_data.orig_gdq[:, :, start_row : start_row + nrows, :].copy()
+        ramp_data_slice.orig_gdq = ogdq
+    else:
+        ramp_data_slice.orig_gdq = None
+
     # Carry over DQ flags.
     ramp_data_slice.flags_do_not_use = ramp_data.flags_do_not_use
     ramp_data_slice.flags_jump_det = ramp_data.flags_jump_det

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -164,11 +164,13 @@ def ols_ramp_fit_multiprocessing(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, weighting, number_slices
     )
 
+    # warnings.filterwarnings("ignore", ".*leaked semaphore objects.*", UserWarning)
     ctx = multiprocessing.get_context("forkserver")
     pool = ctx.Pool(processes=number_slices)
     pool_results = pool.starmap(ols_ramp_fit_single, slices)
     pool.close()
     pool.join()
+    # warnings.resetwarnings()
 
     # Reassemble results
     image_info, integ_info, opt_info = assemble_pool_results(
@@ -577,6 +579,7 @@ def slice_ramp_data(ramp_data, start_row, nrows):
     ramp_data_slice.flags_saturated = ramp_data.flags_saturated
     ramp_data_slice.flags_no_gain_val = ramp_data.flags_no_gain_val
     ramp_data_slice.flags_unreliable_slope = ramp_data.flags_unreliable_slope
+    ramp_data_slice.flags_chargeloss = ramp_data.flags_chargeloss
 
     # Slice info
     ramp_data_slice.start_row = start_row

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -741,16 +741,17 @@ static inline int
 is_pix_in_list(struct pixel_ramp * pr)
 {
     /* Pixel list */
-    // JP-3669 - (1804, 173)
+    // JP-3771 - (5, 1445)
     const int len = 1;
     npy_intp rows[len];
     npy_intp cols[len];
     int k;
 
-    return 0;  /* XXX Null function */
+    // return 0;  /* XXX Null function */
 
-    rows[0] = 1804;
-    cols[0] = 173;
+    // TODO put handling in here for slicing.
+    rows[0] = 5;
+    cols[0] = 1445;
 
     for (k=0; k<len; ++k) {
         if (pr->row==rows[k] && pr->col==cols[k]) {
@@ -2271,6 +2272,7 @@ ols_slope_fit_pixels(
         struct rateint_product * rateint_prod)  /* The rateints product */
 {
     npy_intp row, col;
+    pid_t pid = getpid(); // XXX Debug
 
     for (row = 0; row < rd->nrows; ++row) {
         for (col = 0; col < rd->ncols; ++col) {
@@ -2284,10 +2286,21 @@ ols_slope_fit_pixels(
                 return 1;
             }
 
+            // XXX debug here
+            if (is_pix_in_list(pr)) {
+                dbg_ols_print("[%d] rd->orig_gdq = %p\n", pid, rd->orig_gdq);
+                dbg_ols_print("[%d] Py_None = %p\n", pid, Py_None);
+                dbg_ols_print("[%d] (%ld, %ld) Before: vr = %.6f\n",
+                    pid, pr->row, pr->col, pr->rate.var_rnoise);
+            }
             if (rd->orig_gdq != Py_None) {
                 if (ramp_fit_pixel_rnoise_chargeloss(rd, pr)) {
                     return 1;
                 }
+            }
+            if (is_pix_in_list(pr)) {
+                dbg_ols_print("[%d] (%ld, %ld) After: vr = %.6f\n",
+                    pid, pr->row, pr->col, pr->rate.var_rnoise);
             }
 
             /* Save fitted pixel data for output packaging */


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3771](https://jira.stsci.edu/browse/JP-3771)
Resolves [JP-3771](https://jira.stsci.edu/browse/JP-3771)

<!-- describe the changes comprising this PR here -->

This PR addresses adding ramp fitting and jump step multiprocessing regression test.  The ramp fit multiprocessing regression test revealed a logical bug in the way the read noise variance gets recalculated due to the CHARGELOSS flagging.  The original group DQ flagging array, nor the CHARGELOSS flag, were being properly copied to each data sliced used to divide the data in preparation for multiprocessing.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
