### PR TITLE
add velocity aberration calculations

### DIFF
--- a/changes/385.general.rst
+++ b/changes/385.general.rst
@@ -1,1 +1,1 @@
-add velocity aberration calculations
+Add utility functions for calculating velocity aberration.

--- a/changes/385.general.rst
+++ b/changes/385.general.rst
@@ -1,0 +1,1 @@
+add velocity aberration calculations

--- a/docs/stcal/package_index.rst
+++ b/docs/stcal/package_index.rst
@@ -11,3 +11,4 @@ Package Index
    outlier_detection/index.rst
    resample/index.rst
    skymatch/index.rst
+   velocity_aberration.rst

--- a/docs/stcal/velocity_aberration.rst
+++ b/docs/stcal/velocity_aberration.rst
@@ -1,4 +1,4 @@
-.. _velocity_aberration
+.. _velocity_aberration:
 
 =========================
 Velocity Aberration Utils

--- a/docs/stcal/velocity_aberration.rst
+++ b/docs/stcal/velocity_aberration.rst
@@ -1,0 +1,7 @@
+.. _velocity_aberration
+
+=========================
+Velocity Aberration Utils
+=========================
+
+.. automodapi:: stcal.velocity_aberration

--- a/src/stcal/velocity_aberration.py
+++ b/src/stcal/velocity_aberration.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 SPEED_OF_LIGHT = speed_of_light / 1000  # km / s
 
-__all__ = ["compute_va_effects_vector", "compute_va_effects", "add_dva"]
+__all__ = ["compute_va_effects_vector", "compute_va_effects"]
 
 
 def compute_va_effects_vector(velocity_x, velocity_y, velocity_z, u):

--- a/src/stcal/velocity_aberration.py
+++ b/src/stcal/velocity_aberration.py
@@ -1,0 +1,104 @@
+"""
+Utilities for velocity aberration correction.
+"""
+
+import logging
+
+import numpy as np
+from gwcs.geometry import CartesianToSpherical, SphericalToCartesian
+from scipy.constants import speed_of_light
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+SPEED_OF_LIGHT = speed_of_light / 1000  # km / s
+
+__all__ = ["compute_va_effects_vector", "compute_va_effects", "add_dva"]
+
+
+def compute_va_effects_vector(velocity_x, velocity_y, velocity_z, u):
+    """
+    Compute velocity aberration effects scale factor.
+
+    Computes constant scale factor due to velocity aberration as well as
+    corrected ``RA`` and ``DEC`` values, in vector form.
+
+    Parameters
+    ----------
+    velocity_x, velocity_y, velocity_z : float
+        The components of the velocity of JWST, in km / s with respect to
+        the Sun.  These are celestial coordinates, with x toward the
+        vernal equinox, y toward right ascension 90 degrees and declination
+        0, z toward the north celestial pole.
+
+    u : numpy.array([u0, u1, u2])
+        The vector form of right ascension and declination of the target (or some other
+        point, such as the center of a detector) in the barycentric coordinate
+        system.  The equator and equinox should be the same as the coordinate
+        system for the velocity.
+
+    Returns
+    -------
+    scale_factor : float
+        Multiply the nominal image scale (e.g., in degrees per pixel) by
+        this value to obtain the image scale corrected for the "aberration
+        of starlight" due to the velocity of JWST with respect to the Sun.
+
+    u_corr : numpy.array([ua0, ua1, ua2])
+        Apparent position vector in the moving telescope frame.
+    """
+    beta = np.array([velocity_x, velocity_y, velocity_z]) / SPEED_OF_LIGHT
+    beta2 = np.dot(beta, beta)  # |beta|^2
+    if beta2 == 0.0:
+        logger.warning("Observatory speed is zero. Setting VA scale to 1.0")
+        return 1.0, u
+
+    u_beta = np.dot(u, beta)
+    igamma = np.sqrt(1.0 - beta2)  # inverse of usual gamma
+    scale_factor = (1.0 + u_beta) / igamma
+
+    # Algorithm below is from Colin Cox notebook.
+    # Also see: Instrument Science Report OSG-CAL-97-06 by Colin Cox (1997).
+    u_corr = (igamma * u + beta * (1.0 + (1.0 - igamma) * u_beta / beta2)) / (1.0 + u_beta)
+
+    return scale_factor, u_corr
+
+
+def compute_va_effects(velocity_x, velocity_y, velocity_z, ra, dec):
+    """
+    Compute velocity aberration effects.
+
+    Computes constant scale factor due to velocity aberration as well as
+    corrected ``RA`` and ``DEC`` values.
+
+    Parameters
+    ----------
+    velocity_x, velocity_y, velocity_z : float
+        The components of the velocity of JWST, in km / s with respect to
+        the Sun.  These are celestial coordinates, with x toward the
+        vernal equinox, y toward right ascension 90 degrees and declination
+        0, z toward the north celestial pole.
+
+    ra, dec : float
+        The right ascension and declination of the target (or some other
+        point, such as the center of a detector) in the barycentric coordinate
+        system.  The equator and equinox should be the same as the coordinate
+        system for the velocity.
+
+    Returns
+    -------
+    scale_factor : float
+        Multiply the nominal image scale (e.g., in degrees per pixel) by
+        this value to obtain the image scale corrected for the "aberration
+        of starlight" due to the velocity of JWST with respect to the Sun.
+
+    apparent_ra : float
+        Apparent star position in the moving telescope frame.
+
+    apparent_dec : float
+        Apparent star position in the moving telescope frame.
+    """
+    u = np.asanyarray(SphericalToCartesian()(ra, dec))
+    scale_factor, u_corr = compute_va_effects_vector(velocity_x, velocity_y, velocity_z, u)
+    apparent_ra, apparent_dec = CartesianToSpherical()(*u_corr)
+    return scale_factor, apparent_ra, apparent_dec

--- a/tests/test_velocity_aberration.py
+++ b/tests/test_velocity_aberration.py
@@ -1,0 +1,27 @@
+"""
+Test script for set_velocity_aberration.py
+"""
+from numpy import isclose
+
+from stcal.velocity_aberration import compute_va_effects
+
+# Testing constants
+GOOD_VELOCITY = (100.0, 100.0, 100.0)
+GOOD_POS = (359.0, -2.0)
+GOOD_SCALE_FACTOR = 1.000316017905845
+GOOD_APPARENT_RA = 359.01945099823
+GOOD_APPARENT_DEC = -1.980247580394956
+
+
+def test_compute_va_effects_valid():
+    scale_factor, va_ra, va_dec = compute_va_effects(*GOOD_VELOCITY, *GOOD_POS)
+    assert isclose(scale_factor, GOOD_SCALE_FACTOR)
+    assert isclose(va_ra, GOOD_APPARENT_RA)
+    assert isclose(va_dec, GOOD_APPARENT_DEC)
+
+
+def test_compute_va_effects_zero_velocity():
+    scale_factor, va_ra, va_dec = compute_va_effects(0.0, 0.0, 0.0, *GOOD_POS)
+    assert isclose(scale_factor, 1.0, atol=1e-16)
+    assert isclose(va_ra, GOOD_POS[0], atol=1e-16)
+    assert isclose(va_dec, GOOD_POS[1], atol=1e-16)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [RCAL-1123](https://jira.stsci.edu/browse/RCAL-1123)

Required by romancal [PR#1891](https://github.com/spacetelescope/romancal/pull/1891)

<!-- describe the changes comprising this PR here -->
This PR implements the common base velocity aberration calculation used by the command `roman_set_velocity_aberration`. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) 
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.apichange.rst``: change to public API
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
