### PR TITLE
fix downstream by not running in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
-        - linux: py312-jwst-cov-xdist
-        - linux: py312-romancal-cov-xdist
+        - linux: py312-jwst-cov
+        - linux: py312-romancal-cov
       coverage: codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,12 @@ archs = [
     "aarch64",
 ]
 
+[tool.coverage.run]
+omit = [
+    "config.py",
+    "config-3.py",
+]
+
 [tool.towncrier]
 filename = "CHANGES.rst"
 directory = "changes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ archs = [
 omit = [
     "config.py",
     "config-3.py",
+    "*.rmap",
 ]
 
 [tool.towncrier]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     check-{style,build,types}
     test{,-warnings,-cov}-xdist
-    test-{jwst,romancal}{,-xdist}{,-cov}
+    test-{jwst,romancal}{,-cov}
     build-{docs,dist}
 
 # tox environments are constructed with so-called 'factors' (or terms)


### PR DESCRIPTION
This PR fixes the downstream jwst and romancal jobs by not running them in parallel. This will cause these jobs to take longer but will work around 2 issues:

- pytest-cov and pytest-xdist issue handling warnings: https://github.com/pytest-dev/pytest-cov/issues/693 (since jwst now [turns warnings into errors](https://github.com/spacetelescope/jwst/pull/9490))
- crds issues due to parallel reference file fetching: https://github.com/spacetelescope/crds/issues/930

There is also a somewhat related issue where stray files from opencv are also causing run files See https://github.com/spacetelescope/jwst/pull/9512 for more details but since the coverage configuration for the jwst job uses the pyproject.toml in this directly we need to duplicate those jwst changes here. jwst also either includes or produces a "rmap" file. This is also ignored for coverage.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
