### PR TITLE
RCAL-968: Add compute weight method to Resample

### DIFF
--- a/changes/360.general.rst
+++ b/changes/360.general.rst
@@ -1,0 +1,1 @@
+Added ``compute_input_model_weight`` method to the ``Resample`` class.

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -746,12 +746,7 @@ class Resample:
 
         log.info("Resampling science and variance data")
 
-        weight = build_driz_weight(
-            model,
-            weight_type=self.weight_type,
-            good_bits=self.good_bits,
-            flag_name_map=self.dq_flag_name_map
-        )
+        weight = self.compute_input_model_weight(model)
 
         # apply sky subtraction
         blevel = model["level"]
@@ -863,6 +858,16 @@ class Resample:
 
         """
         pass
+
+    def compute_input_model_weight(self, model):
+        """ Computes the weight array of the input ``model``. """
+        weight = build_driz_weight(
+            model,
+            weight_type=self.weight_type,
+            good_bits=self.good_bits,
+            flag_name_map=self.dq_flag_name_map
+        )
+        return weight
 
     def is_finalized(self):
         """ Indicates whether all attributes of the ``output_model`` have been


### PR DESCRIPTION
Closes #359

This PR adds `Resample.compute_input_model_weight()` methods that can be overridden by subclasses to implement custom/additional weight types.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

Regression Tests:
- Romancal: https://github.com/spacetelescope/RegressionTests/actions/runs/14375612247
- JWST: https://github.com/spacetelescope/RegressionTests/actions/runs/14375606587

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
