### PR TITLE
TST: Improve coverage reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,8 +207,6 @@ archs = ["x86_64", "arm64"]
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
 
-[tool.coverage]
-
 [tool.coverage.run]
 omit = ["config.py", "config-3.py", "*.rmap", "tests/*", "*/tests/*"]
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

This PR addresses coverage weirdness I saw in #425 . It was checking for coverage of a test module, which it is not supposed to do, among other things.

No need for change log nor RT.

Maybe related:

* https://github.com/spacetelescope/stcal/issues/335

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- `changes/<PR#>.apichange.rst`: change to public API
- `changes/<PR#>.bugfix.rst`: fixes an issue
- `changes/<PR#>.general.rst`: infrastructure or miscellaneous change
</details>
