### PR TITLE
JP-3827: Remove unused error from ramp data

### DIFF
--- a/changes/334.apichange.rst
+++ b/changes/334.apichange.rst
@@ -1,0 +1,1 @@
+Removed all references to the unused ramp error array in dark, jump, and ramp fitting steps.

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -9,7 +9,7 @@ an input exposure. On output, the GROUPDQ array is updated with the DQ flag
 In addition, any pixels that have non-positive or NaN values in the gain
 reference file will have DQ flags "NO_GAIN_VALUE" and "DO_NOT_USE" set in the
 output PIXELDQ array.
-The SCI and ERR arrays of the input data are not modified.
+The SCI array of the input data is not modified.
 
 The current implementation uses the two-point difference method described
 in `Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_.

--- a/src/stcal/dark_current/dark_class.py
+++ b/src/stcal/dark_current/dark_class.py
@@ -27,8 +27,8 @@ class DarkData:
             during the dark current step.  This argument is only used if the
             'dark_model' argument is None.  If a dark model is not available
             from which to create a DarkData class, but the dimensions of the
-            data array are known, then 'dims' is used (the arrays data, groupdq,
-            and err are assumed to have the same dimension).
+            data array are known, then 'dims' is used (the arrays data
+            and groupdq are assumed to have the same dimension).
 
 
         dark_model : data model, optional
@@ -92,11 +92,6 @@ class ScienceData:
             self.groupdq = science_model.groupdq
             self.pixeldq = science_model.pixeldq
 
-            if isinstance(science_model.err, u.Quantity):
-                self.err = science_model.err.value
-            else:
-                self.err = science_model.err
-
             self.exp_nframes = science_model.meta.exposure.nframes
             self.exp_groupgap = science_model.meta.exposure.groupgap
             try:  # JWST only
@@ -109,7 +104,6 @@ class ScienceData:
             self.data = None
             self.groupdq = None
             self.pixeldq = None
-            self.err = None
 
             self.exp_nframes = None
             self.exp_groupgap = None

--- a/src/stcal/dark_current/dark_sub.py
+++ b/src/stcal/dark_current/dark_sub.py
@@ -322,9 +322,9 @@ def average_dark_frames_4d(dark_data, nints, ngroups, nframes, groupgap):
 
 def subtract_dark(science_data, dark_data):
     """
-    Subtracts dark current data from science arrays, combines
-    error arrays in quadrature, and updates data quality array based on
-    DQ flags in the dark arrays.
+    Subtracts dark current data from science arrays.
+
+    Also updates data quality array based on DQ flags in the dark arrays.
 
     Parameters
     ----------

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -29,12 +29,12 @@ def detect_jumps_data(jump_data):
     turn.
 
     Note that the detection methods are currently set up on the assumption
-    that the input science and error data arrays will be in units of
+    that the input science data array will be in units of
     electrons, hence this routine scales those input arrays by the detector
     gain. The methods assume that the read noise values will be in units
     of DN.
 
-    The gain is applied to the science data and error arrays using the
+    The gain is applied to the science data array using the
     appropriate instrument- and detector-dependent values for each pixel of an
     image.  Also, a 2-dimensional read noise array with appropriate values for
     each pixel is passed to the detection methods.
@@ -66,11 +66,10 @@ def detect_jumps_data(jump_data):
 
     pdq = setup_pdq(jump_data)
 
-    # Apply gain to the SCI, ERR, and readnoise arrays so they're in units
+    # Apply gain to the SCI and readnoise arrays so they're in units
     # of electrons
     data = jump_data.data * jump_data.gain_2d
     gdq = jump_data.gdq
-    # err = jump_data.err * jump_data.gain_2d
     readnoise_2d = jump_data.rnoise_2d * jump_data.gain_2d
 
     # also apply to the after_jump thresholds
@@ -120,7 +119,6 @@ def detect_jumps_data(jump_data):
         # Back out the applied gain to the SCI, ERR, and readnoise arrays so they're
         #    back in units of DN
         data /= jump_data.gain_2d
-        # err /= jump_data.gain_2d
         readnoise_2d /= jump_data.gain_2d
 
     # Return the updated data quality arrays

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -116,7 +116,7 @@ def detect_jumps_data(jump_data):
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", ".*in divide.*", RuntimeWarning)
-        # Back out the applied gain to the SCI, ERR, and readnoise arrays so they're
+        # Back out the applied gain to the SCI and readnoise arrays so they're
         #    back in units of DN
         data /= jump_data.gain_2d
         readnoise_2d /= jump_data.gain_2d

--- a/src/stcal/jump/jump_class.py
+++ b/src/stcal/jump/jump_class.py
@@ -434,7 +434,6 @@ class JumpData:
         self.data
         self.gdq
         self.pdq
-        self.err
         self.gain_2d
         self.rnoise_2d
         '''

--- a/src/stcal/ramp_fitting/likely_algo_classes.py
+++ b/src/stcal/ramp_fitting/likely_algo_classes.py
@@ -278,6 +278,8 @@ class Covar:
             Bias of the best-fit count rate from using cvec plus the observed
             resultants to estimate the covariance matrix.
         """
+        raise NotImplementedError('Bias calculations are not implemented.')
+
         alpha = countrates[np.newaxis, :] * self.alpha_phnoise[:, np.newaxis]
         alpha += sig**2 * self.alpha_readnoise[:, np.newaxis]
         beta = countrates[np.newaxis, :] * self.beta_phnoise[:, np.newaxis]

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -545,12 +545,11 @@ def slice_ramp_data(ramp_data, start_row, nrows):
 
     # Slice data by row
     data = ramp_data.data[:, :, start_row : start_row + nrows, :].copy()
-    err = ramp_data.err[:, :, start_row : start_row + nrows, :].copy()
     groupdq = ramp_data.groupdq[:, :, start_row : start_row + nrows, :].copy()
     pixeldq = ramp_data.pixeldq[start_row : start_row + nrows, :].copy()
     average_dark_current = ramp_data.average_dark_current[start_row : start_row + nrows, :].copy()
 
-    ramp_data_slice.set_arrays(data, err, groupdq, pixeldq, average_dark_current)
+    ramp_data_slice.set_arrays(data, groupdq, pixeldq, average_dark_current)
 
     if ramp_data.zeroframe is not None:
         ramp_data_slice.zeroframe = ramp_data.zeroframe[:, start_row : start_row + nrows, :].copy()
@@ -785,7 +784,6 @@ def endianness_handler(ramp_data, gain_2d, readnoise_2d):
     readnoise_2d, rn_bswap = handle_array_endianness(readnoise_2d, sys_order)
 
     ramp_data.data, _ = handle_array_endianness(ramp_data.data, sys_order)
-    ramp_data.err, _ = handle_array_endianness(ramp_data.err, sys_order)
     ramp_data.average_dark_current , _ = handle_array_endianness(ramp_data.average_dark_current, sys_order)
     ramp_data.groupdq, _ = handle_array_endianness(ramp_data.groupdq, sys_order)
     ramp_data.pixeldq, _ = handle_array_endianness(ramp_data.pixeldq, sys_order)
@@ -927,7 +925,6 @@ def discard_miri_groups(ramp_data):
         True if usable data available for further processing.
     """
     data = ramp_data.data
-    err = ramp_data.err
     groupdq = ramp_data.groupdq
     orig_gdq = ramp_data.orig_gdq
 
@@ -958,7 +955,6 @@ def discard_miri_groups(ramp_data):
 
     if num_bad_slices > 0:
         data = data[:, num_bad_slices:, :, :]
-        err = err[:, num_bad_slices:, :, :]
         if orig_gdq is not None:
             orig_gdq = orig_gdq[:, num_bad_slices:, :, :]
 
@@ -978,7 +974,6 @@ def discard_miri_groups(ramp_data):
             return False
 
         data = data[:, :-1, :, :]
-        err = err[:, :-1, :, :]
         groupdq = groupdq[:, :-1, :, :]
         if orig_gdq is not None:
             orig_gdq = orig_gdq[:, :-1, :, :]
@@ -993,7 +988,6 @@ def discard_miri_groups(ramp_data):
         return False
 
     ramp_data.data = data
-    ramp_data.err = err
     ramp_data.groupdq = groupdq
     if orig_gdq is not None:
         ramp_data.orig_gdq = orig_gdq
@@ -1061,7 +1055,6 @@ def ramp_fit_slopes(ramp_data, gain_2d, readnoise_2d, save_opt, weighting):
     """
     # Get image data information
     data = ramp_data.data
-    err = ramp_data.err
     groupdq = ramp_data.groupdq
     inpixeldq = ramp_data.pixeldq
 
@@ -1073,7 +1066,7 @@ def ramp_fit_slopes(ramp_data, gain_2d, readnoise_2d, save_opt, weighting):
     imshape = (nrows, ncols)
     cubeshape = (ngroups, *imshape)
 
-    # Get GROUP DQ and ERR arrays from input file
+    # Get GROUP DQ array from input file
     gdq_cube = groupdq
     gdq_cube_shape = gdq_cube.shape
 
@@ -1198,7 +1191,6 @@ def ramp_fit_slopes(ramp_data, gain_2d, readnoise_2d, save_opt, weighting):
         del pixeldq_sect
 
     ramp_data.data = data
-    ramp_data.err = err
     ramp_data.groupdq = groupdq
     ramp_data.pixeldq = inpixeldq
 
@@ -1282,7 +1274,6 @@ def ramp_fit_compute_variances(ramp_data, gain_2d, readnoise_2d, fit_slopes_ans)
     """
     # Get image data information
     data = ramp_data.data
-    err = ramp_data.err
     groupdq = ramp_data.groupdq
     inpixeldq = ramp_data.pixeldq
 
@@ -1440,7 +1431,6 @@ def ramp_fit_compute_variances(ramp_data, gain_2d, readnoise_2d, fit_slopes_ans)
         del segs_4
 
     ramp_data.data = data
-    ramp_data.err = err
     ramp_data.groupdq = groupdq
     ramp_data.pixeldq = inpixeldq
 

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -67,12 +67,11 @@ def create_ramp_fit_class(model, algorithm, dqflags=None, suppress_one_group=Fal
         del wh_chargeloss
 
     if isinstance(model.data, u.Quantity):
-        ramp_data.set_arrays(model.data.value, model.err.value, model.groupdq,
+        ramp_data.set_arrays(model.data.value, model.groupdq,
                              model.pixeldq, dark_current_array)
     else:
         ramp_data.set_arrays(
             model.data,
-            model.err,
             model.groupdq,
             model.pixeldq,
             dark_current_array,

--- a/src/stcal/ramp_fitting/ramp_fit_class.py
+++ b/src/stcal/ramp_fitting/ramp_fit_class.py
@@ -5,7 +5,6 @@ class RampData:
         """Creates an internal ramp fit class."""
         # Arrays from the data model
         self.data = None
-        self.err = None
         self.groupdq = None
         self.pixeldq = None
         self.average_dark_current = None
@@ -56,7 +55,7 @@ class RampData:
 
         self.debug = False
 
-    def set_arrays(self, data, err, groupdq, pixeldq, average_dark_current, orig_gdq=None):
+    def set_arrays(self, data, groupdq, pixeldq, average_dark_current, orig_gdq=None):
         """
         Set the arrays needed for ramp fitting.
 
@@ -64,10 +63,6 @@ class RampData:
         ---------
         data : ndarray
             4-D array containing the pixel information.  It has dimensions
-            (nintegrations, ngroups, nrows, ncols)
-
-        err : ndarray
-            4-D array containing the error information.  It has dimensions
             (nintegrations, ngroups, nrows, ncols)
 
         groupdq : ndarray (uint16)
@@ -89,7 +84,6 @@ class RampData:
         """
         # Get arrays from the data model
         self.data = data
-        self.err = err
         self.groupdq = groupdq
         self.pixeldq = pixeldq
         self.average_dark_current = average_dark_current
@@ -155,7 +149,6 @@ class RampData:
         print("-" * 80)
         print("    Array Types:")
         print(f"data : {type(self.data)}")
-        print(f"err : {type(self.err)}")
         print(f"groupdq : {type(self.groupdq)}")
         print(f"pixeldq : {type(self.pixeldq)}")
 
@@ -203,7 +196,6 @@ class RampData:
         print(f"Shape : {self.data.shape}")
         print(f"data : \n{self.data}")
         print(f"groupdq : \n{self.groupdq}")
-        # print(f"err : \n{self.err}")
         # print(f"pixeldq : \n{self.pixeldq}")
         print("-" * 80)
 
@@ -215,7 +207,6 @@ class RampData:
         print(f"    groupdq")
         for integ in range(self.data.shape[0]):
             print(f"[{integ}] {self.groupdq[integ, :, row, col]}")
-        # print(f"    err :\n{self.err[:, :, row, col]}")
         # print(f"    pixeldq :\n{self.pixeldq[row, col]}")
 
     def dbg_print_info(self):
@@ -258,7 +249,6 @@ class RampData:
 
         nints, ngroups, nrows, ncols = self.data.shape
         fd.write(f"{indent}data = np.zeros(({nints}, {ngroups}, 1, 1), dtype=np.float32)\n")
-        fd.write(f"{indent}err = np.zeros(({nints}, {ngroups}, 1, 1), dtype=np.float32)\n")
         fd.write(f"{indent}gdq = np.zeros(({nints}, {ngroups}, 1, 1), dtype=np.uint8)\n")
         fd.write(f"{indent}pdq = np.zeros((1, 1), dtype=np.uint32)\n")
 
@@ -267,7 +257,6 @@ class RampData:
         indent = INDENT
 
         fd.write(f"{indent}ramp_data.data = data\n")
-        fd.write(f"{indent}ramp_data.err = err\n")
         fd.write(f"{indent}ramp_data.groupdq = gdq\n")
         fd.write(f"{indent}ramp_data.pixeldq = pdq\n")
         fd.write(f"{indent}ramp_data.zeroframe = zframe\n\n")
@@ -288,11 +277,6 @@ class RampData:
         for integ in range(nints):
             arr_str = np.array2string(self.data[integ, :, row, col], precision=12, max_line_width=np.nan, separator=", ")
             fd.write(f"{indent}data[{integ}, :, 0, 0] = np.array({arr_str})\n")
-        fd.write("\n")
-
-        for integ in range(nints):
-            arr_str = np.array2string(self.err[integ, :, row, col], precision=12, max_line_width=np.nan, separator=", ")
-            fd.write(f"{indent}err[{integ}, :, 0, 0] = np.array({arr_str})\n")
         fd.write("\n")
 
         for integ in range(nints):

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -186,7 +186,6 @@ struct ramp_data {
 
     /* Functions to get the proper data. */
     float (*get_data)(PyArrayObject*, npy_intp, npy_intp, npy_intp, npy_intp);
-    float (*get_err)(PyArrayObject*, npy_intp, npy_intp, npy_intp, npy_intp);
     uint32_t (*get_pixeldq)(PyArrayObject*, npy_intp, npy_intp);
     float (*get_gain)(PyArrayObject*, npy_intp, npy_intp);
     float (*get_rnoise)(PyArrayObject*, npy_intp, npy_intp);
@@ -195,7 +194,6 @@ struct ramp_data {
 
     /* The 4-D arrays with dimensions (nints, ngroups, nrows, ncols) */
     PyArrayObject * data;       /* The 4-D science data */
-    PyArrayObject * err;        /* The 4-D err data */
     PyArrayObject * groupdq;    /* The 4-D group DQ array */
 
     PyArrayObject * orig_gdq;   /* The 4-D group DQ array */
@@ -1132,7 +1130,6 @@ clean_ramp_data(
 
     Py_XDECREF(rd->data);
     Py_XDECREF(rd->groupdq);
-    Py_XDECREF(rd->err);
     Py_XDECREF(rd->pixeldq);
     Py_XDECREF(rd->zframe);
     Py_XDECREF(rd->dcurrent);
@@ -2072,7 +2069,6 @@ get_ramp_data_arrays(
     rd->data = (PyArrayObject*)PyObject_GetAttrString(Py_ramp_data, "data");
     rd->groupdq = (PyArrayObject*)PyObject_GetAttrString(Py_ramp_data, "groupdq");
     rd->orig_gdq = (PyArrayObject*)PyObject_GetAttrString(Py_ramp_data, "orig_gdq");
-    rd->err = (PyArrayObject*)PyObject_GetAttrString(Py_ramp_data, "err");
     rd->pixeldq = (PyArrayObject*)PyObject_GetAttrString(Py_ramp_data, "pixeldq");
     rd->zframe = (PyArrayObject*)PyObject_GetAttrString(Py_ramp_data, "zeroframe");
     rd->dcurrent = (PyArrayObject*)PyObject_GetAttrString(Py_ramp_data, "average_dark_current");
@@ -2208,7 +2204,6 @@ get_ramp_data_new_validate(
     /* Validate the types for each of the ndarrays */
     if (!(
             (NPY_FLOAT==PyArray_TYPE(rd->data)) &&
-            (NPY_FLOAT==PyArray_TYPE(rd->err)) &&
             (NPY_UBYTE == PyArray_TYPE(rd->groupdq)) &&
             (NPY_UINT32 == PyArray_TYPE(rd->pixeldq)) &&
             (NPY_FLOAT==PyArray_TYPE(rd->dcurrent)) &&
@@ -2263,7 +2258,6 @@ get_ramp_data_getters(
         struct ramp_data * rd) /* The ramp data */
 {
     rd->get_data = get_float4;
-    rd->get_err = get_float4;
 
     rd->get_pixeldq = get_uint32_2;
 
@@ -2593,7 +2587,6 @@ print_ramp_data_types(
     printf("NPY_UBYTE = %d\n", NPY_UBYTE);
     printf("NPY_UINT322 = %d\n", NPY_UINT32);
     printf("PyArray_TYPE(rd->data))    = %d\n", PyArray_TYPE(rd->data));
-    printf("PyArray_TYPE(rd->err))     = %d\n", PyArray_TYPE(rd->err));
     printf("PyArray_TYPE(rd->groupdq)) = %d\n", PyArray_TYPE(rd->groupdq));
     printf("PyArray_TYPE(rd->pixeldq)) = %d\n", PyArray_TYPE(rd->pixeldq));
     printf("\n");
@@ -2655,7 +2648,6 @@ print_rd_type_info(struct ramp_data * rd) { /* The ramp data */
     print_delim();
     print_npy_types();
     dbg_ols_print("data = %d (%d)\n", PyArray_TYPE(rd->data), NPY_FLOAT);
-    dbg_ols_print("err  = %d (%d)\n", PyArray_TYPE(rd->err), NPY_FLOAT);
     dbg_ols_print("gdq  = %d (%d)\n", PyArray_TYPE(rd->groupdq), NPY_UBYTE);
     dbg_ols_print("pdq  = %d (%d)\n", PyArray_TYPE(rd->pixeldq), NPY_UINT32);
     dbg_ols_print("dcur = %d (%d)\n", PyArray_TYPE(rd->dcurrent), NPY_FLOAT);

--- a/tests/test_dark_current.py
+++ b/tests/test_dark_current.py
@@ -39,7 +39,6 @@ def make_rampmodel():
         ramp_data.data = np.full(dims, 1.0, dtype=np.float32)
         ramp_data.groupdq = np.zeros(dims, dtype=np.uint32)
         ramp_data.pixeldq = np.zeros(imshape, dtype=np.uint32)
-        ramp_data.err = np.zeros(dims, dtype=np.float32)
 
         ramp_data.instrument_name = "MIRI"
 
@@ -84,7 +83,6 @@ def setup_nrc_cube():
         ramp_data.data = np.zeros(dims, dtype=np.float32)
         ramp_data.groupdq = np.zeros(dims, dtype=np.uint32)
         ramp_data.pixeldq = np.zeros(dims, dtype=np.uint32)
-        ramp_data.err = np.zeros(dims, dtype=np.float32)
 
         ramp_data.instrument_name = "NIRCAM"
         ramp_data.exp_nframes = nframes
@@ -345,8 +343,7 @@ def test_dq_combine(make_rampmodel, make_darkmodel):
 def test_frame_avg(make_rampmodel, make_darkmodel):
     """
     Check that if NFRAMES>1 or GROUPGAP>0, the frame-averaged dark data are
-    subtracted group-by-group from science data groups and the ERR arrays
-    are not modified
+    subtracted group-by-group from science data groups.
     """
 
     # size of integration
@@ -382,7 +379,3 @@ def test_frame_avg(make_rampmodel, make_darkmodel):
     assert outfile.data[0, 1, 500, 500] == pytest.approx(1.45)
     assert outfile.data[0, 2, 500, 500] == pytest.approx(2.05)
     assert outfile.data[0, 3, 500, 500] == pytest.approx(2.65)
-
-    # check that the error array is not modified.
-    tol = 1.0e-6
-    np.testing.assert_allclose(outfile.err[:, :], 0, tol)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -156,9 +156,6 @@ def test_multiprocessing():
 
 
 def test_multiprocessing_big():
-    """
-    
-    """
     nints, ngroups, nrows, ncols = 1, 13, 2048, 7
     gval, rnval = 4., 10.
     frame_time, nframes, groupgap = 10.6, 1, 0

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -113,7 +113,6 @@ def test_multiprocessing():
     frame_time, nframes, groupgap = 10.6, 1, 0
 
     dims = nints, ngroups, nrows, ncols
-    var = rnval, gval
     tm = frame_time, nframes, groupgap
 
     jump_data = create_jump_data(dims, gval, rnval, tm)

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -198,11 +198,7 @@ def test_neg_med_rates_multi_integration_integ():
     # Passes C extension
     slopes, cube, optional, gls_dummy, dims = base_neg_med_rates_multi_integrations()
 
-    sdata, sdq, svp, svr, serr = slopes
-    idata, idq, ivp, ivr, ierr = cube
     tol = 1e-6
-
-    sdata, sdq, svp, svr, serr = slopes
     idata, idq, ivp, ivr, ierr = cube
 
     np.testing.assert_allclose(ivp[:, 0, 0], np.array([0.0, 0.0, 0.0]), tol)
@@ -217,7 +213,6 @@ def test_neg_med_rates_multi_integration_optional():
     """
     slopes, cube, optional, gls_dummy, dims = base_neg_med_rates_multi_integrations()
 
-    sdata, sdq, svp, svr, serr = slopes
     oslope, osigslope, ovp, ovr, oyint, osigyint, opedestal, oweights, ocrmag = optional
 
     tol = 1e-6
@@ -390,7 +385,6 @@ def jp_2326_test_setup():
 
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     dark_current = np.zeros((nrows, ncols), dtype=np.float32)
 
@@ -398,7 +392,7 @@ def jp_2326_test_setup():
     gdq[0, :, 0, 0] = dq.copy()
 
     ramp_data = RampData()
-    ramp_data.set_arrays(data=data, err=err, groupdq=gdq, pixeldq=pdq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data=data, groupdq=gdq, pixeldq=pdq, average_dark_current=dark_current)
     ramp_data.set_meta(
         name="MIRI", frame_time=2.77504, group_time=2.77504, groupgap=0, nframes=1, drop_frames1=None
     )
@@ -494,10 +488,6 @@ def test_2_group_cases():
     for k in range(npix):
         data[0, :, 0, k] = np.array(base_group)
 
-    err = np.zeros(dims, dtype=np.float32)  # Error data
-    for k in range(npix):
-        err[0, :, 0, k] = np.array(base_err)
-
     groupdq = np.zeros(dims, dtype=np.uint8)  # Group DQ
     for k in range(npix):
         groupdq[0, :, 0, k] = np.array(possibilities[k])
@@ -505,7 +495,7 @@ def test_2_group_cases():
     # Setup the RampData class to run ramp fitting on.
     ramp_data = RampData()
 
-    ramp_data.set_arrays(data, err, groupdq, pixeldq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data, groupdq, pixeldq, average_dark_current=dark_current)
 
     ramp_data.set_meta(
         name="NIRSPEC", frame_time=14.58889, group_time=14.58889, groupgap=0, nframes=1, drop_frames1=None
@@ -799,7 +789,6 @@ def create_zero_frame_data():
 
     # Create arrays for RampData.
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     zframe = np.ones(shape=(nints, nrows, ncols), dtype=np.float32)
@@ -831,7 +820,7 @@ def create_zero_frame_data():
 
     # Create RampData for testing.
     ramp_data = RampData()
-    ramp_data.set_arrays(data=data, err=err, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data=data, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
     ramp_data.set_meta(
         name="NIRCam",
         frame_time=frame_time,
@@ -927,7 +916,6 @@ def create_only_good_0th_group_data():
 
     # Create arrays for RampData.
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     dark_current = np.zeros((nrows, ncols), dtype=np.float32)
@@ -954,7 +942,7 @@ def create_only_good_0th_group_data():
 
     # Create RampData for testing.
     ramp_data = RampData()
-    ramp_data.set_arrays(data=data, err=err, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data=data, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
     ramp_data.set_meta(
         name="NIRCam",
         frame_time=frame_time,
@@ -1536,16 +1524,14 @@ def test_refcounter():
 
     b_data = sys.getrefcount(ramp.data)
     b_dq = sys.getrefcount(ramp.groupdq)
-    b_err = sys.getrefcount(ramp.err)
     b_pdq = sys.getrefcount(ramp.pixeldq)
     b_dc = sys.getrefcount(ramp.average_dark_current)
 
     wt, opt = "optimal", False
-    image, integ, opt= ols_slope_fitter(ramp, gain, rnoise, wt, opt)
+    ols_slope_fitter(ramp, gain, rnoise, wt, opt)
 
     a_data = sys.getrefcount(ramp.data)
     a_dq = sys.getrefcount(ramp.groupdq)
-    a_err = sys.getrefcount(ramp.err)
     a_pdq = sys.getrefcount(ramp.pixeldq)
     a_dc = sys.getrefcount(ramp.average_dark_current)
 
@@ -1553,7 +1539,6 @@ def test_refcounter():
     # memory will be properly managed.
     assert b_data == a_data
     assert b_dq == a_dq
-    assert b_err == a_err
     assert b_pdq == a_pdq
     assert b_dc == a_dc
 
@@ -1696,13 +1681,12 @@ def create_blank_ramp_data(dims, var, tm):
     group_time = (nframes + groupgap) * frame_time
 
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     dark_current = np.zeros(shape=(nrows, ncols), dtype = np.float32)
 
     ramp_data = RampData()
-    ramp_data.set_arrays(data=data, err=err, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data=data, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
     ramp_data.set_meta(
         name="NIRSpec",
         frame_time=frame_time,
@@ -1729,7 +1713,6 @@ def setup_inputs(dims, var, tm):
     nframes, gtime, dtime = tm
 
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     dark_current = np.zeros(shape=(nrows, ncols), dtype=np.float32)
@@ -1745,7 +1728,7 @@ def setup_inputs(dims, var, tm):
         data[c_int, :, :, :] = data[0, :, :, :].copy()
 
     ramp_data = RampData()
-    ramp_data.set_arrays(data=data, err=err, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data=data, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
     ramp_data.set_meta(
         name="MIRI", frame_time=dtime, group_time=gtime, groupgap=0, nframes=nframes, drop_frames1=None
     )
@@ -1803,16 +1786,11 @@ def create_test_2seg_obs(
     # Set up pixel DQ array
     pixdq = np.zeros(shape=(ncols, nrows), dtype=np.uint32)
 
-    # Set up err array
-    dims = (num_ints, num_grps1 + num_grps2 + 1, nrows, ncols)
-    err = np.ones(shape=dims, dtype=np.float32)
-
     # Set up RampData class
     ramp_data = RampData()
     dark_current = np.zeros((nrows, ncols), dtype=np.float32)
     ramp_data.set_arrays(
         data=outdata,
-        err=err,
         groupdq=outgdq,
         pixeldq=pixdq,
         average_dark_current=dark_current)

--- a/tests/test_ramp_fitting_cases.py
+++ b/tests/test_ramp_fitting_cases.py
@@ -785,13 +785,12 @@ def create_blank_ramp_data(dims, var, timing, ts_name="NIRSpec"):
     groupgap = 0
 
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     dark_current = np.zeros(shape=(nrows, ncols), dtype=np.float32)
 
     ramp_data = RampData()
-    ramp_data.set_arrays(data=data, err=err, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data=data, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
     ramp_data.set_meta(
         name=ts_name,
         frame_time=frame_time,

--- a/tests/test_ramp_fitting_gls_fit.py
+++ b/tests/test_ramp_fitting_gls_fit.py
@@ -62,14 +62,13 @@ def setup_inputs(dims, gain, rnoise, group_time, frame_time):
 
     # Create zero arrays according to dimensions
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     groupdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     pixeldq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     dark_current = np.zeros(shape=(nrows, ncols), dtype=np.float32)
 
 
     # Set clas arrays
-    ramp_class.set_arrays(data, err, groupdq, pixeldq, average_dark_current=dark_current)
+    ramp_class.set_arrays(data, groupdq, pixeldq, dark_current)
 
     # Set class meta
     ramp_class.set_meta(
@@ -227,7 +226,7 @@ def test_error_when_frame_time_not_set():
 
     save_opt, algo, ncores = False, "GLS", "none"
     with pytest.raises(UnboundLocalError):
-        slopes, cube, ols_opt, gls_opt = ramp_fit_data(
+        ramp_fit_data(
             ramp_data, 512, save_opt, rnoise2d, gain2d, algo, "optimal", ncores, test_dq_flags
         )
 

--- a/tests/test_ramp_fitting_likely_fit.py
+++ b/tests/test_ramp_fitting_likely_fit.py
@@ -36,13 +36,12 @@ def create_blank_ramp_data(dims, var, tm):
     group_time = (nframes + groupgap) * frame_time
 
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
-    err = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
     pixdq = np.zeros(shape=(nrows, ncols), dtype=np.uint32)
     gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.uint8)
     dark_current = np.zeros(shape=(nrows, ncols), dtype = np.float32)
 
     ramp_data = RampData()
-    ramp_data.set_arrays(data=data, err=err, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
+    ramp_data.set_arrays(data=data, groupdq=gdq, pixeldq=pixdq, average_dark_current=dark_current)
     ramp_data.set_meta(
         name="NIRSpec",
         frame_time=frame_time,
@@ -375,9 +374,7 @@ def test_too_few_group_ramp(ngroups):
     ramp_data.data[0, :, 0, 0] = ramp
 
     with pytest.raises(ValueError):
-        image_info, integ_info, opt_info = likely_ramp_fit(
-            ramp_data, rnoise2d, gain2d
-        )
+        likely_ramp_fit(ramp_data, rnoise2d, gain2d)
 
 
 @pytest.mark.parametrize("nframes", [1, 2, 4, 8])
@@ -611,9 +608,8 @@ def dbg_print_slopes(slope, pix=(0, 0), label=None):
 
 def dbg_print_cube(cube, pix=(0, 0), label=None):
     data, dq, vp, vr, err = cube
-    data1, dq1, vp1, vr1, err1 = cube1
     row, col = pix
-    nints = data1.shape[0]
+    nints = data.shape[0]
 
     print(" ")
     print(DELIM)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3827](https://jira.stsci.edu/browse/JP-3827)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

This PR removes references to the unused error array from the 4D ramp models. In the jwst pipeline, error values are not meaningful until after ramp fitting.

I also did a little minor cleaning for trivial things I noticed while making this change.  I'll note any significant differences.

Requires:
https://github.com/spacetelescope/stdatamodels/pull/384
https://github.com/spacetelescope/jwst/pull/9109

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
