### PR TITLE
run devdeps serially

### DIFF
--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -36,5 +36,5 @@ jobs:
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
-        - linux: py313-jwst-devdeps-xdist
-        - linux: py313-romancal-devdeps-xdist
+        - linux: py313-jwst-devdeps
+        - linux: py313-romancal-devdeps


### PR DESCRIPTION
This is a follow-up to https://github.com/spacetelescope/stcal/pull/375 applying similar changes to the devdeps jobs.

I added the run devdeps label to trigger them as part of this CI.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
