### PR TITLE
JP-4104: Updating Memory Management in Ramp Fit C-Extension

### DIFF
--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -967,6 +967,18 @@ ERROR:
     clean_rateint_product(&rateint_prod);
 
     /* Return (None, None, None) */
+#if 0
+    Review from ChatGPT:
+This steals no references, but you’re passing borrowed refs. This works only
+because `Py_None` is immortal since Python 3.10 — older versions would leak.
+👉 Safer:
+
+```c
+Py_INCREF(Py_None);
+Py_INCREF(Py_None);
+Py_INCREF(Py_None);
+```
+#endif
     result = Py_BuildValue("(NNN)", Py_None, Py_None, Py_None);
 
 CLEANUP:
@@ -1141,16 +1153,18 @@ clean_ramp_data(
          */
         for (idx=0; idx < rd->cube_sz; ++idx) {
             current = rd->segs[idx];
-            if (current) {
+            while (current) {
                 next = current->flink;
+                memset(current, 0, sizeof(*current));
                 SET_FREE(current);
                 current = next;
             }
 
             /* CR list */
             cr_current = rd->crs[idx];
-            if (cr_current) {
+            while (cr_current) {
                 cr_next = cr_current->flink;
+                memset(cr_current, 0, sizeof(*cr_current));
                 SET_FREE(cr_current);
                 cr_current = cr_next;
             }
@@ -1513,7 +1527,7 @@ static struct pixel_ramp *
 create_pixel_ramp(
         struct ramp_data * rd) /* The ramp fitting data */
 {
-    struct pixel_ramp * pr = (struct pixel_ramp*)calloc(1, sizeof(*rd));
+    struct pixel_ramp * pr = (struct pixel_ramp*)calloc(1, sizeof(*pr));
     char msg[256] = {0};
 
     /* Make sure memory allocation worked */
@@ -1577,27 +1591,27 @@ create_rate_product(
     dims[1] = rd->ncols;
 
     rate->slope = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rate->slope) {
+    if (NULL==rate->slope) {
         goto FAILED_ALLOC;
     }
 
     rate->dq = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_UINT32, fortran);
-    if (Py_None==(PyObject*)rate->dq) {
+    if (NULL==rate->dq) {
         goto FAILED_ALLOC;
     }
 
     rate->var_poisson = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rate->var_poisson) {
+    if (NULL==rate->var_poisson) {
         goto FAILED_ALLOC;
     }
 
     rate->var_rnoise = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rate->var_rnoise) {
+    if (NULL==rate->var_rnoise) {
         goto FAILED_ALLOC;
     }
 
     rate->var_err = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rate->var_err) {
+    if (NULL==rate->var_err) {
         goto FAILED_ALLOC;
     }
 
@@ -1636,27 +1650,27 @@ create_rateint_product(
     dims[2] = rd->ncols;
 
     rateint->slope = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rateint->slope) {
+    if (NULL==rateint->slope) {
         goto FAILED_ALLOC;
     }
 
     rateint->dq = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_UINT32, fortran);
-    if (Py_None==(PyObject*)rateint->dq) {
+    if (NULL==rateint->dq) {
         goto FAILED_ALLOC;
     }
 
     rateint->var_poisson = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rateint->var_poisson) {
+    if (NULL==rateint->var_poisson) {
         goto FAILED_ALLOC;
     }
 
     rateint->var_rnoise = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rateint->var_rnoise) {
+    if (NULL==rateint->var_rnoise) {
         goto FAILED_ALLOC;
     }
 
     rateint->var_err = (PyArrayObject*)PyArray_EMPTY(nd, dims, NPY_FLOAT, fortran);
-    if (Py_None==(PyObject*)rateint->var_err) {
+    if (NULL==rateint->var_err) {
         goto FAILED_ALLOC;
     }
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4104](https://jira.stsci.edu/browse/JP-4104)

<!-- describe the changes comprising this PR here -->

This PR addresses memory management in ramp fitting C-extension.  Corrects a sizing issue when allocation memory for the pixel ramp.  Properly deallocates all memory associated with the linked list of segments for each ramp.  Changed the checking of `NULL` for return values, instead of `Py_None`.

Regression test: https://github.com/spacetelescope/RegressionTests/actions/runs/17302353573


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- `changes/<PR#>.apichange.rst`: change to public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.general.rst`: infrastructure or miscellaneous change
</details>
