### PR TITLE
Fix [tool.mypy.overrides] brackets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 
-[[tool.mypy.overrides]]
+[tool.mypy.overrides]
 module = [
   "astropy.*",
   "gwcs.*",


### PR DESCRIPTION
I cannot tell if the double bracket is typo or not.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
