### PR TITLE
JP-4138: Move warnings to log messages; remove setLevel calls

### DIFF
--- a/src/stcal/alignment/resample_utils.py
+++ b/src/stcal/alignment/resample_utils.py
@@ -6,7 +6,6 @@ from gwcs.wcstools import grid_from_bounding_box
 from stcal.alignment import util
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def calc_pixmap(in_wcs, out_wcs, shape=None):

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -23,7 +23,6 @@ from astropy import units as u
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = [
     "compute_scale",

--- a/src/stcal/dark_current/dark_sub.py
+++ b/src/stcal/dark_current/dark_sub.py
@@ -11,7 +11,6 @@ import numpy as np
 from . import dark_class
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, dark_model, dark_output=None):

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -18,7 +18,6 @@ from .twopoint_difference_class import TwoPointParams
 from . import twopoint_difference as twopt
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def detect_jumps_data(jump_data):

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -7,7 +7,6 @@ from astropy import stats
 from astropy.utils.exceptions import AstropyUserWarning
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def find_crs(data, group_dq, read_noise, twopt_p):

--- a/src/stcal/outlier_detection/median.py
+++ b/src/stcal/outlier_detection/median.py
@@ -11,7 +11,6 @@ from typing import Any
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 _ONE_MB = 1 << 20
 

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -14,7 +14,6 @@ from stcal.alignment.util import wcs_bbox_from_shape
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = [

--- a/src/stcal/ramp_fitting/likely_fit.py
+++ b/src/stcal/ramp_fitting/likely_fit.py
@@ -13,7 +13,6 @@ SQRT2 = np.sqrt(2)
 LIKELY_MIN_NGROUPS = 4
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def likely_ramp_fit(ramp_data, readnoise_2d, gain_2d):

--- a/src/stcal/ramp_fitting/ols_fit.py
+++ b/src/stcal/ramp_fitting/ols_fit.py
@@ -12,14 +12,9 @@ import numpy as np
 from .slope_fitter import ols_slope_fitter  # c extension
 from . import ramp_fit_class, utils
 
-
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 BUFSIZE = 1024 * 300000  # 300Mb cache size for data section
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def ols_ramp_fit_multi(ramp_data, save_opt, readnoise_2d, gain_2d, weighting, max_cores):

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -24,7 +24,6 @@ from . import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 BUFSIZE = 1024 * 300000  # 300Mb cache size for data section
 

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -8,7 +8,6 @@ import numpy as np
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # Replace zero or negative variances with this:
 LARGE_VARIANCE = 1.0e8

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -20,7 +20,6 @@ from stcal.resample.utils import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = [
     "Resample",

--- a/src/stcal/resample/utils.py
+++ b/src/stcal/resample/utils.py
@@ -446,10 +446,9 @@ def _get_inverse_variance(array, data_shape, array_name):
             inv = 1.0 / array
         inv[~np.isfinite(inv)] = 0  # zeros for bad pixels
     else:
-        warnings.warn(
+        log.warning(
             f"'{array_name}' array not available. "
             "Setting drizzle weight map to 1",
-            RuntimeWarning
         )
         inv = np.full(data_shape, 1, dtype=np.float32)   # ones for missing/misshaped array
 

--- a/src/stcal/resample/utils.py
+++ b/src/stcal/resample/utils.py
@@ -22,7 +22,6 @@ __all__ = [
 ]
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def resample_range(data_shape, bbox=None):

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -5,7 +5,6 @@ import numpy as np
 from scipy import ndimage
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def flag_saturated_pixels(

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -19,7 +19,6 @@ __all__ = ['skymatch']
 __local_debug__ = True
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def skymatch(images, skymethod='global+match', match_down=True, subtract=False):

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import Counter
 import math
 import warnings
@@ -28,6 +29,8 @@ _SINGLE_GROUP_REFCAT_STR = ",".join(SINGLE_GROUP_REFCAT)
 
 __all__ = ["relative_align", "absolute_align", "SINGLE_GROUP_REFCAT",
            "filter_catalog_by_bounding_box"]
+
+log = logging.getLogger(__name__)
 
 
 class TweakregError(BaseException):
@@ -298,7 +301,7 @@ def _parse_sky_centroid(catalog: Table) -> Table:
         if ncentroid > 0:
             msg = ("Absolute reference catalog contains both RA/DEC "
                    "and sky_centroid columns. Ignoring sky_centroid.")
-            warnings.warn(msg, stacklevel=2)
+            log.warning(msg)
             catalog.remove_column("sky_centroid")
         return catalog
 

--- a/tests/resample/test_resample_utils.py
+++ b/tests/resample/test_resample_utils.py
@@ -184,19 +184,20 @@ def test_unsupported_weight_type(weight_type):
 
 
 @pytest.mark.parametrize("array_name", ["var_rnoise", "var_sky"])
-def test_get_inverse_variance_valid_and_invalid(array_name):
+def test_get_inverse_variance_valid_and_invalid(caplog, array_name):
     arr = np.array([[4.0, 0.0], [np.nan, 1.0]])
     inv = _get_inverse_variance(arr, arr.shape, array_name)
     assert np.isclose(inv[0, 0], 0.25)
     assert inv[0, 1] == 0
     assert inv[1, 0] == 0
     assert inv[1, 1] == 1.0
+
     # Wrong shape
-    with pytest.warns(RuntimeWarning, match=f"'{array_name}' array not available."):
-        inv2 = _get_inverse_variance(None, (2, 2), array_name)
+    inv2 = _get_inverse_variance(None, (2, 2), array_name)
     np.testing.assert_array_equal(inv2, 1)
-    with pytest.warns(RuntimeWarning, match=f"'{array_name}' array not available."):
-        inv3 = _get_inverse_variance(np.ones((1, 1)), (2, 2), array_name)
+
+    inv3 = _get_inverse_variance(np.ones((1, 1)), (2, 2), array_name)
     np.testing.assert_array_equal(inv3, 1)
 
-
+    # Warning message logged both times
+    assert caplog.text.count(f"'{array_name}' array not available.") == 2

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -246,7 +246,7 @@ def test_parse_refcat(datamodel, abs_refcat, tmp_path):
     assert refcat.meta["name"] == TEST_CATALOG
 
 
-def test_parse_sky_centroid(abs_refcat):
+def test_parse_sky_centroid(caplog, abs_refcat):
 
     # make a SkyCoord object out of the RA and DEC columns
     sky_centroid = SkyCoord(abs_refcat["ra"], abs_refcat["dec"], unit="deg")
@@ -254,8 +254,11 @@ def test_parse_sky_centroid(abs_refcat):
 
     # test case where ra, dec, and sky_centroid are all present
     cat = abs_refcat.copy()
-    with pytest.warns(UserWarning):
-        cat_out = _parse_sky_centroid(cat)
+    cat_out = _parse_sky_centroid(cat)
+
+    # warning for duplicate columns is logged
+    assert "Ignoring sky_centroid" in caplog.text
+
     assert isinstance(cat_out, Table)
     assert np.all(abs_refcat["ra"] == cat_out["RA"])
     assert np.all(abs_refcat["dec"] == cat_out["DEC"])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4138](https://jira.stsci.edu/browse/JP-4138)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->

Make sure warning messages are captured in the log by logging them instead of using the warnings module.

Also, make sure local loggers can inherit their parent level by removing `setLevel` calls at the import level.

Requires https://github.com/spacetelescope/jwst/pull/9884, which updates one test in the resample suite to expect a log message instead of a UserWarning.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- `changes/<PR#>.apichange.rst`: change to public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.general.rst`: infrastructure or miscellaneous change
</details>
