### PR TITLE
JP-3726: Resource Warnings when Using Multiprocessing

### DIFF
--- a/changes/350.bugfix.rst
+++ b/changes/350.bugfix.rst
@@ -1,0 +1,1 @@
+Changed multiprocessing from forkserver to spawn.

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -164,7 +164,7 @@ def twopoint_diff_multi(jump_data, twopt_params, data, gdq, readnoise_2d, n_slic
     slices, yinc = slice_data(twopt_params, data, gdq, readnoise_2d, n_slices)
 
     log.info("Creating %d processes for jump detection ", n_slices)
-    ctx = multiprocessing.get_context("forkserver")
+    ctx = multiprocessing.get_context("spawn")
     pool = ctx.Pool(processes=n_slices)
     ######### JUST FOR DEBUGGING #########################
     # pool = ctx.Pool(processes=1)

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -160,7 +160,7 @@ def ols_ramp_fit_multiprocessing(
         ramp_data, buffsize, save_opt, readnoise_2d, gain_2d, weighting, number_slices
     )
 
-    ctx = multiprocessing.get_context("forkserver")
+    ctx = multiprocessing.get_context("spawn")
     pool = ctx.Pool(processes=number_slices)
     pool_results = pool.starmap(ols_ramp_fit_single, slices)
     pool.close()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3726](https://jira.stsci.edu/browse/JP-3726)

<!-- describe the changes comprising this PR here -->

This PR addresses when running the detector 1 pipeline, "No space left on device" and "warnings.warn('resource_tracker: There appear to be %d '" warnings appeared.  On @melanieclarke's recommendation, I switched the multiprocessing from "forkserver" to "spawn" and those warnings disappeared.  

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
