### PR TITLE
JP-3892: Adding Documentation for Cross Integration Jump Detection

### DIFF
--- a/changes/357.jump.rst
+++ b/changes/357.jump.rst
@@ -1,0 +1,1 @@
+Expanding jump step documentation to include information about cross integration jump detection.

--- a/changes/357.jump.rst
+++ b/changes/357.jump.rst
@@ -1,1 +1,0 @@
-Expanding jump step documentation to include information about cross integration jump detection.

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -2,14 +2,19 @@
 
 Algorithm
 ---------
-This routine detects jumps by looking for outliers
-in the up-the-ramp signal for each pixel in each integration within
-an input exposure. On output, the GROUPDQ array is updated with the DQ flag
-"JUMP_DET" to indicate the location of each jump that was found.
-In addition, any pixels that have non-positive or NaN values in the gain
-reference file will have DQ flags "NO_GAIN_VALUE" and "DO_NOT_USE" set in the
-output PIXELDQ array.
+This routine detects jumps by looking for outliers in the up-the-ramp signal
+for each pixel.  On output, the GROUPDQ array is updated with the DQ flag
+"JUMP_DET" to indicate the location of each jump that was found. In addition,
+any pixels that have non-positive or NaN values in the gain reference file will
+have DQ flags "NO_GAIN_VALUE" and "DO_NOT_USE" set in the output PIXELDQ array.
 The SCI array of the input data is not modified.
+
+Jumps can be detected in two different ways.  The primary way is the two-point
+difference methode described below.  The other way is by selecting ``only_use_ints``
+as ``True`` and if there are enough integrations, then ``sigma_clip`` from the
+``astropy.stats`` will be used to detect jumps.  Also, ``sigma_clip`` will be used
+if the total number of usable groups (number of groups per integration multiplied
+by the number of integrations) is above a minimum threshold.
 
 The current implementation uses the two-point difference method described
 in `Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_.

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -10,11 +10,11 @@ have DQ flags "NO_GAIN_VALUE" and "DO_NOT_USE" set in the output PIXELDQ array.
 The SCI array of the input data is not modified.
 
 Jumps can be detected in two different ways.  The primary way is the two-point
-difference methode described below.  The other way is by selecting ``only_use_ints``
+difference method described below.  The other way is by selecting ``only_use_ints``
 as ``True`` and if there are enough integrations, then ``sigma_clip`` from the
-``astropy.stats`` will be used to detect jumps.  Also, ``sigma_clip`` will be used
-if the total number of usable groups (number of groups per integration multiplied
-by the number of integrations) is above a minimum threshold.
+``astropy.stats`` package will be used to detect jumps.  The ``sigma_clip`` method
+will also be used if the total number of usable groups (number of groups per
+integration multiplied by the number of integrations) is above a minimum threshold.
 
 The current implementation uses the two-point difference method described
 in `Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_.

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -382,7 +382,6 @@ def look_for_more_than_one_jump(
     return gdq
 
 
-# XXX develop CI test for this function.
 def det_jump_sigma_clipping(
     gdq, nints, ngroups, total_groups, first_diffs_finite, first_diffs, twopt_p
 ):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3892](https://jira.stsci.edu/browse/JP-3892)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #9207

<!-- describe the changes comprising this PR here -->

This PR adds documentation for cross integration jump detection using sigma clipping when there are enough integrations, when `only_use_ints` is True or enough total groups across all integrations when False.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
