### PR TITLE
Bugfix source catalog passed into tweakwcs

### DIFF
--- a/changes/355.bugfix.rst
+++ b/changes/355.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix catalog parsing for tweakreg absolute refcat

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -286,6 +286,8 @@ def _parse_sky_centroid(catalog: Table) -> Table:
                    "and sky_centroid columns. Ignoring sky_centroid.")
             warnings.warn(msg, stacklevel=2)
             catalog.remove_column("sky_centroid")
+        catalog["ra"].name = "RA"
+        catalog["dec"].name = "DEC"
         return catalog
 
     if ncentroid > 1:
@@ -300,8 +302,8 @@ def _parse_sky_centroid(catalog: Table) -> Table:
     
     # Convert SkyCoord object to RA/DEC
     skycoord = catalog["sky_centroid"].to_table()
-    catalog["ra"] = skycoord["ra"]
-    catalog["dec"] = skycoord["dec"]
+    catalog["RA"] = skycoord["ra"]
+    catalog["DEC"] = skycoord["dec"]
     catalog.remove_column("sky_centroid")
 
     return catalog

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -247,14 +247,18 @@ def _parse_refcat(abs_refcat: str | Path,
                         ref_wcsinfo=wcsinfo,
         )
 
-        return create_astrometric_catalog(
+        ref_table = create_astrometric_catalog(
             combined_wcs, epoch,
             catalog=gaia_cat_name,
             output=output_name,
         )
+        ref_table.meta["name"] = gaia_cat_name # accessed by tweakwcs log message
+        return ref_table
 
     if Path(abs_refcat).is_file():
-        return _parse_sky_centroid(Table.read(abs_refcat))
+        ref_table = Table.read(abs_refcat)
+        ref_table.meta["name"] = Path(abs_refcat).name # accessed by tweakwcs log message
+        return _parse_sky_centroid(ref_table)
 
     msg = (f"Invalid 'abs_refcat' value: {abs_refcat}. 'abs_refcat' must be "
            "a path to an existing file name or one of the supported "

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -230,10 +230,12 @@ def test_parse_refcat(datamodel, abs_refcat, tmp_path):
                            datamodel.meta.wcsinfo,
                            epoch)
     assert isinstance(refcat, Table)
+    assert refcat.meta["name"] == CATALOG_FNAME
 
     # find refcat from web
     refcat = _parse_refcat(TEST_CATALOG, correctors, datamodel.meta.wcs, datamodel.meta.wcsinfo, epoch)
     assert isinstance(refcat, Table)
+    assert refcat.meta["name"] == TEST_CATALOG
 
 
 def test_parse_sky_centroid(abs_refcat):

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -247,8 +247,8 @@ def test_parse_sky_centroid(abs_refcat):
     with pytest.warns(UserWarning):
         cat_out = _parse_sky_centroid(cat)
     assert isinstance(cat_out, Table)
-    assert np.all(cat["ra"] == cat_out["ra"])
-    assert np.all(cat["dec"] == cat_out["dec"])
+    assert np.all(abs_refcat["ra"] == cat_out["RA"])
+    assert np.all(abs_refcat["dec"] == cat_out["DEC"])
     assert "sky_centroid" not in cat_out.columns
 
     # test case where ra, dec are no longer present
@@ -256,8 +256,8 @@ def test_parse_sky_centroid(abs_refcat):
     cat.remove_columns(["ra", "dec"])
     cat_out = _parse_sky_centroid(cat)
     assert isinstance(cat_out, Table)
-    assert np.all(cat["ra"] == cat_out["ra"])
-    assert np.all(cat["dec"] == cat_out["dec"])
+    assert np.all(abs_refcat["ra"] == cat_out["RA"])
+    assert np.all(abs_refcat["dec"] == cat_out["DEC"])
 
     # test case where neither present
     cat = abs_refcat.copy()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Provides bugfix for new feature introduced in [JP-3686](https://jira.stsci.edu/browse/JP-3686). See that issue's GitHub mirror at https://github.com/spacetelescope/jwst/issues/8639

<!-- describe the changes comprising this PR here -->

This PR addresses a bug found in the new feature discussed on the ticket.  In short, `tweakwcs` expects the reference catalog to have `RA` and `DEC` columns (case-sensitive, all-caps) but the catalog parser was not converting those columns to uppercase.

The stcal changes are a one-liner, but the existence of the bug revealed that a test was needed that actually round-trips the output from the `SourceCatalogStep` into the `TweakRegStep`.  This is provided in https://github.com/spacetelescope/jwst/pull/9301.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
