### PR TITLE
Fixed argmax -> nanargmax

### DIFF
--- a/changes/344.bugfix.rst
+++ b/changes/344.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in ``jump.twopointdifference.calc_med_first_diffs()`` where ``argmax`` was being used instead of ``nanargmax``.

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -567,7 +567,7 @@ def calc_med_first_diffs(in_first_diffs):
         num_usable_diffs = first_diffs.size - np.sum(np.isnan(first_diffs), axis=(0, 1))
         if num_usable_diffs >= 4:  # if 4+, clip largest and return median
             mask = np.ones_like(first_diffs).astype(bool)
-            location = np.unravel_index(first_diffs.argmax(), first_diffs.shape)
+            location = np.unravel_index(np.nanargmax(first_diffs), first_diffs.shape)
             mask[location] = False  # clip the diff with the largest abs value
             return np.nanmedian(first_diffs[mask])
         elif num_usable_diffs == 3:  # if 3, no clipping just return median


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3894](https://jira.stsci.edu/browse/JP-3894)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #

<!-- describe the changes comprising this PR here -->

This PR fixes a bug where, for iterative flagging of jumps in a pixel, NaN values were not ignored when determining the maximum value. This affects jump detection results for pixels with >=4 valid groups and with at least one NaN in the ramp or set of ramps (if there are multiple integrations).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
