### PR TITLE
replace astropy isiterable with np.iterable

### DIFF
--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -18,7 +18,6 @@ import numpy as np
 from astropy import wcs as fitswcs
 from astropy.coordinates import SkyCoord
 from astropy.modeling import models as astmodels
-from astropy.utils.misc import isiterable
 from gwcs.wcstools import wcs_from_fiducial
 
 log = logging.getLogger(__name__)
@@ -354,7 +353,7 @@ def _validate_wcs_list(wcs_list: list[gwcs.wcs.WCS]) -> bool:
         Raised whenever wcs_list is empty or any of its content is not an
         instance of WCS.
     """
-    if not isiterable(wcs_list):
+    if not np.iterable(wcs_list):
         msg = "Expected 'wcs_list' to be an iterable of WCS objects."
         raise ValueError(msg)
 


### PR DESCRIPTION
Astropy has deprecated `isiterable`:
https://github.com/astropy/astropy/pull/18053
it's implementation is identical to `np.iterable`:
https://numpy.org/doc/1.23/reference/generated/numpy.iterable.html

This PR switches `isiterable` usage to `np.iterable`.

Romancal regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/14710781790
JWST regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/14711586754

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
