### PR TITLE
Saturation speedup

### DIFF
--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -135,6 +135,14 @@ def flag_saturated_pixels(
             else:
                 dilution_factor = 1
 
+            # No point in this step if the dilution factor is 1.  In
+            # that case, there is no way that we would have missed
+            # saturation before but flag it now, since the threshold
+            # would be the same.
+
+            if dilution_factor == 1:
+                continue
+
             # Find where this plane looks like it might saturate given
             # the dilution factor, *and* this group did not already get
             # flagged as saturated or do not use, *and* the next group

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -127,20 +127,21 @@ def flag_saturated_pixels(
             nextdq = gdq[ints, group + 1, :, :]
 
             # Determine the dilution factor due to group averaging
-            if read_pattern is not None:
-                # Single value dilution factor for this group
-                dilution_factor = np.mean(read_pattern[group]) / read_pattern[group][-1]
-                # Broadcast to array size
-                dilution_factor = np.where(no_sat_check_mask, 1, dilution_factor)
-            else:
-                dilution_factor = 1
 
             # No point in this step if the dilution factor is 1.  In
             # that case, there is no way that we would have missed
             # saturation before but flag it now, since the threshold
             # would be the same.
 
-            if dilution_factor == 1:
+            if read_pattern is not None:
+                # Single value dilution factor for this group
+                dilution_factor = np.mean(read_pattern[group]) / read_pattern[group][-1]
+                if dilution_factor == 1:
+                    continue
+                # Broadcast to array size
+                dilution_factor = np.where(no_sat_check_mask, 1, dilution_factor)
+            else:
+                dilution_factor = 1
                 continue
 
             # Find where this plane looks like it might saturate given


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3820](https://jira.stsci.edu/browse/JP-3820)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #

<!-- describe the changes comprising this PR here -->

This PR improves the performance of the saturation step, reducing its runtime by as much as a factor of 5-10 while leaving results unchanged.  It does this primarily with three changes. First, when a pixel saturates, that saturation is propagated into all subsequent reads using a running boolean tally of pixels that have saturated.  Second, ndimage.binary_dilation is very slow, an order of magnitude slower than writing the operations out explicitly.  Finally, if there is no averaging in groups, there is no point in the diluted saturation check; this check is skipped if the dilution factor is 1.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
