### PR TITLE
revert #314 and #322

### DIFF
--- a/changes/314.bugfix.rst
+++ b/changes/314.bugfix.rst
@@ -1,1 +1,0 @@
-Do not evaluate the inverse WCS transform within the bounding box in cases where a resampled WCS is computed. Do not pass table columns to the WCS Shared API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "numpy >=1.21.2",
     "opencv-python-headless >=4.6.0.66",
     "asdf >=2.15.0",
-    "gwcs @ git+https://github.com/spacetelescope/gwcs.git@master",
+    "gwcs >= 0.18.1",
     "tweakwcs >=0.8.8",
     "requests >=2.22",
 ]

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -394,7 +394,7 @@ def compute_scale(
         msg = "If input WCS is spectral, a disp_axis must be given"
         raise ValueError(msg)
 
-    crpix = np.array(wcs.invert(*fiducial, with_bounding_box=False))
+    crpix = np.array(wcs.invert(*fiducial))
 
     delta = np.zeros_like(crpix)
     spatial_idx = np.where(np.array(wcs.output_frame.axes_type) == "SPATIAL")[0]
@@ -441,7 +441,7 @@ def compute_fiducial(wcslist: list,
         (low, high) values. The bounding_box is in the order of the axes, axes_order.
         For two inputs and axes_order(0, 1) the bounding box can be either
         ((xlow, xhigh), (ylow, yhigh)) or [[xlow, xhigh], [ylow, yhigh]].
-
+    
     Returns
     -------
     fiducial : np.ndarray
@@ -704,7 +704,7 @@ def wcs_from_sregions(
     footprints : list of np.ndarray or list of str
         If list elements are numpy arrays, each should have shape (N, 2) and contain
         (RA, Dec) vertices demarcating the footprint of the input WCSs.
-        If list elements are strings, each should be the S_REGION header keyword
+        If list elements are strings, each should be the S_REGION header keyword 
         containing (RA, Dec) vertices demarcating the footprint of the input WCSs.
 
     ref_wcs :
@@ -756,8 +756,8 @@ def wcs_from_sregions(
         The WCS object corresponding to the combined input footprints.
 
     """
-    footprints = [_sregion_to_footprint(s_region)
-                  if isinstance(s_region, str) else s_region
+    footprints = [_sregion_to_footprint(s_region) 
+                  if isinstance(s_region, str) else s_region 
                   for s_region in footprints]
     fiducial = _calculate_fiducial(footprints, crval=crval)
 

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -244,7 +244,7 @@ def input_catalog(datamodel):
     cat = amutils.get_catalog(fiducial[0], fiducial[1], search_radius=radius,
                               catalog=TEST_CATALOG)
 
-    x, y = w.world_to_pixel(cat["ra"].value, cat["dec"].value)
+    x, y = w.world_to_pixel(cat["ra"], cat["dec"])
     return Table({"x": x, "y": y})
 
 


### PR DESCRIPTION
#314 and #322 are causing jwst test failures. This PR reverts #314 and #322 to allow ongoing jwst and stcal work to be tested.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
