### PR TITLE
Rescale resample kernels by pixel scale ratio - V2

### DIFF
--- a/changes/418.bugfix.rst
+++ b/changes/418.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in resample due to which the "turbo", "gaussian", and "lanczos" resample kernels were not properly rescaled by pixel scale ratio.

--- a/changes/418.bugfix.rst
+++ b/changes/418.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a bug in resample due to which the "turbo", "gaussian", and "lanczos" resample kernels were not properly rescaled by pixel scale ratio.

--- a/changes/418.resample.rst
+++ b/changes/418.resample.rst
@@ -1,0 +1,1 @@
+Fix a bug in resample due to which the "turbo", "gaussian", and "lanczos" resample kernels were not properly rescaled by pixel scale ratio.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
 ]
 dependencies = [
   "astropy >=6.0.0",
-  "drizzle@git+https://github.com/mcara/drizzle.git@decouple-scales",
+  "drizzle >=2.2.0",
   "scipy >=1.14.1",
   "scikit-image>=0.21.0",
   "numpy >=1.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
 ]
 dependencies = [
   "astropy >=6.0.0",
-  "drizzle >=2.0.1",
+  "drizzle@git+https://github.com/mcara/drizzle.git@decouple-scales",
   "scipy >=1.14.1",
   "scikit-image>=0.21.0",
   "numpy >=1.25.0",

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -269,7 +269,7 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio, fillval=
         pixmap=pixmap,
         out_img=outsci,
         fillval=fillval,
-        iscale=1.0,
+        iscale=1.0 / (pix_ratio * pix_ratio),
         interp="linear",
         sinscl=1.0,
     )

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -269,6 +269,12 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio, fillval=
         pixmap=pixmap,
         out_img=outsci,
         fillval=fillval,
+        # scaling of the input pixel is unnecessary since outlier detection
+        # is based on SNR (ratio being a key word here). However, to preserve
+        # the same accuracy loss as before, we keep the scaling in order for
+        # the regression tests to pass.
+        # TODO: Consider setting iscale=1 to avoid accuracy loss and simplify
+        # the logic.
         iscale=1.0 / (pix_ratio * pix_ratio),
         interp="linear",
         sinscl=1.0,

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -6,7 +6,7 @@ import warnings
 import gwcs
 import numpy as np
 from astropy.stats import sigma_clip
-from drizzle.cdrizzle import tblot
+from drizzle.resample import blot_image
 from scipy import ndimage
 from skimage.util import view_as_windows
 
@@ -263,15 +263,14 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio, fillval=
     # what we've been doing up until now, so more investigation is needed
     # before a change is made.  Preferably, fix tblot in drizzle.
     pixmap[np.isnan(pixmap)] = -1
-    tblot(
-        median_data,
-        pixmap,
-        outsci,
-        scale=pix_ratio,
-        kscale=1.0,
+
+    blot_image(
+        data=median_data,
+        pixmap=pixmap,
+        out_img=outsci,
+        fillval=fillval,
+        iscale=1.0,
         interp="linear",
-        exptime=1.0,
-        misval=fillval,
         sinscl=1.0,
     )
 

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -557,7 +557,7 @@ class Resample:
         ):
             # If input image is in flux density units, correct the
             # flux for the user-specified change to the spatial dimension
-            iscale = 1.0 / math.sqrt(self.pixel_scale_ratio)
+            iscale = 1.0 / self.pixel_scale_ratio
 
         else:
             iscale = 1.0

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -774,18 +774,18 @@ class Resample:
         xmin, xmax, ymin, ymax = resample_range(data.shape, wcs.bounding_box)
 
         add_image_kwargs = {
-            'exptime': model["exposure_time"],
-            'pixmap': pixmap,
-            'pixel_scale_ratio': self.pixel_scale_ratio,
-            'iscale': iscale,
-            'weight_map': weight,
-            'wht_scale': 1.0,
-            'pixfrac': self.pixfrac,
-            'in_units': 'cps',
-            'xmin': xmin,
-            'xmax': xmax,
-            'ymin': ymin,
-            'ymax': ymax,
+            "exptime": model["exposure_time"],
+            "pixmap": pixmap,
+            "pixel_scale_ratio": self.pixel_scale_ratio,
+            "iscale": iscale,
+            "weight_map": weight,
+            "wht_scale": 1.0,
+            "pixfrac": self.pixfrac,
+            "in_units": "cps",
+            "xmin": xmin,
+            "xmax": xmax,
+            "ymin": ymin,
+            "ymax": ymax,
         }
 
         self._driz.add_image(data, **add_image_kwargs)
@@ -819,7 +819,7 @@ class Resample:
                 xmin=xmin,
                 xmax=xmax,
                 ymin=ymin,
-                ymax=ymax
+                ymax=ymax,
             )
 
         # update output model (variance is too expensive so it's omitted)
@@ -832,9 +832,8 @@ class Resample:
             # use resampled error
             self._output_model["err"] = self._driz_error.out_img
 
-    def add_model_hook(self, model, pixmap, pixel_scale_ratio, iscale,
-                       weight_map, xmin, xmax, ymin, ymax):
-        """ A hook method called by the :py:meth:`~Resample.add_model` method.
+    def add_model_hook(self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax):
+        """A hook method called by the :py:meth:`~Resample.add_model` method.
         It allows subclasses perform additional processing at the time the
         ``model["data"]`` array is resampled.
 
@@ -997,9 +996,10 @@ class Resample:
                 "wt": np.zeros(shape, dtype=var_dtype),
             }
 
-    def resample_variance_arrays(self, model, pixmap, pixel_scale_ratio,
-                                 iscale, weight_map, xmin, xmax, ymin, ymax):
-        """ Resample and co-add variance arrays using appropriate weights
+    def resample_variance_arrays(
+        self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax
+    ):
+        """Resample and co-add variance arrays using appropriate weights
         and update total weights.
 
         Parameters
@@ -1063,14 +1063,14 @@ class Resample:
         # Do the read noise variance first, so it can be
         # used for weights if needed
         pars = {
-            'pixmap': pixmap,
-            'pixel_scale_ratio': pixel_scale_ratio,
-            'iscale': iscale,
-            'weight_map': weight_map,
-            'xmin': xmin,
-            'xmax': xmax,
-            'ymin': ymin,
-            'ymax': ymax,
+            "pixmap": pixmap,
+            "pixel_scale_ratio": pixel_scale_ratio,
+            "iscale": iscale,
+            "weight_map": weight_map,
+            "xmin": xmin,
+            "xmax": xmax,
+            "ymin": ymin,
+            "ymax": ymax,
         }
 
         for varname in self.variance_array_names:
@@ -1152,10 +1152,19 @@ class Resample:
             del self._variance_info
             self._finalized = True
 
-    def _resample_one_variance_array(self, name, model, pixel_scale_ratio,
-                                     iscale, weight_map, pixmap,
-                                     xmin=None, xmax=None, ymin=None,
-                                     ymax=None):
+    def _resample_one_variance_array(
+        self,
+        name,
+        model,
+        pixel_scale_ratio,
+        iscale,
+        weight_map,
+        pixmap,
+        xmin=None,
+        xmax=None,
+        ymin=None,
+        ymax=None,
+    ):
         """Resample one variance image from an input model.
 
         The error image is passed to drizzle instead of the variance in order

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -776,8 +776,8 @@ class Resample:
         add_image_kwargs = {
             'exptime': model["exposure_time"],
             'pixmap': pixmap,
-            'iscale': iscale,
             'pixel_scale_ratio': self.pixel_scale_ratio,
+            'iscale': iscale,
             'weight_map': weight,
             'wht_scale': 1.0,
             'pixfrac': self.pixfrac,
@@ -811,15 +811,15 @@ class Resample:
 
         if self._enable_var:
             self.resample_variance_arrays(
-                model,
-                pixmap,
-                self.pixel_scale_ratio,
-                iscale,
-                weight,
-                xmin,
-                xmax,
-                ymin,
-                ymax
+                model=model,
+                pixmap=pixmap,
+                pixel_scale_ratio=self.pixel_scale_ratio,
+                iscale=iscale,
+                weight_map=weight,
+                xmin=xmin,
+                xmax=xmax,
+                ymin=ymin,
+                ymax=ymax
             )
 
         # update output model (variance is too expensive so it's omitted)

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -833,9 +833,10 @@ class Resample:
             self._output_model["err"] = self._driz_error.out_img
 
     def add_model_hook(self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax):
-        """A hook method called by the :py:meth:`~Resample.add_model` method.
-        It allows subclasses perform additional processing at the time the
-        ``model["data"]`` array is resampled.
+        """ Add a hook method called by the :py:meth:`~Resample.add_model` method.
+
+        It allows subclasses perform additional processing at the time
+        the ``model["data"]`` array is resampled.
 
         This method is called immediately after ``model["data"]`` is resampled.
 

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -836,11 +836,8 @@ class Resample:
         """Perform additional processing while resampling.
 
         A hook method called by the :py:meth:`~Resample.add_model` method.
-        It allows subclasses perform additional processing at the time the
-        ``model["data"]`` array is resampled.
-
-        It allows subclasses perform additional processing at the time
-        the ``model["data"]`` array is resampled.
+       It allows subclasses perform additional processing at the time the
+       ``model["data"]`` array is resampled.
 
         This method is called immediately after ``model["data"]`` is resampled.
 

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -833,7 +833,11 @@ class Resample:
             self._output_model["err"] = self._driz_error.out_img
 
     def add_model_hook(self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax):
-        """Add a hook method called by the :py:meth:`~Resample.add_model` method.
+        """Perform additional processing while resampling.
+
+        A hook method called by the :py:meth:`~Resample.add_model` method.
+        It allows subclasses perform additional processing at the time the
+        ``model["data"]`` array is resampled.
 
         It allows subclasses perform additional processing at the time
         the ``model["data"]`` array is resampled.
@@ -1000,7 +1004,10 @@ class Resample:
     def resample_variance_arrays(
         self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax
     ):
-        """Resample and co-add variance arrays using appropriate weights and update total weights.
+        """Resample variance arrays.
+
+        Resample and co-add variance arrays using appropriate weights
+        and update total weights.
 
         Parameters
         ----------

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -833,7 +833,7 @@ class Resample:
             self._output_model["err"] = self._driz_error.out_img
 
     def add_model_hook(self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax):
-        """ Add a hook method called by the :py:meth:`~Resample.add_model` method.
+        """Add a hook method called by the :py:meth:`~Resample.add_model` method.
 
         It allows subclasses perform additional processing at the time
         the ``model["data"]`` array is resampled.

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -836,8 +836,8 @@ class Resample:
         """Perform additional processing while resampling.
 
         A hook method called by the :py:meth:`~Resample.add_model` method.
-       It allows subclasses perform additional processing at the time the
-       ``model["data"]`` array is resampled.
+        It allows subclasses perform additional processing at the time the
+        ``model["data"]`` array is resampled.
 
         This method is called immediately after ``model["data"]`` is resampled.
 

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -1000,8 +1000,7 @@ class Resample:
     def resample_variance_arrays(
         self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax
     ):
-        """Resample and co-add variance arrays using appropriate weights
-        and update total weights.
+        """Resample and co-add variance arrays using appropriate weights and update total weights.
 
         Parameters
         ----------

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -20,7 +20,8 @@ from .helpers import (
 
 
 class _CustomResample(Resample):
-    def add_model_hook(self, model, pixmap, iscale, weight_map, xmin, xmax, ymin, ymax):
+    def add_model_hook(self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax):
+
         data = model["data"]
         wcs = model["wcs"]
         iscale_ref = self._get_intensity_scale(model)

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -21,7 +21,6 @@ from .helpers import (
 
 class _CustomResample(Resample):
     def add_model_hook(self, model, pixmap, pixel_scale_ratio, iscale, weight_map, xmin, xmax, ymin, ymax):
-
         data = model["data"]
         wcs = model["wcs"]
         iscale_ref = self._get_intensity_scale(model)


### PR DESCRIPTION
Resolves [JP-4137](https://jira.stsci.edu/browse/JP-4137)
Closes spacetelescope/stcal#412

This PR fixes a bug in the resample code which is caused by the fact that we fix the `iscale` to be 1 while `drizzle` uses it in some kernels (turbo, gaussian, and lanczos) not only to apply a scale to input image data but also to compute kernel size in the input image frame from sizes in output image (that is, `drizzle` expects it to be pixel scale ratio). 

This PR takes a different approach from spacetelescope/stcal#412: `iscale` and (old) `kscale` (now `pixel_scale_ratio`) have been decoupled in https://github.com/spacetelescope/drizzle/pull/203 and this PR makes necessary code changes in `stcal` to work with the upcoming `drizzle` release that will include https://github.com/spacetelescope/drizzle/pull/203

## Tasks

- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/runs/18666316914)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- `changes/<PR#>.apichange.rst`: change to public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.general.rst`: infrastructure or miscellaneous change
</details>
