### PR TITLE
Fix wcs api call in tests

### DIFF
--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -244,7 +244,7 @@ def input_catalog(datamodel):
     cat = amutils.get_catalog(fiducial[0], fiducial[1], search_radius=radius,
                               catalog=TEST_CATALOG)
 
-    x, y = w.world_to_pixel(cat["ra"].value, cat["dec"].value)
+    x, y = w.world_to_pixel_values(cat["ra"].value, cat["dec"].value)
     return Table({"x": x, "y": y})
 
 


### PR DESCRIPTION
There are failures detected by the CI when using the dev version of GWCS. These are due to an incorrect call to the GWCS API that happened to work before when constructing test data. This PR fixes that for the tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
