### PR TITLE
Fix issues in outlier det. due to GWCS.inverse enforcing bbox

### DIFF
--- a/changes/324.bugfix.rst
+++ b/changes/324.bugfix.rst
@@ -1,0 +1,1 @@
+Updated ``outlier_detection`` to work with the upcoming GWCS release that by default enables filtering of world coordinates by footprint of the bounding box on the sky for inverse transformations (world->detector).

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -284,7 +284,18 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, in_shape):
     log.debug("Bounding box from data shape: {}".format(bb))
 
     grid = gwcs.wcstools.grid_from_bounding_box(bb)
-    return np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
+
+    # temporarily disable the bounding box:
+    orig_bbox = out_wcs.bounding_box
+    out_wcs.bounding_box = None
+    try:
+        pixmap = np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
+    finally:
+        # restore bounding box:
+        if orig_bbox is not None:
+            out_wcs.bounding_box = orig_bbox
+
+    return pixmap
 
 
 def reproject(wcs1, wcs2):


### PR DESCRIPTION
Fixes failures in JWST pipeline due to GWCS inverse transformation enforcing bounding box.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
