### PR TITLE
Weight threshold part duex

### DIFF
--- a/changes/319.bugfix.rst
+++ b/changes/319.bugfix.rst
@@ -1,0 +1,1 @@
+Update weight threshold calculation in outlier detection to work around numpy bug that introduces small numerical differences for a mean of a masked array.

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -68,25 +68,15 @@ def compute_weight_threshold(weight, maskpt):
     float
         The weight threshold for this integration.
     '''
-    # necessary in order to assure that mask gets applied correctly
-    if hasattr(weight, '_mask'):
-        del weight._mask
-    mask_zero_weight = np.equal(weight, 0.)
-    mask_nans = np.isnan(weight)
-    # Combine the masks
-    weight_masked = np.ma.array(weight, mask=np.logical_or(
-        mask_zero_weight, mask_nans))
-    # Sigma-clip the unmasked data
-    weight_masked = sigma_clip(weight_masked,
-                               sigma=3,
-                               maxiters=5,
-                               masked=False,
-                               copy=False,
-                               )
-    mean_weight = np.mean(weight_masked)
-    # Mask pixels where weight falls below maskpt percent
-    weight_threshold = mean_weight * maskpt
-    return weight_threshold
+    return np.mean(
+        sigma_clip(
+            weight[np.isfinite(weight) & (weight != 0)],
+            sigma=3,
+            maxiters=5,
+            masked=False,
+            copy=False,
+        ),
+    dtype='f8') * maskpt
 
 
 def _abs_deriv(array):

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -77,7 +77,12 @@ def compute_weight_threshold(weight, maskpt):
     weight_masked = np.ma.array(weight, mask=np.logical_or(
         mask_zero_weight, mask_nans))
     # Sigma-clip the unmasked data
-    weight_masked = sigma_clip(weight_masked, sigma=3, maxiters=5)
+    weight_masked = sigma_clip(weight_masked,
+                               sigma=3,
+                               maxiters=5,
+                               masked=False,
+                               copy=False,
+                               )
     mean_weight = np.mean(weight_masked)
     # Mask pixels where weight falls below maskpt percent
     weight_threshold = mean_weight * maskpt

--- a/tests/outlier_detection/test_utils.py
+++ b/tests/outlier_detection/test_utils.py
@@ -92,7 +92,7 @@ def test_compute_weight_threshold_memory():
 
     # buffer to account for memory overhead needs to be small enough
     # to ensure that the array was not copied
-    fractional_memory_buffer = 1.9
+    fractional_memory_buffer = 0.9
     expected_mem = int(arr.nbytes*fractional_memory_buffer)
     with MemoryThreshold(str(expected_mem) + " B"):
         result = compute_weight_threshold(arr, 0.5)


### PR DESCRIPTION
This is "take 2" of https://github.com/spacetelescope/stcal/pull/312

At the moment this PR will create small numerical differences in the output of `compute_weight_threshold` but I'm convinced that the current behavior on main is incorrect and a by-product of related numpy bugs:
- https://github.com/numpy/numpy/issues/14462
- https://github.com/numpy/numpy/issues/25548
- https://github.com/numpy/numpy/issues/12313

A minimal example is:
```python
import numpy as np

one_f = np.float32(1)
s_f = np.spacing(one_f)
arr_f = np.array([one_f, one_f + s_f, one_f + s_f + s_f], dtype=np.float32)

one_d = np.float64(1)
arr_d = np.array([one_d, one_d + s_f, one_d + s_f + s_f], dtype=np.float64)

print(f"expected mean: {np.mean(arr_d)=}")
print(f"{np.mean(np.ma.array(arr_f, mask=False))=}")
print(f"{np.mean(arr_f, dtype='f8')=}")
```
Produces:
```
expected mean: np.mean(arr_d)=1.0000001192092896
np.mean(np.ma.array(arr_f, mask=False))=1.0000000794728596
np.mean(arr_f, dtype='f8')=1.0000001192092896
```
The second line is similar to what's occuring on main where a mean of a masked array of float32 values is producing a float64 that is incorrect (given the precision). The third line is similar to what is produced with this PR.

One added benefit is this PR appears to reduce the memory usage lower than #312 (as seen by the `0.9` vs `1.9` multiplier in the memory usage test). I believe this is due to providing a non-masked array to sigma clip to avoid the allocation here:
https://github.com/astropy/astropy/blob/3bd8b404bf558561da469128d570280f3b65e57f/astropy/stats/sigma_clipping.py#L400-L401

Further optimizations might require changes to sigma clip (which appears to create an array copy for `_compute_bounds`:
<img width="1459" alt="Screenshot 2024-11-14 at 1 34 03 PM" src="https://github.com/user-attachments/assets/51e7b730-b2f4-4caf-9a39-294a0cad3ff3">

Regression tests running:
Romancal: https://github.com/spacetelescope/RegressionTests/actions/runs/11956099949
JWST: https://github.com/spacetelescope/RegressionTests/actions/runs/11956106816
(these are expected to have a few minor differences)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
