### PR TITLE
Clean up files generated by tests

### DIFF
--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -354,7 +354,7 @@ def test_flag_large_events_withsnowball_noextension():
     assert cube[0, 2, 2, 2] == 0  # Saturation was NOT extended due to max_extended_radius=1
 
 
-def test_find_faint_extended():
+def test_find_faint_extended(tmp_path):
     nint, ngrps, ncols, nrows = 1, 66, 25, 25
     data = np.zeros(shape=(nint, ngrps, nrows, ncols), dtype=np.float32)
     gdq = np.zeros_like(data, dtype=np.uint32)
@@ -366,7 +366,7 @@ def test_find_faint_extended():
     rng = np.random.default_rng(12345)
     data[0, 1:, 14:20, 15:20] = 6 * gain * 6.0 * np.sqrt(2)
     data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
-    fits.writeto("data.fits", data, overwrite=True)
+    fits.writeto(tmp_path / "data.fits", data, overwrite=True)
     gdq, num_showers = find_faint_extended(
         data,
         gdq,
@@ -386,7 +386,7 @@ def test_find_faint_extended():
     )
     #  Check that all the expected samples in group 2 are flagged as jump and
     #  that they are not flagged outside
-    fits.writeto("gdq.fits", gdq, overwrite=True)
+    fits.writeto(tmp_path / "gdq.fits", gdq, overwrite=True)
 #    assert num_showers == 1
     assert np.all(gdq[0, 1, 22, 14:23] == 0)
     assert gdq[0, 1, 16, 18] == DQFLAGS['JUMP_DET']

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -203,7 +203,7 @@ def datamodel(wcsobj2, group_id=None):
     return MinimalDataWithWCS(wcsobj2, group_id=group_id)
 
 
-def test_parse_refcat(datamodel):
+def test_parse_refcat(datamodel, tmp_path):
 
     wcsobj = datamodel.meta.wcs
     correctors = fake_correctors(0.0)
@@ -216,11 +216,11 @@ def test_parse_refcat(datamodel):
                               catalog=TEST_CATALOG)
 
     # save refcat to file
-    cat.write(Path.cwd() / CATALOG_FNAME, format="ascii.ecsv", overwrite=True)
+    cat.write(tmp_path / CATALOG_FNAME, format="ascii.ecsv", overwrite=True)
 
     # parse refcat from file
     epoch = Time(datamodel.meta.observation.date).decimalyear
-    refcat = _parse_refcat(Path.cwd() / CATALOG_FNAME,
+    refcat = _parse_refcat(tmp_path / CATALOG_FNAME,
                            correctors,
                            datamodel.meta.wcs,
                            datamodel.meta.wcsinfo,


### PR DESCRIPTION
This PR adds the use of the [`tmp_path`](https://docs.pytest.org/en/stable/how-to/tmp_path.html#the-tmp-path-fixture) fixture so that the files generated by tests get cleaned up at the end of the test.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
