### PR TITLE
JP-3793: Fix numbers of flagged groups

### DIFF
--- a/changes/338.bugfix.rst
+++ b/changes/338.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in the jump step with counting the number of usable groups.

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -246,10 +246,9 @@ def find_crs_old(
     sig_clip_grps_fails = False
     total_noise_min_grps_fails = False
 
-    # Determine whether there are enough usable groups the two sigma clip options
-    if (only_use_ints and nints < minimum_sigclip_groups) \
-            or \
-            (not only_use_ints and total_sigclip_groups < minimum_sigclip_groups):
+    # Determine whether there are enough usable groups for the two sigma clip options
+    if ((only_use_ints and nints < minimum_sigclip_groups)
+        or (not only_use_ints and total_sigclip_groups < minimum_sigclip_groups)):
         sig_clip_grps_fails = True
     if min_usable_groups < minimum_groups:
         total_noise_min_grps_fails = True

--- a/tests/test_jump_twopoint_difference.py
+++ b/tests/test_jump_twopoint_difference.py
@@ -24,9 +24,6 @@ def setup_cube():
 
 def test_sigclip_not_enough_groups(setup_cube):
     ngroups = 10
-    nints = 9
-    nrows = 200
-    ncols = 200
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
     out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
         data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
@@ -37,9 +34,6 @@ def test_sigclip_not_enough_groups(setup_cube):
 
 def test_sigclip_not_enough_groups(setup_cube):
     ngroups = 5
-    nints = 9
-    nrows = 200
-    ncols = 200
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
     out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
         data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
@@ -50,9 +44,6 @@ def test_sigclip_not_enough_groups(setup_cube):
 
 def test_sigclip_not_enough_groups(setup_cube):
     ngroups = 12
-    nints = 9
-    nrows = 200
-    ncols = 200
 
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
     data[0, 0:2, 0:, 0] = 1

--- a/tests/test_jump_twopoint_difference.py
+++ b/tests/test_jump_twopoint_difference.py
@@ -22,7 +22,7 @@ def setup_cube():
 
     return _cube
 
-def test_sigclip_not_enough_groups(setup_cube):
+def test_sigclip_not_enough_groups_ng10(setup_cube):
     ngroups = 10
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
     out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
@@ -32,7 +32,7 @@ def test_sigclip_not_enough_groups(setup_cube):
     )
     assert total_crs == -99
 
-def test_sigclip_not_enough_groups(setup_cube):
+def test_sigclip_not_enough_groups_ng5(setup_cube):
     ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
     out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
@@ -42,7 +42,7 @@ def test_sigclip_not_enough_groups(setup_cube):
     )
     assert total_crs == -99
 
-def test_sigclip_not_enough_groups(setup_cube):
+def test_sigclip_not_enough_groups_ng12(setup_cube):
     ngroups = 12
 
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
@@ -54,7 +54,7 @@ def test_sigclip_not_enough_groups(setup_cube):
     )
     assert total_crs == -99
 
-def test_sigclip_with_num_small_groups(setup_cube):
+def test_sigclip_with_num_small_groups_ni190(setup_cube):
     ngroups = 12
     nints = 190
 
@@ -67,7 +67,7 @@ def test_sigclip_with_num_small_groups(setup_cube):
     )
     assert total_crs != -99
 
-def test_nosigclip_with_enough_groups(setup_cube):
+def test_nosigclip_with_enough_groups_ni1(setup_cube):
     ngroups = 12
     nints = 1
 
@@ -80,7 +80,7 @@ def test_nosigclip_with_enough_groups(setup_cube):
     )
     assert total_crs != -99
 
-def test_nosigclip_with_num_small_groups(setup_cube):
+def test_nosigclip_with_num_small_groups_ni1(setup_cube):
     ngroups = 4
     nints = 1
 
@@ -93,7 +93,7 @@ def test_nosigclip_with_num_small_groups(setup_cube):
     )
     assert total_crs == -99
 
-def test_nosigclip_with_num_small_groups(setup_cube):
+def test_nosigclip_with_num_small_groups_ni100(setup_cube):
     ngroups = 4
     nints = 100
 

--- a/tests/test_jump_twopoint_difference.py
+++ b/tests/test_jump_twopoint_difference.py
@@ -22,6 +22,98 @@ def setup_cube():
 
     return _cube
 
+def test_sigclip_not_enough_groups(setup_cube):
+    ngroups = 10
+    nints = 9
+    nrows = 200
+    ncols = 200
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
+    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
+        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
+        nframes, False, 200, 10, DQFLAGS,
+        minimum_sigclip_groups=10, minimum_groups=5
+    )
+    assert total_crs == -99
+
+def test_sigclip_not_enough_groups(setup_cube):
+    ngroups = 5
+    nints = 9
+    nrows = 200
+    ncols = 200
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
+    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
+        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
+        nframes, False, 200, 10, DQFLAGS,
+        minimum_sigclip_groups=11, minimum_groups=6
+    )
+    assert total_crs == -99
+
+def test_sigclip_not_enough_groups(setup_cube):
+    ngroups = 12
+    nints = 9
+    nrows = 200
+    ncols = 200
+
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
+    data[0, 0:2, 0:, 0] = 1
+    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
+        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
+        nframes, False, 200, 10, DQFLAGS,
+        minimum_sigclip_groups=11, minimum_groups=16
+    )
+    assert total_crs == -99
+
+def test_sigclip_with_num_small_groups(setup_cube):
+    ngroups = 12
+    nints = 190
+
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=nints, nrows=2, ncols=2, readnoise=8)
+    data[0, 0:2, 0:, 0] = 1
+    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
+        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
+        nframes, False, 200, 10, DQFLAGS,
+        minimum_sigclip_groups=11, minimum_groups=16
+    )
+    assert total_crs != -99
+
+def test_nosigclip_with_enough_groups(setup_cube):
+    ngroups = 12
+    nints = 1
+
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=nints, nrows=2, ncols=2, readnoise=8)
+    data[0, 0:2, 0:, 0] = 1
+    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
+        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
+        nframes, False, 200, 10, DQFLAGS,
+        minimum_sigclip_groups=11, minimum_groups=5
+    )
+    assert total_crs != -99
+
+def test_nosigclip_with_num_small_groups(setup_cube):
+    ngroups = 4
+    nints = 1
+
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=nints, nrows=2, ncols=2, readnoise=8)
+    data[0, 0:2, 0:, 0] = 1
+    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
+        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
+        nframes, False, 200, 10, DQFLAGS,
+        minimum_sigclip_groups=11, minimum_groups=16
+    )
+    assert total_crs == -99
+
+def test_nosigclip_with_num_small_groups(setup_cube):
+    ngroups = 4
+    nints = 100
+
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=nints, nrows=2, ncols=2, readnoise=8)
+    data[0, 0:2, 0:, 0] = 1
+    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
+        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
+        nframes, False, 200, 10, DQFLAGS,
+        minimum_sigclip_groups=100, minimum_groups=16
+    )
+    assert total_crs != -99
 
 def test_varying_groups(setup_cube):
     ngroups = 5

--- a/tests/test_jump_twopoint_difference.py
+++ b/tests/test_jump_twopoint_difference.py
@@ -22,16 +22,6 @@ def setup_cube():
 
     return _cube
 
-def test_sigclip_not_enough_groups_ng10(setup_cube):
-    ngroups = 10
-    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)
-    out_gdq, row_below_gdq, rows_above_gdq, total_crs, stddev = find_crs(
-        data, gdq, read_noise, rej_threshold, rej_threshold, rej_threshold,
-        nframes, False, 200, 10, DQFLAGS,
-        minimum_sigclip_groups=10, minimum_groups=5
-    )
-    assert total_crs == -99
-
 def test_sigclip_not_enough_groups_ng5(setup_cube):
     ngroups = 5
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, nints=8, nrows=2, ncols=2, readnoise=8)


### PR DESCRIPTION
Resolves [JP-3793](https://jira.stsci.edu/browse/JP-3793) regarding inaccurate calculation of the number of groups in the jump step.  This PR updates prior https://github.com/spacetelescope/stcal/pull/317 to account for recent unrelated changes.

EDIT: See also [JP-3877](https://jira.stsci.edu/browse/JP-3877).  This PR ensures that long TSO exposures don't fall into the wrong processing type, reducing runtime from over an hour to about 1 minute in the example given there.