### PR TITLE
update gwcs dependency to released version, update other dependencies (to allow minimum deps to pass)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "astropy >=5.0.4",
+    "astropy >=6.0.0",
     "drizzle>=1.15.0",
-    "scipy >=1.7.2",
-    "scikit-image>=0.19",
-    "numpy >=1.21.2",
+    "scipy >=1.14.1",
+    "scikit-image>=0.20.0",
+    "numpy >=1.25.0",
     "opencv-python-headless >=4.6.0.66",
-    "asdf >=2.15.0",
-    "gwcs @ git+https://github.com/spacetelescope/gwcs.git@master",
+    "asdf >=3.3.0",
+    "gwcs >=0.22.0",
     "tweakwcs >=0.8.8",
     "requests >=2.22",
 ]


### PR DESCRIPTION
Now that gwcs 0.22.0 is out we can remove the development dependency.

This updates the dependencies to use the new gwcs.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
