### PR TITLE
Generic variances

### DIFF
--- a/changes/364.general.rst
+++ b/changes/364.general.rst
@@ -1,0 +1,1 @@
+Allow resample to resample arbitrary variance arrays.

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -211,7 +211,7 @@ class Resample:
 
         include_var_in_err : list or None, optional
             Indicates which variances to include in the ``err`` computation.
-            This field is only used if ``compute_err`` is ``from_var``.  If
+            This field is used only if ``compute_err`` is ``from_var``.  If
             None, all variances are included in the error computation.
 
         """
@@ -930,21 +930,19 @@ class Resample:
             self.output_model["err"] = self._driz_error.out_img
             del self._driz_error
 
-        elif self._enable_var:
+        elif self._enable_var and (self._compute_err == "from_var"):
             # compute error from variance arrays:
             var_components = [
                 self._output_model[x] for x in self._include_var_in_err]
-            if self._compute_err == "from_var":
-                self.output_model["err"] = np.sqrt(
-                    np.nansum(var_components, axis=0)
-                )
+            self.output_model["err"] = np.sqrt(
+                np.nansum(var_components, axis=0)
+            )
 
-                # nansum returns zero for input that is all NaN -
-                # set those values to NaN instead
-                all_nan = np.all(np.isnan(var_components), axis=0)
-                self._output_model["err"][all_nan] = np.nan
-                del all_nan
-
+            # nansum returns zero for input that is all NaN -
+            # set those values to NaN instead
+            all_nan = np.all(np.isnan(var_components), axis=0)
+            self._output_model["err"][all_nan] = np.nan
+            del all_nan
             del var_components
 
         self.finalize_time_info()

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -704,7 +704,8 @@ class Resample:
             min_attributes.append("err")
 
         if (not self._enable_var and self.weight_type is not None and
-                self.weight_type.startswith('ivm')):
+                self.weight_type.startswith('ivm') and
+                ("var_rnoise" not in min_attributes)):
             min_attributes.append("var_rnoise")
 
         for attr in min_attributes:

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -5,7 +5,7 @@ import sys
 
 import numpy as np
 from collections import defaultdict
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from drizzle.utils import calc_pixmap
 from drizzle.resample import Drizzle

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -73,7 +73,6 @@ class Resample:
     # variances to include in output 'err'
     # default None means all of variance_array_names
     error_from_variances = None
-    
 
     dq_flag_name_map = None
 
@@ -219,8 +218,8 @@ class Resample:
         self._n_res_models = 0
 
         self._enable_ctx = enable_ctx
-        self._compute_err = compute_err
         self._enable_var = enable_var
+        self._compute_err = compute_err
 
         # these attributes are used only for informational purposes
         # and are added to created the output_model only if they are
@@ -457,8 +456,9 @@ class Resample:
             "duration": 0.0,
         }
 
-        for varname in self.variance_array_names:
-            output_model[varname] = None
+        if self._enable_var:
+            for varname in self.variance_array_names:
+                output_model[varname] = None
 
         if self._compute_err is not None:
             output_model["err"] = None
@@ -505,7 +505,7 @@ class Resample:
 
     @property
     def enable_var(self):
-        """ Indicates whether variance arrays are resample. """
+        """ Indicates whether variance arrays are resampled. """
         return self._enable_var
 
     @property

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -953,17 +953,17 @@ class Resample:
         weights. """
         shape = self.output_array_shape
 
-        self._variance_info = dict()
+        self._variance_info = {}
         for noise_type in self._enable_var:
             # note: output_array_types is a defaultdict, so this will succeed
             # even when noise_type is not in output_array_types
             var_dtype = self.output_array_types[noise_type]
             wsum = np.full(shape, np.nan, dtype=var_dtype)
             wt = np.zeros(shape, dtype=var_dtype)
-            self._variance_info[noise_type] = dict(
-                wsum=np.full(shape, np.nan, dtype=var_dtype),
-                wt=np.zeros(shape, dtype=var_dtype),
-            )
+            self._variance_info[noise_type] = {
+                "wsum": np.full(shape, np.nan, dtype=var_dtype),
+                "wt": np.zeros(shape, dtype=var_dtype),
+            }
 
     def resample_variance_arrays(self, model, pixmap, iscale,
                                  weight_map, xmin, xmax, ymin, ymax):
@@ -1044,7 +1044,7 @@ class Resample:
 
         # Set the weight for the image from the weight type
         if self.weight_type.startswith("ivm"):
-            rn_var_info = self._variance_info.get('var_rnoise', dict())
+            rn_var_info = self._variance_info.get('var_rnoise', {})
             rn_var = rn_var_info.get('var', None)
             if rn_var is not None:
                 mask = (rn_var > 0) & np.isfinite(rn_var)

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -5,7 +5,7 @@ import sys
 
 import numpy as np
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from numpy.typing import DTypeLike
 
 from drizzle.utils import calc_pixmap
 from drizzle.resample import Drizzle
@@ -17,9 +17,6 @@ from stcal.resample.utils import (
     resample_range,
     is_flux_density,
 )
-
-if TYPE_CHECKING:
-    from numpy.typing import DTypeLike
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -918,10 +918,10 @@ class Resample:
 
         elif self._enable_var and (self._compute_err == "from_var"):
             # compute error from variance arrays:
-            include_var = (
-                self.error_from_variances
-                if self.error_from_variances is not None
-                else self.variance_array_names)
+            if self.error_from_variances is None:
+                include_var = self.variance_array_names
+            else:
+                include_var = self.error_from_variances
             var_components = [
                 self._output_model[x] for x in include_var]
             self.output_model["err"] = np.sqrt(

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -129,7 +129,6 @@ def test_resample_mostly_defaults(weight_type):
     "compute_err,weight_type",
     [
         ("from_var", "ivm"),
-        ("from_var", "ivm"),
         ("from_var", "exptime"),
         ("driz_err", "ivm"),
     ]

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -126,16 +126,16 @@ def test_resample_mostly_defaults(weight_type):
 
 
 @pytest.mark.parametrize(
-    "compute_err,weight_type,include_var_in_err",
+    "compute_err,weight_type",
     [
-        ("from_var", "ivm", None),
-        ("from_var", "ivm", ["var_rnoise", "var_poisson"]),
-        ("from_var", "exptime", None),
-        ("driz_err", "ivm", None)
+        ("from_var", "ivm"),
+        ("from_var", "ivm"),
+        ("from_var", "exptime"),
+        ("driz_err", "ivm"),
     ]
 )
 def test_resample_compute_error_mode(
-        compute_err, weight_type, include_var_in_err):
+        compute_err, weight_type):
     crval = (150.0, 2.0)
     crpix = (500.0, 500.0)
     shape = (1000, 1000)
@@ -157,7 +157,6 @@ def test_resample_compute_error_mode(
         output_wcs=output_model,
         weight_type=weight_type,
         compute_err=compute_err,
-        include_var_in_err=include_var_in_err,
     )
     resample.dq_flag_name_map = JWST_DQ_FLAG_DEF
 

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -130,11 +130,10 @@ def test_resample_mostly_defaults(weight_type):
     [
         ("from_var", "ivm"),
         ("from_var", "exptime"),
-        ("driz_err", "ivm"),
+        ("driz_err", "ivm")
     ]
 )
-def test_resample_compute_error_mode(
-        compute_err, weight_type):
+def test_resample_compute_error_mode(compute_err, weight_type):
     crval = (150.0, 2.0)
     crpix = (500.0, 500.0)
     shape = (1000, 1000)

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -126,14 +126,16 @@ def test_resample_mostly_defaults(weight_type):
 
 
 @pytest.mark.parametrize(
-    "compute_err,weight_type",
+    "compute_err,weight_type,include_var_in_err",
     [
-        ("from_var", "ivm"),
-        ("from_var", "exptime"),
-        ("driz_err", "ivm")
+        ("from_var", "ivm", None),
+        ("from_var", "ivm", ["var_rnoise", "var_poisson"]),
+        ("from_var", "exptime", None),
+        ("driz_err", "ivm", None)
     ]
 )
-def test_resample_compute_error_mode(compute_err, weight_type):
+def test_resample_compute_error_mode(
+        compute_err, weight_type, include_var_in_err):
     crval = (150.0, 2.0)
     crpix = (500.0, 500.0)
     shape = (1000, 1000)
@@ -155,6 +157,7 @@ def test_resample_compute_error_mode(compute_err, weight_type):
         output_wcs=output_model,
         weight_type=weight_type,
         compute_err=compute_err,
+        include_var_in_err=include_var_in_err,
     )
     resample.dq_flag_name_map = JWST_DQ_FLAG_DEF
 


### PR DESCRIPTION
This PR attempts to treat the various variance arrays in resample more symmetrically while not changing the behavior very much.  The basic idea is that all of the different variance arrays should be resampled in the same way.  It simplifies the code somewhat and allows other variance arrays to be specified for resampling, without adding more code to stcal/resample.  It does this by extending the "enable_var" argument to talk a list of variance arrays that should be resampled, but retaining the current behavior when enable_var = True.

Currently all romancal and most jwst tests pass.  The two failing jwst tests involve tests that the resample does the right thing when enable_var is True and the ivm weight type is selected, but the images do not include the var_rnoise weight type needed for ivm.  I can update this PR to handle that case if desired; it's not obvious to me that erroring out is not appropriate behavior when people ask for ivm weights but var_rnoise is not available!

Is this something that we would like to have in stcal?  I'll add a changelog entry if so.

Regression tests are here:
Webb: https://github.com/spacetelescope/RegressionTests/actions/runs/15025203836/job/42224326282
Roman: https://github.com/spacetelescope/RegressionTests/actions/runs/14623806303/job/42214787253