### PR TITLE
Update docs to reflect correct definition for pixel scale ratio

### DIFF
--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -93,8 +93,9 @@ def _generate_tranform(
         A two-elements array containing the world coordinates of the fiducial point.
 
     pscale_ratio : int, None, optional
-        Ratio of input to output pixel scale. This parameter is only used when
-        ``pscale=None`` and, in that case, it is passed on to ``compute_scale``.
+        Ratio of output pixel scale to input pixel scale. This parameter is
+        only used when ``pscale=None`` and, in that case, it is passed on to
+        ``compute_scale``.
 
     pscale : float, None, optional
         The plate scale. If `None`, the plate scale is calculated from the reference
@@ -390,7 +391,7 @@ def compute_scale(
         ``wcsinfo.dispersion_direction``
 
     pscale_ratio : int, None, optional
-        Ratio of input to output pixel scale
+        Ratio of output pixel scale to input pixel scale.
 
     Returns
     -------
@@ -604,7 +605,7 @@ def wcs_from_footprints(
         If not supplied it is computed from the bounding_box of all inputs.
 
     pscale_ratio : float, None, optional
-        Ratio of input to output pixel scale. Ignored when either
+        Ratio of output pixel scale to input pixel scale. Ignored when either
         ``transform`` or ``pscale`` are provided.
 
     pscale : float, None, optional
@@ -731,7 +732,7 @@ def wcs_from_sregions(
         If not supplied `Scaling | Rotation` is computed from ``refmodel``.
 
     pscale_ratio : float, None, optional
-        Ratio of input to output pixel scale. Ignored when either
+        Ratio of output pixel scale to input pixel scale. Ignored when either
         ``transform`` or ``pscale`` are provided.
 
     pscale : float, None, optional


### PR DESCRIPTION
Resolves [RCAL-1054](https://jira.stsci.edu/browse/RCAL-1054)

This PR corrects the definition of pixel scale ratio as used in resampling of imaging data (NOTE: for JWST, spectral resampling may use opposite definition to the one used in imaging)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
