### PR TITLE
JP-3964: create_astrometric_catalog() needs more control for stars without Gaia proper motions (affects TweakReg)

### DIFF
--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -145,7 +145,6 @@ def get_catalog(
     search_radius=0.1,
     catalog="GAIADR3",
     timeout=TIMEOUT,
-    apply_pm=True,
     pm_err_max=None,
 ):
     """Extract catalog from VO web service.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3964](https://jira.stsci.edu/browse/JP-3964)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

This PR addresses https://github.com/spacetelescope/jwst/issues/8168

Closes #446

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
