### PR TITLE
JP-3824: Fix a bug in wcs_from_sregions when crpix is provided

### DIFF
--- a/changes/326.bugfix.rst
+++ b/changes/326.bugfix.rst
@@ -1,0 +1,4 @@
+Fix a bug in ``alignment.util.wcs_from_sregions()`` and
+``alignment.util.wcs_from_footprints()`` functions due to which, when the
+``crpix`` argument was provided, the bounding box of the created WCS was
+not adjusted to account for this ``crpix`` value.

--- a/changes/326.bugfix.rst
+++ b/changes/326.bugfix.rst
@@ -1,4 +1,3 @@
 Fix a bug in ``alignment.util.wcs_from_sregions()`` and
-``alignment.util.wcs_from_footprints()`` functions due to which, when the
-``crpix`` argument was provided, the bounding box of the created WCS was
-not adjusted to account for this ``crpix`` value.
+``alignment.util.wcs_from_footprints()`` functions that was causing incorrect WCS bounding boxes
+when the ``crpix`` argument was provided.

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -332,7 +332,12 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
     wcs_new.bounding_box = output_bounding_box
 
     if shape is None:
-        shape = [int(axs[1] - axs[0] + 0.5) for axs in output_bounding_box[::-1]]
+        if crpix is None:
+            shape = [
+                int(axs[1] - axs[0] + 0.5) for axs in output_bounding_box[::-1]
+            ]
+        else:
+            shape = [int(axs[1] + 1.5) for axs in output_bounding_box[::-1]]
 
     wcs_new.pixel_shape = shape[::-1]
     wcs_new.array_shape = shape

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -196,8 +196,6 @@ def _get_bounding_box_with_offsets(
     domain_max = np.max(domain_bounds, axis=1)
 
     native_crpix = ref_wcs.backward_transform(*fiducial)
-    # DEBUG: code to reproduce old results (for old unit test test_wcs_from_footprints)
-    native_crpix = (0.0, 0.0)
 
     if crpix is None:
         # shift the coordinates by domain_min so that all input footprints
@@ -216,15 +214,10 @@ def _get_bounding_box_with_offsets(
     domain_max += offsets
 
     if shape is None:
-        # shape = tuple(int(dmax + 0.5) for dmax in domain_max[::-1])
-        # bounding_box = tuple(
-        #     (-0.5, s - 0.5) for s in shape[::-1]
-        # )
-        # DEBUG: code to reproduce old results (for old unit test test_wcs_from_footprints)
-        bounding_box = tuple(
-            (0.0, dmax) for dmax in domain_max
-        )
         shape = tuple(int(dmax + 0.5) for dmax in domain_max[::-1])
+        bounding_box = tuple(
+            (-0.5, s - 0.5) for s in shape[::-1]
+        )
 
     else:
         # trim upper bounding box limits

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -320,9 +320,12 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
         output_bounding_box = bbox
     else:
         output_bounding_box = []
-        for axis_range, shift in zip(bbox, shifts):
+        for axis_range, minval, shift in zip(bbox, axis_min_values, shifts):
             output_bounding_box.append(
-                (axis_range[0] + shift, axis_range[1] + shift)
+                (
+                    axis_range[0] + shift + minval,
+                    axis_range[1] + shift + minval
+                )
             )
 
     wcs_new.insert_transform("detector", offsets, after=True)

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -221,6 +221,7 @@ def _get_bounding_box_with_offsets(
 
     else:
         # trim upper bounding box limits
+        shape = tuple(shape)
         bounding_box = tuple(
             (max(0, int(dmin + 0.5)) - 0.5, min(int(dmax + 0.5), sz) - 0.5)
             for dmin, dmax, sz in zip(domain_min, domain_max, shape[::-1])

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -332,7 +332,20 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
                 int(axs[1] - axs[0] + 0.5) for axs in output_bounding_box[::-1]
             ]
         else:
-            shape = [int(axs[1] + 1.5) for axs in output_bounding_box[::-1]]
+            shape = []
+            for k, axs in enumerate(output_bounding_box[::-1]):
+                upper = int(axs[1] + 0.5)
+                if upper < 1:
+                    log.warning(
+                        "Input images do not overlap with created WCS. "
+                        "Consider adjusting crval and/or crpix values."
+                    )
+                    log.warning(
+                        "Setting minimum array dimension for axis %d to 10."
+                        % (len(output_bounding_box) - k)
+                    )
+                    upper = 10
+                shape.append(upper)
 
     wcs_new.pixel_shape = shape[::-1]
     wcs_new.array_shape = shape

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -89,15 +89,18 @@ def _generate_tranform(
     wcsinfo : dict
         A dictionary containing the WCS FITS keywords and corresponding values.
 
-    pscale_ratio : int, None
+    ref_fiducial : np.array
+        A two-elements array containing the world coordinates of the fiducial point.
+
+    pscale_ratio : int, None, optional
         Ratio of input to output pixel scale. This parameter is only used when
         ``pscale=None`` and, in that case, it is passed on to ``compute_scale``.
 
-    pscale : float, None
+    pscale : float, None, optional
         The plate scale. If `None`, the plate scale is calculated from the reference
         datamodel.
 
-    rotation : float, None
+    rotation : float, None, optional
         Position angle of output image's Y-axis relative to North.
         A value of 0.0 would orient the final output image to be North up.
         The default of `None` specifies that the images will not be rotated,
@@ -107,10 +110,7 @@ def _generate_tranform(
         provided. If `None`, the rotation angle is extracted from the
         reference model's ``meta.wcsinfo.roll_ref``.
 
-    ref_fiducial : np.array
-        A two-elements array containing the world coordinates of the fiducial point.
-
-    transform : ~astropy.modeling.Model
+    transform : ~astropy.modeling.Model, None, optional
         A transform between frames.
 
     Returns
@@ -167,10 +167,10 @@ def _get_bounding_box_with_offsets(
     fiducial : tuple
         A tuple containing the world coordinates of the fiducial point.
 
-    crpix : list or tuple, optional
+    crpix : list or tuple, None, optional
         0-indexed pixel coordinates of the reference pixel.
 
-    shape : tuple, optional
+    shape : tuple, None, optional
         Shape (using `numpy.ndarray` convention) of the image array associated
         with the ``ref_wcs``.
 
@@ -277,10 +277,6 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
     wcs : ~gwcs.wcs.WCS
         The reference WCS object.
 
-    shape : list
-        The shape of the new WCS's pixel grid. If `None`, then the output bounding box
-        will be used to determine it.
-
     footprints : list
         A list of numpy arrays each of shape (N, 2) containing the
         (RA, Dec) vertices demarcating the footprint of the input WCSs.
@@ -289,10 +285,14 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
         A tuple containing the location on the sky in some standard
         coordinate system.
 
-    crpix : tuple, optional
+    shape : list, None, optional
+        The shape of the new WCS's pixel grid. If `None`, then the output bounding box
+        will be used to determine it.
+
+    crpix : tuple, None, optional
         0-indexed coordinates of the reference pixel.
 
-    transform : ~astropy.modeling.Model
+    transform : ~astropy.modeling.Model, None, optional
         An optional transform to be prepended to the transform constructed by the
         fiducial point. The number of outputs of this transform must equal the number
         of axes in the coordinate frame.
@@ -385,11 +385,11 @@ def compute_scale(
         Input fiducial of (RA, DEC) or (RA, DEC, Wavelength) used in calculating
         reference points.
 
-    disp_axis : int
+    disp_axis : int, None, optional
         Dispersion axis integer. Assumes the same convention as
         ``wcsinfo.dispersion_direction``
 
-    pscale_ratio : int
+    pscale_ratio : int, None, optional
         Ratio of input to output pixel scale
 
     Returns
@@ -445,7 +445,7 @@ def compute_fiducial(wcslist: list,
     wcslist : list
         A list containing all the WCS objects for which the fiducial is to be
         calculated.
-    bounding_box : tuple, list, None
+    bounding_box : tuple, list, None, optional
         The bounding box over which the WCS is valid. It can be a either tuple of tuples
         or a list of lists of size 2 where each element represents a range of
         (low, high) values. The bounding_box is in the order of the axes, axes_order.
@@ -595,23 +595,23 @@ def wcs_from_footprints(
     ref_wcsinfo : dict
         A dictionary containing the WCS FITS keywords and corresponding values.
 
-    transform : ~astropy.modeling.Model
+    transform : ~astropy.modeling.Model, None, optional
         A transform, passed to :py:func:`gwcs.wcstools.wcs_from_fiducial`
         If not supplied `Scaling | Rotation` is computed from ``refmodel``.
 
-    bounding_box : tuple
+    bounding_box : tuple, None, optional
         Bounding_box of the new WCS.
         If not supplied it is computed from the bounding_box of all inputs.
 
-    pscale_ratio : float, None
+    pscale_ratio : float, None, optional
         Ratio of input to output pixel scale. Ignored when either
         ``transform`` or ``pscale`` are provided.
 
-    pscale : float, None
+    pscale : float, None, optional
         Absolute pixel scale in degrees. When provided, overrides
         ``pscale_ratio``. Ignored when ``transform`` is provided.
 
-    rotation : float, None
+    rotation : float, None, optional
         Position angle of output image's Y-axis relative to North.
         A value of 0.0 would orient the final output image to be North up.
         The default of `None` specifies that the images will not be rotated,
@@ -620,22 +620,22 @@ def wcs_from_footprints(
         approximately to the detector axes. Ignored when ``transform`` is
         provided.
 
-    shape : tuple of int, None
+    shape : tuple of int, None, optional
         Shape of the image (data array) using ``np.ndarray`` convention
         (``ny`` first and ``nx`` second). This value will be assigned to
         ``pixel_shape`` and ``array_shape`` properties of the returned
         WCS object.
 
-    crpix : tuple of float, None
+    crpix : tuple of float, None, optional
         Position of the reference pixel in the image array.  If ``crpix`` is not
         specified, it will be set to the center of the bounding box of the
         returned WCS object.
 
-    crval : tuple of float, None
+    crval : tuple of float, None, optional
         Right ascension and declination of the reference pixel. Automatically
         computed if not provided.
 
-    wcs_list : list
+    wcs_list : list, None, optional
         A list of WCS objects. If not supplied, the WCS objects are extracted
         from the input datamodels.
 
@@ -717,26 +717,26 @@ def wcs_from_sregions(
         If list elements are strings, each should be the S_REGION header keyword
         containing (RA, Dec) vertices demarcating the footprint of the input WCSs.
 
-    ref_wcs :
+    ref_wcs : ~gwcs.wcs.WCS
         A WCS used as reference for the creation of the output
         coordinate frame, projection, and scaling and rotation transforms.
 
     ref_wcsinfo : dict
         A dictionary containing the WCS FITS keywords and corresponding values.
 
-    transform : ~astropy.modeling.Model
+    transform : ~astropy.modeling.Model, None, optional
         A transform, passed to :py:func:`gwcs.wcstools.wcs_from_fiducial`
         If not supplied `Scaling | Rotation` is computed from ``refmodel``.
 
-    pscale_ratio : float, None
+    pscale_ratio : float, None, optional
         Ratio of input to output pixel scale. Ignored when either
         ``transform`` or ``pscale`` are provided.
 
-    pscale : float, None
+    pscale : float, None, optional
         Absolute pixel scale in degrees. When provided, overrides
         ``pscale_ratio``. Ignored when ``transform`` is provided.
 
-    rotation : float, None
+    rotation : float, None, optional
         Position angle of output image's Y-axis relative to North.
         A value of 0.0 would orient the final output image to be North up.
         The default of `None` specifies that the images will not be rotated,
@@ -745,18 +745,18 @@ def wcs_from_sregions(
         approximately to the detector axes. Ignored when ``transform`` is
         provided.
 
-    shape : tuple of int, None
+    shape : tuple of int, None, optional
         Shape of the image (data array) using ``np.ndarray`` convention
         (``ny`` first and ``nx`` second). This value will be assigned to
         ``pixel_shape`` and ``array_shape`` properties of the returned
         WCS object.
 
-    crpix : tuple of float, None
+    crpix : tuple of float, None, optional
         Position of the reference pixel in the image array.  If ``crpix`` is not
         specified, it will be set to the center of the bounding box of the
         returned WCS object.
 
-    crval : tuple of float, None
+    crval : tuple of float, None, optional
         Right ascension and declination of the reference pixel. Automatically
         computed if not provided.
 
@@ -783,10 +783,10 @@ def wcs_from_sregions(
 
     return _calculate_new_wcs(
         wcs=ref_wcs,
-        shape=shape,
-        crpix=crpix,
         footprints=footprints,
         fiducial=fiducial,
+        shape=shape,
+        crpix=crpix,
         transform=transform,
     )
 
@@ -802,11 +802,11 @@ def compute_s_region_imaging(wcs: gwcs.wcs.WCS,
     wcs : ~gwcs.wcs.WCS
         The WCS object.
 
-    shape : tuple, optional
+    shape : tuple, None, optional
         Shape of input model data array. Used to compute the bounding box if not
         provided in the WCS object, and required in that case. The default is None.
 
-    center : bool, optional
+    center : bool, None, optional
         Whether or not to use the center of the pixel as reference for the
         coordinates, by default True
 

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -172,7 +172,7 @@ def _get_axis_min_and_bounding_box(footprints: list[np.ndarray],
     output_bounding_box = []
     for axis in ref_wcs.output_frame.axes_order:
         axis_min, axis_max = (
-            domain_bounds[axis].min(),
+            0.0,
             domain_bounds[axis].max(),
         )
         # populate output_bounding_box
@@ -327,25 +327,20 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
     wcs_new.bounding_box = output_bounding_box
 
     if shape is None:
-        if crpix is None:
-            shape = [
-                int(axs[1] - axs[0] + 0.5) for axs in output_bounding_box[::-1]
-            ]
-        else:
-            shape = []
-            for k, axs in enumerate(output_bounding_box[::-1]):
-                upper = int(axs[1] + 0.5)
-                if upper < 1:
-                    log.warning(
-                        "Input images do not overlap with created WCS. "
-                        "Consider adjusting crval and/or crpix values."
-                    )
-                    log.warning(
-                        "Setting minimum array dimension for axis %d to 10."
-                        % (len(output_bounding_box) - k)
-                    )
-                    upper = 10
-                shape.append(upper)
+        shape = []
+        for k, axs in enumerate(output_bounding_box[::-1]):
+            upper = int(axs[1] + 0.5)
+            if upper < 1:
+                log.warning(
+                    "Input images do not overlap with created WCS. "
+                    "Consider adjusting crval and/or crpix values."
+                )
+                log.warning(
+                    "Setting minimum array dimension for axis %d to 10."
+                    % (len(output_bounding_box) - k)
+                )
+                upper = 10
+            shape.append(upper)
 
     wcs_new.pixel_shape = shape[::-1]
     wcs_new.array_shape = shape

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -196,6 +196,8 @@ def _get_bounding_box_with_offsets(
     domain_max = np.max(domain_bounds, axis=1)
 
     native_crpix = ref_wcs.backward_transform(*fiducial)
+    # DEBUG: code to reproduce old results (for old unit test test_wcs_from_footprints)
+    native_crpix = (0.0, 0.0)
 
     if crpix is None:
         # shift the coordinates by domain_min so that all input footprints
@@ -214,15 +216,15 @@ def _get_bounding_box_with_offsets(
     domain_max += offsets
 
     if shape is None:
-        shape = tuple(int(dmax + 0.5) for dmax in domain_max[::-1])
-        bounding_box = tuple(
-            (-0.5, s - 0.5) for s in shape[::-1]
-        )
-        # code to reproduce old results (for old unit test test_wcs_from_footprints)
-        # bounding_box = tuple(
-        #     (0.0, dmax) for dmax in domain_max
-        # )
         # shape = tuple(int(dmax + 0.5) for dmax in domain_max[::-1])
+        # bounding_box = tuple(
+        #     (-0.5, s - 0.5) for s in shape[::-1]
+        # )
+        # DEBUG: code to reproduce old results (for old unit test test_wcs_from_footprints)
+        bounding_box = tuple(
+            (0.0, dmax) for dmax in domain_max
+        )
+        shape = tuple(int(dmax + 0.5) for dmax in domain_max[::-1])
 
     else:
         # trim upper bounding box limits

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -234,11 +234,6 @@ def _calculate_offsets(fiducial: tuple,
     ~astropy.modeling.Model
         A model with the offsets to be added to the WCS's transform.
 
-    tuple
-        A tuple of offset *values* that are to be *subtracted* from input
-        coordinates (negative values of offsets in the returned transform).
-        Note: these are equivalent to an effective 0-indexed "crpix".
-
     Notes
     -----
     If ``crpix=None``, then ``fiducial``, ``wcs``, and ``axis_min_values`` must be
@@ -257,7 +252,7 @@ def _calculate_offsets(fiducial: tuple,
         # assume 0-based CRPIX
         offset1, offset2 = crpix
 
-    return astmodels.Shift(-offset1, name="crpix1") & astmodels.Shift(-offset2, name="crpix2"), (offset1, offset2)
+    return astmodels.Shift(-offset1, name="crpix1") & astmodels.Shift(-offset2, name="crpix2")
 
 
 def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
@@ -309,7 +304,7 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
         input_frame=wcs.input_frame,
     )
     axis_min_values, bbox = _get_axis_min_and_bounding_box(footprints, wcs_new)
-    offsets, shifts = _calculate_offsets(
+    offsets = _calculate_offsets(
         fiducial=fiducial,
         wcs=wcs_new,
         axis_min_values=axis_min_values,
@@ -320,7 +315,7 @@ def _calculate_new_wcs(wcs: gwcs.wcs.WCS,
         output_bounding_box = bbox
     else:
         output_bounding_box = []
-        for axis_range, minval, shift in zip(bbox, axis_min_values, shifts):
+        for axis_range, minval, shift in zip(bbox, axis_min_values, crpix):
             output_bounding_box.append(
                 (
                     axis_range[0] + shift + minval,

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -215,10 +215,10 @@ def test_wcs_from_footprints(s_regions):
     # check that all elements of footprint match the *vertices* of the new
     # combined WCS
     footprnt = wcs.footprint()
-    assert all(np.isclose(footprnt[0], wcs(0, 0)))
-    assert all(np.isclose(footprnt[1], wcs(0, 4)))
-    assert all(np.isclose(footprnt[2], wcs(4, 4)))
-    assert all(np.isclose(footprnt[3], wcs(4, 0)))
+    assert all(np.isclose(footprnt[0], wcs(-0.5, -0.5)))
+    assert all(np.isclose(footprnt[1], wcs(-0.5, 3.5)))
+    assert all(np.isclose(footprnt[2], wcs(3.5, 3.5)))
+    assert all(np.isclose(footprnt[3], wcs(3.5, -0.5)))
 
     # check that fiducials match their expected coords in the new combined WCS
     assert all(np.isclose(wcs_1(0, 0), wcs(2.5, 1.5)))

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -214,18 +214,11 @@ def test_wcs_from_footprints(s_regions):
 
     # check that all elements of footprint match the *vertices* of the new
     # combined WCS
-
-    # footprnt = wcs.footprint()
-    # assert all(np.isclose(footprnt[0], wcs(-0.5, -0.5)))
-    # assert all(np.isclose(footprnt[1], wcs(-0.5, 3.5)))
-    # assert all(np.isclose(footprnt[2], wcs(3.5, 3.5)))
-    # assert all(np.isclose(footprnt[3], wcs(3.5, -0.5)))
-
-    # DEBUG: code to reproduce the old unit test:
-    assert all(np.isclose(wcs.footprint()[0], wcs(0, 0)))
-    assert all(np.isclose(wcs.footprint()[1], wcs(0, 4)))
-    assert all(np.isclose(wcs.footprint()[2], wcs(4, 4)))
-    assert all(np.isclose(wcs.footprint()[3], wcs(4, 0)))
+    footprnt = wcs.footprint()
+    assert all(np.isclose(footprnt[0], wcs(-0.5, -0.5)))
+    assert all(np.isclose(footprnt[1], wcs(-0.5, 3.5)))
+    assert all(np.isclose(footprnt[2], wcs(3.5, 3.5)))
+    assert all(np.isclose(footprnt[3], wcs(3.5, -0.5)))
 
     # check that fiducials match their expected coords in the new combined WCS
     assert all(np.isclose(wcs_1(0, 0), wcs(2.5, 1.5)))

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -214,11 +214,18 @@ def test_wcs_from_footprints(s_regions):
 
     # check that all elements of footprint match the *vertices* of the new
     # combined WCS
-    footprnt = wcs.footprint()
-    assert all(np.isclose(footprnt[0], wcs(-0.5, -0.5)))
-    assert all(np.isclose(footprnt[1], wcs(-0.5, 3.5)))
-    assert all(np.isclose(footprnt[2], wcs(3.5, 3.5)))
-    assert all(np.isclose(footprnt[3], wcs(3.5, -0.5)))
+
+    # footprnt = wcs.footprint()
+    # assert all(np.isclose(footprnt[0], wcs(-0.5, -0.5)))
+    # assert all(np.isclose(footprnt[1], wcs(-0.5, 3.5)))
+    # assert all(np.isclose(footprnt[2], wcs(3.5, 3.5)))
+    # assert all(np.isclose(footprnt[3], wcs(3.5, -0.5)))
+
+    # DEBUG: code to reproduce the old unit test:
+    assert all(np.isclose(wcs.footprint()[0], wcs(0, 0)))
+    assert all(np.isclose(wcs.footprint()[1], wcs(0, 4)))
+    assert all(np.isclose(wcs.footprint()[2], wcs(4, 4)))
+    assert all(np.isclose(wcs.footprint()[3], wcs(4, 0)))
 
     # check that fiducials match their expected coords in the new combined WCS
     assert all(np.isclose(wcs_1(0, 0), wcs(2.5, 1.5)))

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -29,9 +29,8 @@ def _create_wcs_object_without_distortion(
     pscale,
     shape,
 ):
-    # subtract 1 to account for pixel indexing starting at 0
-    shift = models.Shift(0) & models.Shift(0)
-
+    # subtract 0 shift to mimic a resampled WCS that does include shift transforms
+    shift = models.Shift() & models.Shift()
     scale = models.Scale(pscale[0]) & models.Scale(pscale[1])
 
     tan = models.Pix2Sky_TAN()

--- a/tests/test_ramp_fitting_gls_fit.py
+++ b/tests/test_ramp_fitting_gls_fit.py
@@ -677,12 +677,11 @@ def test_two_groups_unc():
     answer = slopes[2][50, 50]
     check = np.sqrt((deltaDN / gain) / group_time**2 + (rnoise**2 / group_time**2))
     tol = 1.0e-6
-    # print(f"answer = {answer}")
-    # print(f"check = {check}")
+
     np.testing.assert_allclose(answer, check, tol)
 
 
-@pytest.mark.skip(reason="GLS does not comopute VAR_XXX arrays.")
+@pytest.mark.skip(reason="GLS does not compute VAR_XXX arrays.")
 def test_five_groups_unc():
     """ """
     """


### PR DESCRIPTION
Resolves [JP-3824](https://jira.stsci.edu/browse/JP-3824)

`wcs_from_sregions` is used by `make_output_wcs` function in the JWST pipeline to compute output WCS of the resampled image for the `ResampleStep` . Currently `wcs_from_sregions` assigns a bounding box to the output WCS that is computed in the assumption that `crpix` is `(0, 0)` and it is not adjusted when `crpix` is provided by the user and when it is different from `(0, 0)`. This causes unit test failures in JWST pipeline when run with master branch of `gwcs` since now inverse WCS transforms check for bounding box.

A separate issue observed while working on this (which may or may not be an issue) is that currently `crpix` is considered 0-indexed while in FITS WCS standard it is 1-indexed.

## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
