### PR TITLE
JP-3686: Allow tweakreg to parse skycoord objects in absolute refcat

### DIFF
--- a/changes/333.bugfix.rst
+++ b/changes/333.bugfix.rst
@@ -1,0 +1,1 @@
+Allow tweakreg to parse absolute reference catalogs with skycoord objects in them

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -275,11 +275,12 @@ def _parse_sky_centroid(catalog: Table) -> Table:
             msg = ("Catalog contains both (RA, DEC) and sky_centroid. "
                    "Ignoring sky_centroid.")
             warnings.warn(msg, stacklevel=2)
+            catalog.remove_column("sky_centroid")
         return catalog
     if "sky_centroid" not in cols:
         msg = ("Absolute reference catalog contains neither RA, DEC "
                "nor sky_centroid.ra, sky_centroid.dec.")
-        raise ValueError(msg)
+        raise KeyError(msg)
     
     skycoord = catalog["sky_centroid"].to_table()
 

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -269,8 +269,8 @@ def _parse_sky_centroid(catalog: Table) -> Table:
     permits the use of catalogs directly from the jwst source_catalog step.
     No action is taken if the catalog already contains RA and DEC columns.
     """
-    cols = catalog.colnames
-    if ("RA" in cols) and ("DEC" in cols):
+    cols = [name.lower() for name in catalog.colnames]
+    if ("ra" in cols) and ("dec" in cols):
         if "sky_centroid" in cols:
             msg = ("Catalog contains both (RA, DEC) and sky_centroid. "
                    "Ignoring sky_centroid.")
@@ -283,8 +283,8 @@ def _parse_sky_centroid(catalog: Table) -> Table:
     
     skycoord = catalog["sky_centroid"].to_table()
 
-    catalog["RA"] = skycoord["ra"]
-    catalog["DEC"] = skycoord["dec"]
+    catalog["ra"] = skycoord["ra"]
+    catalog["dec"] = skycoord["dec"]
     catalog.remove_column("sky_centroid")
 
     return catalog


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3686](https://jira.stsci.edu/browse/JP-3686)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes spacetelescope/jwst#8639

<!-- describe the changes comprising this PR here -->

This PR allows the tweakreg step to parse absolute reference catalogs that resemble the output from the JWST `source_catalog` step.  That step reports absolute RA, DEC in columns called `sky_centroid.ra` and `sky_centroid.dec` which are parsed by into an astropy Table as a single column containing a SkyCoord.  This PR adds the functionality to re-cast this into RA/DEC columns as expected by `tweakwcs.align_wcs`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
