### PR TITLE
JP-4000: Persistence Flagging for Large Events

### DIFF
--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -17,6 +17,13 @@ from astropy.convolution import convolve
 from .twopoint_difference_class import TwoPointParams
 from . import twopoint_difference as twopt
 
+###################################################
+#        HELP!!
+import sys
+sys.path.insert(1, "/Users/kmacdonald/code/common")
+from print_statements import dbg_print
+###################################################
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -336,6 +343,7 @@ def flag_large_events(gdq, jump_flag, sat_flag, jump_data):
     total_snowballs = 0
     nints, ngrps, nrows, ncols = gdq.shape
     persist_jumps = np.zeros(shape=(nints, nrows, ncols), dtype=np.uint8)
+
     for integration in range(nints):
         for group in range(1, ngrps):
             current_gdq = gdq[integration, group, :, :]
@@ -352,6 +360,11 @@ def flag_large_events(gdq, jump_flag, sat_flag, jump_data):
                 not_current_sat = np.logical_not(current_sat)
                 next_new_sat = next_sat * not_current_sat
 
+            import ipdb; ipdb.set_trace()
+            # dbg_print("Here")
+
+            # XXX Could be a bug. next_new_sat is created conditionally.  Also,
+            #     for the last group, this is reused. Should it be?
             next_sat_ellipses = find_ellipses(next_new_sat, sat_flag, jump_data.min_sat_area)
             sat_ellipses = find_ellipses(new_sat, sat_flag, jump_data.min_sat_area)
 
@@ -613,6 +626,7 @@ def find_ellipses(dqplane, bitmask, min_area):
     # at least the minimum
     # area and return a list of the minimum enclosing ellipse parameters.
     pixels = np.bitwise_and(dqplane, bitmask)
+    # XXX here
     contours, hierarchy = cv.findContours(pixels, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
     bigcontours = [con for con in contours if cv.contourArea(con) > min_area]
 

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -17,13 +17,6 @@ from astropy.convolution import convolve
 from .twopoint_difference_class import TwoPointParams
 from . import twopoint_difference as twopt
 
-###################################################
-#        HELP!!
-import sys
-sys.path.insert(1, "/Users/kmacdonald/code/common")
-from print_statements import dbg_print
-###################################################
-
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/src/stcal/jump/jump_class.py
+++ b/src/stcal/jump/jump_class.py
@@ -104,6 +104,10 @@ class JumpData:
         self.after_jump_flag_e1 = None
         self.after_jump_flag_e2 = None
 
+        # For persistence flagging
+        self.persistence_fname = None
+        self.persistence = False
+
         # Snowball information for near-IR
         #  Turns on Snowball detector for NIR detectors
         self.expand_large_events = False


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4000](https://jira.stsci.edu/browse/JP-4000)

<!-- describe the changes comprising this PR here -->

This PR is a first pass at addressing persistence flagging for large events. A persistence flag and an optional persistence file name parameter has been added to the `jump_data` class in the jump step. With default settings this will not affect the current processing of the jump step.

These parameters allow for persistence flagging when the persistence flag is set to `True`. If a persistence file name is passed, the file is opened and a 2-D `uint8` array is retrieved to be `or`'d into each group. If a file name is not passed, a 2-D `uint8` array is created and populated from the first integration, which persists through all subsequent integrations.

Currently, these changes will not affect `JWST` processing and are not accessible from that pipeline. To access these options, the `JumpData` class needs to be directly modified and the `jump` function in `STCAL` `jump` module called.

Tests have not been developed, yet.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- `changes/<PR#>.apichange.rst`: change to public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.general.rst`: infrastructure or miscellaneous change
</details>
