### PR TITLE
Revert "AL-875: Add memory saving options to compute_weight_threshold sigma_clip call"

### DIFF
--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -77,12 +77,7 @@ def compute_weight_threshold(weight, maskpt):
     weight_masked = np.ma.array(weight, mask=np.logical_or(
         mask_zero_weight, mask_nans))
     # Sigma-clip the unmasked data
-    weight_masked = sigma_clip(weight_masked,
-                               sigma=3,
-                               maxiters=5,
-                               masked=False,
-                               copy=False,
-                               )
+    weight_masked = sigma_clip(weight_masked, sigma=3, maxiters=5)
     mean_weight = np.mean(weight_masked)
     # Mask pixels where weight falls below maskpt percent
     weight_threshold = mean_weight * maskpt

--- a/tests/outlier_detection/test_utils.py
+++ b/tests/outlier_detection/test_utils.py
@@ -16,7 +16,6 @@ from stcal.outlier_detection.utils import (
     reproject,
     medfilt,
 )
-from stcal.testing_helpers import MemoryThreshold
 
 
 @pytest.mark.parametrize("shape,diff", [
@@ -70,23 +69,6 @@ def test_compute_weight_threshold_zeros():
     arr = np.zeros([10, 10], dtype=np.float32)
     arr[:5, :5] = 42
     result = compute_weight_threshold(arr, 0.5)
-    np.testing.assert_allclose(result, 21)
-
-
-def test_compute_weight_threshold_memory():
-    """Test that weight threshold function modifies
-    the weight array in place"""
-    arr = np.zeros([500, 500], dtype=np.float32)
-    arr[:250, :250] = 42
-    arr[10,10] = 0
-    arr[-10,-10] = np.nan
-
-    # buffer to account for memory overhead needs to be small enough
-    # to ensure that the array was not copied
-    fractional_memory_buffer = 1.9
-    expected_mem = int(arr.nbytes*fractional_memory_buffer)
-    with MemoryThreshold(str(expected_mem) + " B"):
-        result = compute_weight_threshold(arr, 0.5)
     np.testing.assert_allclose(result, 21)
 
 


### PR DESCRIPTION
Reverts spacetelescope/stcal#312

The reverted PR is causing regression test failures due in part to np.mean on a masked float32 array (which was the pre-PR behavior) producing a different result compared to a np.mean on a float32 array.