### PR TITLE
RCAL-968: add inverse of sky variance as an option for creating weight map in resample.

### DIFF
--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -223,7 +223,7 @@ class Resample:
         self.fillval = fillval
         self.good_bits = good_bits
 
-        if weight_type.startswith("ivm") or weight_type == "exptime":
+        if weight_type.startswith("ivm") or weight_type in ("exptime", "ivsky"):
             self.weight_type = weight_type
         else:
             raise ValueError("Unexpected weight type: '{self.weight_type}'")
@@ -964,9 +964,10 @@ class Resample:
             else:
                 mask = np.full_like(rn_var, False)
 
+            weight = np.ones(self.output_array_shape)
+
             # Set the weight for the image from the weight type
             if self.weight_type.startswith("ivm") and rn_var is not None:
-                weight = np.ones(self.output_array_shape)
                 weight[mask] = np.reciprocal(rn_var[mask])
 
             elif self.weight_type == "exptime":

--- a/src/stcal/resample/utils.py
+++ b/src/stcal/resample/utils.py
@@ -143,6 +143,24 @@ def build_driz_weight(model, weight_type=None, good_bits=None,
     elif weight_type == 'exptime':
         exptime, s = get_tmeasure(model)
         result = exptime * dqmask
+        
+    elif weight_type == "ivsky":
+        var_sky = model["var_sky"]
+        if (
+            var_sky is not None and 
+            var_sky.shape == data.shape
+        ):
+            with np.errstate(divide="ignore", invalid="ignore"):
+                inv_sky_variance = var_sky**-1
+            inv_sky_variance[~np.isfinite(inv_sky_variance)] = 0
+        else:
+            warnings.warn(
+                "'var_sky' array is not available. "
+                "Setting drizzle weight map to 1",
+                RuntimeError,
+            )
+            inv_sky_variance = 1.0
+        result = inv_sky_variance * dqmask
 
     else:
         result = np.ones(data.shape, dtype=data.dtype) * dqmask

--- a/tests/resample/helpers.py
+++ b/tests/resample/helpers.py
@@ -107,7 +107,7 @@ def make_input_model(shape, crpix=(0, 0), crval=(0, 0), pscale=2.0e-5,
         "subtracted": False,
     }
 
-    for arr in ["var_flat", "var_rnoise", "var_poisson"]:
+    for arr in ["var_flat", "var_rnoise", "var_poisson", "var_sky"]:
         model[arr] = np.ones(shape, dtype=np.float32)
 
     model["err"] = np.sqrt(3.0) * np.ones(shape, dtype=np.float32)

--- a/tests/resample/test_resample_utils.py
+++ b/tests/resample/test_resample_utils.py
@@ -120,7 +120,7 @@ def test_is_flux_density(unit, result):
     assert is_flux_density(unit) is result
 
 
-@pytest.mark.parametrize("weight_type", ["ivm", "exptime"])
+@pytest.mark.parametrize("weight_type", ["ivm", "exptime", "ivsky", ])
 def test_build_driz_weight(weight_type):
     """Check that correct weight map is returned of different weight types"""
 
@@ -129,6 +129,7 @@ def test_build_driz_weight(weight_type):
     model["dq"][0] = JWST_DQ_FLAG_DEF.DO_NOT_USE
     model["measurement_time"] = 10.0
     model["var_rnoise"] /= 10.0
+    model["var_sky"] /= 10.0
 
     weight_map = build_driz_weight(
         model,


### PR DESCRIPTION
Resolves [RCAL-968](https://jira.stsci.edu/browse/RCAL-968)

This PR adds another option for the creation of a weight map by using the inverse of the sky variance in resample.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
