### PR TITLE
JP-3708, JP-3771, JP-3791

### DIFF
--- a/changes/304.bugfix.rst
+++ b/changes/304.bugfix.rst
@@ -1,0 +1,1 @@
+Added the ``crmag`` array to the optional results product in ``ramp_fitting``.

--- a/changes/304.bugfix.rst
+++ b/changes/304.bugfix.rst
@@ -1,1 +1,0 @@
-Added the ``crmag`` array to the optional results product in ``ramp_fitting``.

--- a/changes/318.bugfix.rst
+++ b/changes/318.bugfix.rst
@@ -1,6 +1,19 @@
-JP-3791: Fixed the multiprocessing portion of the CHARGELOSS recomputation of the readnoise variances.  The DQ array wasn't properly sliced and distributed to the multiple processes to properly do the recompute.  This is now properly sliced for distribution.
+JP-3791: Fixed the `ramp fitting` multiprocessing portion of the 
+         CHARGELOSS recomputation of the readnoise variances.  The
+         DQ array wasn't properly sliced and distributed to the
+         multiple processes to properly do the recompute.  This is
+         now properly sliced for distribution.
 
-JP-3771: Added multiple regression tests to the JWST repo.  The tests test multiprocessing in the jump step and ramp step and ensure the outout is the same as during single processing.  This is done by running the same tests as currently being done, but selecting multiprocessing and comparing output files that are used for single processing as well.  There is an additional ramp fit multiprocessing test that also saves the optional results product.
+JP-3771: Added multiple regression tests to the JWST repo.  The tests
+         test multiprocessing in the `jump` step and `ramp_step` and
+         ensure the outout is the same as during single processing.
+         This is done by running the same tests as currently being done,
+         but selecting multiprocessing and comparing output files that
+         are used for single processing as well.  There is an additional
+         ramp fit multiprocessing test that also saves the optional results
+         product.
 
-JP-3708: Added the CRMAG array to the optional results product.  This particular element of the optional results product had not previously been implemented in the C-extension.
+JP-3708: Added the CRMAG array to the optional results product in `ramp_fit`.
+         This element of the optional results product had not previously been
+         implemented in the C-extension.
 

--- a/changes/318.bugfix.rst
+++ b/changes/318.bugfix.rst
@@ -1,6 +1,6 @@
-This PR fixes JP-3791, JP-3771, and JP-3708.  For `ramp_fitting`, the
-`CRMAG` element was not originally implementd in the C-extension for
-ramp fitting.  It is now implemented.  The bug the read noise recalculation
-for CHARGELOSS when using the multiprocessing option has been fixed.  Further,
-in `JWST` regression tests have been added to test for multiprocessing to
-ensure testing for anything that could affect multiprocessing.
+For `ramp_fitting`, the `CRMAG` element was not originally implementd in
+the C-extension for ramp fitting.  It is now implemented.  A bug in the read
+noise recalculation for CHARGELOSS when using the multiprocessing option has
+been fixed.  Further, in `JWST` regression tests have been added to test for
+multiprocessing to ensure testing for anything that could affect
+multiprocessing.

--- a/changes/318.bugfix.rst
+++ b/changes/318.bugfix.rst
@@ -1,6 +1,5 @@
-For `ramp_fitting`, the `CRMAG` element was not originally implementd in
+For `ramp_fitting`, the `CRMAG` element was not originally implemented in
 the C-extension for ramp fitting.  It is now implemented.  A bug in the read
 noise recalculation for CHARGELOSS when using the multiprocessing option has
 been fixed.  Further, in `JWST` regression tests have been added to test for
-multiprocessing to ensure testing for anything that could affect
-multiprocessing.
+multiprocessing to ensure testing for anything that could affect multiprocessing.

--- a/changes/318.bugfix.rst
+++ b/changes/318.bugfix.rst
@@ -1,19 +1,6 @@
-JP-3791: Fixed the `ramp fitting` multiprocessing portion of the 
-         CHARGELOSS recomputation of the readnoise variances.  The
-         DQ array wasn't properly sliced and distributed to the
-         multiple processes to properly do the recompute.  This is
-         now properly sliced for distribution.
-
-JP-3771: Added multiple regression tests to the JWST repo.  The tests
-         test multiprocessing in the `jump` step and `ramp_step` and
-         ensure the outout is the same as during single processing.
-         This is done by running the same tests as currently being done,
-         but selecting multiprocessing and comparing output files that
-         are used for single processing as well.  There is an additional
-         ramp fit multiprocessing test that also saves the optional results
-         product.
-
-JP-3708: Added the CRMAG array to the optional results product in `ramp_fit`.
-         This element of the optional results product had not previously been
-         implemented in the C-extension.
-
+This PR fixes JP-3791, JP-3771, and JP-3708.  For `ramp_fitting`, the
+`CRMAG` element was not originally implementd in the C-extension for
+ramp fitting.  It is now implemented.  The bug the read noise recalculation
+for CHARGELOSS when using the multiprocessing option has been fixed.  Further,
+in `JWST` regression tests have been added to test for multiprocessing to
+ensure testing for anything that could affect multiprocessing.

--- a/changes/318.bugfix.rst
+++ b/changes/318.bugfix.rst
@@ -1,0 +1,6 @@
+JP-3791: Fixed the multiprocessing portion of the CHARGELOSS recomputation of the readnoise variances.  The DQ array wasn't properly sliced and distributed to the multiple processes to properly do the recompute.  This is now properly sliced for distribution.
+
+JP-3771: Added multiple regression tests to the JWST repo.  The tests test multiprocessing in the jump step and ramp step and ensure the outout is the same as during single processing.  This is done by running the same tests as currently being done, but selecting multiprocessing and comparing output files that are used for single processing as well.  There is an additional ramp fit multiprocessing test that also saves the optional results product.
+
+JP-3708: Added the CRMAG array to the optional results product.  This particular element of the optional results product had not previously been implemented in the C-extension.
+

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -575,6 +575,14 @@ def slice_ramp_data(ramp_data, start_row, nrows):
     ramp_data_slice.flags_saturated = ramp_data.flags_saturated
     ramp_data_slice.flags_no_gain_val = ramp_data.flags_no_gain_val
     ramp_data_slice.flags_unreliable_slope = ramp_data.flags_unreliable_slope
+    ramp_data_slice.flags_chargeloss = ramp_data.flags_chargeloss
+
+    # For possible CHARGELOSS flagging.
+    if ramp_data.orig_gdq is not None:
+        ogdq = ramp_data.orig_gdq[:, :, start_row : start_row + nrows, :].copy()
+        ramp_data_slice.orig_gdq = ogdq
+    else:
+        ramp_data_slice.orig_gdq = None
 
     # Slice info
     ramp_data_slice.start_row = start_row

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -214,6 +214,11 @@ def assemble_pool_results(ramp_data, save_opt, pool_results, rows_per_slice):
     """
     # Create output arrays for each output tuple.  The input ramp data and
     # slices are needed for this.
+    for result in pool_results:
+        image_slice, integ_slice, opt_slice = result
+        if image_slice is None or integ_slice is None:
+            return None, None, None
+
     image_info, integ_info, opt_info = create_output_info(ramp_data, pool_results, save_opt)
 
     # Loop over the slices and assemble each slice into the main return arrays.

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -46,10 +46,6 @@ def ols_ramp_fit_multi(ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, wei
     gain_2d : ndarray
         gain for all pixels
 
-    algorithm : str
-        'OLS' specifies that ordinary least squares should be used;
-        'GLS' specifies that generalized least squares should be used.
-
     weighting : str
         'optimal' specifies that optimal weighting should be used;
          currently the only weighting supported.

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -872,12 +872,14 @@ print_pid_info(long long prev, int line, char * label) {
  */
 void
 set_up_logger() {
-    const char * log_dir = "/Users/kmacdonald/code/stcal/logs";
+    const char * log_dir = NULL;
     char tbuffer[128];
     time_t now = time(NULL);
     struct tm * curr_tm = localtime(&now);
     int sz;
     const char * string_fmt = "%Y_%m_%d_%H%M%S";
+
+    return;
 
     memset(tbuffer, 0, 128);
     strftime(tbuffer, 127, string_fmt, curr_tm);

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -800,7 +800,10 @@ print_delim_char(char c, int len) {
     printf("\n");
 }
 
-/* Used for debugging to determine if a pixel is in a list */
+/* 
+ * Used to determine if a pixel is in a list.
+ * This is a debugging function.
+ */
 static inline int
 is_pix_in_list(struct ramp_data * rd, struct pixel_ramp * pr)
 {

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -903,7 +903,7 @@ ols_slope_fitter(
     struct rate_product rate_prod = {0};
     struct rateint_product rateint_prod = {0};
 
-    g_pid = getpid();
+    g_pid = getpid();  /* Global variable to track the PID. */
 
     // SET_DEBUGGING;
 

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1352,7 +1352,7 @@ create_opt_res(
 
     /* cr_mag has different dimensions */
     dims[1] = rd->max_num_crs;
-    opt_res->cr_mag = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
+    opt_res->cr_mag = (PyArrayObject*)PyArray_ZEROS(nd, dims, NPY_FLOAT, fortran);
     if (!opt_res->cr_mag) {
         goto FAILED_ALLOC;
     }

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1557,7 +1557,7 @@ get_pixel_ramp(
 {
     npy_intp integ, group;
     ssize_t idx = 0, integ_idx;
-    real_t zframe;
+    real_t zframe, crmag;
 
     get_pixel_ramp_zero(pr);
     get_pixel_ramp_meta(pr, rd, row, col);
@@ -1569,6 +1569,10 @@ get_pixel_ramp(
         integ_idx = idx;
         for (group = 0; group < pr->ngroups; ++group) {
             get_pixel_ramp_integration(pr, rd, row, col, integ, group, idx);
+            if ((group>0) && (pr->groupdq[idx] & rd->jump)) {
+                crmag = pr->data[idx] - pr->data[idx-1];
+                dbg_ols_print("Row: %ld, Group: %ld, crmag = %.4f\n", row, group, crmag);
+            }
             idx++;
         }
         /* Check for 0th group and ZEROFRAME */

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -450,6 +450,9 @@ static PyObject *
 build_opt_res(struct ramp_data * rd);
 
 static void
+clean_opt_res(struct opt_res_product * opt_res);
+
+static void
 clean_pixel_ramp(struct pixel_ramp * pr);
 
 static void
@@ -1049,8 +1052,10 @@ build_opt_res(
     }
 
     /* Copy data from rd->segs to these arrays */
-    /* XXX check return value */
-    save_opt_res(&opt_res, rd);
+    if (save_opt_res(&opt_res, rd)) {
+        clean_opt_res(&opt_res);
+        return Py_None;
+    }
 
     /* Package arrays into output tuple */
     opt_res_info = Py_BuildValue("NNNNNNNNN",
@@ -1059,6 +1064,21 @@ build_opt_res(
         opt_res.cr_mag);
 
     return opt_res_info;
+}
+
+static void
+clean_opt_res(
+        struct opt_res_product * opt_res)
+{
+    Py_XDECREF(opt_res->slope);
+    Py_XDECREF(opt_res->sigslope);
+    Py_XDECREF(opt_res->var_p);
+    Py_XDECREF(opt_res->var_r);
+    Py_XDECREF(opt_res->yint);
+    Py_XDECREF(opt_res->sigyint);
+    Py_XDECREF(opt_res->pedestal);
+    Py_XDECREF(opt_res->weights);
+    Py_XDECREF(opt_res->cr_mag);
 }
 
 /*

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1637,7 +1637,10 @@ def test_cext_chargeloss():
 
 def test_crmag():
     """
-    Do something with the crmag from the optional results product.
+    A basic test with two ramps, one with jumps and one without, then
+    test to make sure the ramp with jumps has non-zero entries in the
+    'crmag' array in the optional results product, while the ramp with
+    no jumps is all zeros.
     """
     nints, ngroups, nrows, ncols = 1, 10, 1, 2
     rnval, gval = 0.7071, 1.

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1635,6 +1635,49 @@ def test_cext_chargeloss():
     assert svr[0, 1] == svr[0, 3]
 
 
+def test_crmag():
+    """
+    Do something with the crmag from the optional results product.
+    """
+    nints, ngroups, nrows, ncols = 1, 10, 1, 2
+    rnval, gval = 0.7071, 1.
+    frame_time, nframes, groupgap = 10.6, 1, 0
+    group_time = 10.6
+
+    dims = nints, ngroups, nrows, ncols
+    var = rnval, gval
+    tm = frame_time, nframes, groupgap
+
+    ramp, gain, rnoise = create_blank_ramp_data(dims, var, tm)
+
+    # Define data
+    base = 13.67
+    arr = np.array([(k+1) * base for k in range(ngroups)])
+    ramp.data[0, :, 0, 0] = arr
+    ramp.data[0, :, 0, 1] = arr * 1.34
+
+    # Add jumps
+    ramp.data[0, 3:, 0, 0] += 165.855
+    ramp.data[0, 7:, 0, 0] += 430.543
+    ramp.groupdq[0, 3, 0, 0] = JUMP
+    ramp.groupdq[0, 7, 0, 0] = JUMP
+
+    algo = DEFAULT_OLS
+    save_opt, ncores, bufsize = True, "none", 1024 * 30000
+    slopes, cube, ols_opt, gls_opt = ramp_fit_data(
+        ramp, bufsize, save_opt, rnoise, gain, algo, "optimal", ncores, dqflags
+    )
+
+    oslope, osigslope, ovp, ovr, oyint, osigyint, opedestal, oweights, ocrmag = ols_opt
+
+    tol = 1.e-4
+    check = np.array([179.52501, 444.213], dtype=np.float32)
+    np.testing.assert_allclose(ocrmag[0, :, 0, 0], check, tol)
+
+    check = np.array([0., 0.], dtype=np.float32)
+    np.testing.assert_allclose(ocrmag[0, :, 0, 1], check, tol)
+
+
 # -----------------------------------------------------------------------------
 #                           Set up functions
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3708](https://jira.stsci.edu/browse/JP-3708)
Resolves [JP-3771](https://jira.stsci.edu/browse/JP-3771)
Resolves [JP-3791](https://jira.stsci.edu/browse/JP-3791)

JP-3708: Add the CRMAG parameter to the optional results product in the C-extension.  This wasn't implemented with the C-extension, nor was it properly handled for multiprocessing.

JP-3771: Corrected bugs exposed by adding multiprocessing regression tests to the JWST regression testing suite.  The primary bug found was incorrect dimension sizes for internal arrays used for the optional results product.  The internal arrays should have dimensions of `(nints, nrows, ncols)`, but they had dimensions `(ngroups, nrows, ncols)`.  These incorrect dimensions caused memory corruption causing processes to freeze or segfault.

JP-3791: Corrected the CHARGELOSS recomputation of the read noise variance.  For multiprocessing the DQ flags were not being properly sliced and passed to the C-extension for recomputation.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
