### PR TITLE
Move the default timeout to the call level

### DIFF
--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -90,7 +90,9 @@ def create_astrometric_catalog(
         fiducial[1],
         epoch=epoch,
         search_radius=radius,
-        catalog=catalog)
+        catalog=catalog,
+        timeout=TIMEOUT
+    )
     if len(ref_dict) == 0:
         return ref_dict
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

WIP [RCAL-1130](https://jira.stsci.edu/browse/RCAL-1130)

<!-- describe the changes comprising this PR here -->

This PR addresses an issue where the call to the VO catalog service times out due to crowded fields in the Roman FOV. The current solution is a stop-gap measure that provides access to the timeout argument in tweakreg.astrometric_utils.create_astrometric_catalog. Basically the default timeout provided in the module is moved to the call of `get_catalog`, allowing external modification of the module-level TIMEOUT parameter.

This avoids api changes at a number of levels while a more permanent solution is determined.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
