### PR TITLE
JP-3737: Handle micrometeorite flashes (v2)

### DIFF
--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -112,6 +112,10 @@ def detect_jumps_data(jump_data):
         log.info("Total showers= %i", num_showers)
         number_extended_events = num_showers  # XXX overwritten
 
+    # This controls flagging of micrometeorite flashes
+    if (jump_data.mmflashfrac < 1.0):
+        gdq = find_micrometeorite_flashes(gdq, jump, jump_data.mmflashfrac)
+
     elapsed = time.time() - start
     log.info("Total elapsed time = %g sec", elapsed)
 
@@ -1349,3 +1353,60 @@ def calc_num_slices(n_rows, max_cores, max_available):
 
     # Make sure we don't have more slices than rows or available cores.
     return min([n_rows, n_slices, max_available])
+
+
+# Find micrometeorite flashes
+def find_micrometeorite_flashes(gdq, jump_flag, mmflashfrac, mmflashnmax=5):
+    """
+    This routine looks for micrometeorite flashes that light up the entire array in a small number
+    of groups.  It does this by looking for cases where greater than mmflash_pct percent
+    of the array is flagged as 'JUMP_DET', and flags the entire array as JUMP_DET in such cases.
+    Since such flashes are rare (a few per instrument per year, although they can affect 2-3 groups)
+    this routine also applies a safety catch to ensure that not too many are flagged in any one
+    exposure due to unexpected detector effects.
+    Parameters
+    ----------
+    gdq : int, 4D array
+        Group dq array
+    jump_flag : int
+        DQ flag for jump detection.
+    mmflashfrac : float
+        Fraction of the array that can be flagged as a jump before the entire array
+        will be flagged.
+    mmflashnmax : float
+        Maximum number of groups in any given exposure that can be affected by
+        micrometeorites before we declare a detection failure and flag nothing.
+    Returns
+    -------
+    gdq : int, 4D array
+        Updated group dq array
+    """
+    log.info("Looking for micrometeorite flashes")
+    nints, ngroups, nrows, ncols = gdq.shape
+    npix = nrows * ncols # Number of pixels in array
+
+    # Initial loop over integrations + groups to find flashes
+    flash_int, flash_group = [], []
+
+    # Loop over integrations
+    for ii in range(0, nints):
+        # Loop over groups
+        for jj in range(0, ngroups):
+            indx = np.where(gdq[ii, jj, :, :] & jump_flag != 0)
+            fraction = float(len(indx[0])) / npix
+            if (fraction > mmflashfrac):
+                flash_int.append(ii)
+                flash_group.append(jj)
+
+    # If an unrealistically large number of flashes were found, fail out
+    nflash=len(flash_int)
+    if (nflash > mmflashnmax):
+        log.info(f"Unreasonably large number of possible micrometeorite flashes detected ({nflash})")
+        log.info("Quitting micrometeorite routine and flagging nothing.")
+    else:
+        for kk in range(0, nflash):
+            ii, jj = flash_int[kk], flash_group[kk]
+            gdq[ii, jj, :, :] = gdq[ii, jj, :, :] | jump_flag
+            log.info(f"Flagged a micrometeorite flash in integ = {ii}, group = {jj}")
+
+    return gdq

--- a/src/stcal/jump/jump_class.py
+++ b/src/stcal/jump/jump_class.py
@@ -192,6 +192,10 @@ class JumpData:
         # subsequent integrations.
         self.persist_grps_flagged = 25
 
+        # Fraction of pixels that can be flagged as JUMP in a given group before flagging the entire
+        # array as JUMP due to a likely micrometeorite event
+        self.mmflashfrac = 1.0
+
         # Multiprocessing, data a sliced by row
         self.max_cores = None  # Number of processes
         self.start_row = 0  # Start row of current slice
@@ -568,5 +572,6 @@ class JumpData:
         oline += f"grps_masked_after_shower = {self.grps_masked_after_shower}\n"
         oline += f"mask_persist_grps_next_int = {self.mask_persist_grps_next_int}\n"
         oline += f"persist_grps_flagged = {self.persist_grps_flagged}\n"
+        oline += f"mmflashfrac = {self.mmflashfrac}\n"
         oline += f"{DELIM}\n\n"
         return oline


### PR DESCRIPTION
This PR addresses JP-3737 by adding an additional check in the jump step to look for micrometeorite flashes, which manifest as bursts of jumps across a large fraction of the detector.  This replaces prior PR https://github.com/spacetelescope/stcal/pull/308, updating it to work with the refactored jump step.  Corresponding jwst PR is https://github.com/spacetelescope/jwst/pull/9253

Kept in draft form for now pending potential future modifications.