### PR TITLE
[SCSB-223] align dependencies with explicit imports and add upper pins to STScI-managed packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,20 +10,19 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "astropy >=6.0.0",
-  "drizzle >=2.2.0",
-  "scipy >=1.14.1",
+  "astropy>=6.0.0",
+  "astropy_healpix>=1.1.2",
+  "drizzle>=2.2.0,<2.3.0",
+  "gwcs>=1.0.1,<2.0.0",
+  "numpy>=1.25.0",
+  "pyarrow>=10.0.1",
+  "requests>=2.22",
   "scikit-image>=0.21.0",
-  "numpy >=1.25.0",
-  "asdf >=3.3.0",
-  "gwcs >=1.0.1,<2.0.0",
-  "tweakwcs >=0.8.8",
-  "requests >=2.22",
-  "spherical-geometry >=1.3",
-  "stsci.imagestats >=1.8.3",
-  "shapely >=2.1.1",
-  "pyarrow >= 10.0.1",
-  "astropy_healpix >= 1.1.2",
+  "scipy>=1.14.1",
+  "shapely>=2.1.1",
+  "spherical-geometry>=1.3,<1.5",
+  "stsci.imagestats>=1.8.3,<1.9",
+  "tweakwcs>=0.8.8,<0.9",
 ]
 license-files = ["LICENSE"]
 dynamic = ["version"]
@@ -37,7 +36,7 @@ docs = [
   "sphinx-rtd-theme",
   "tomli; python_version <=\"3.11\"",
 ]
-test = ["psutil", "pytest>=9.0", "pytest-cov", "pytest-doctestplus"]
+test = ["asdf>=3.3.0", "pytest>=9.0", "pytest-doctestplus>=1.3.0"]
 
 [project.urls]
 repository = "https://github.com/spacetelescope/stcal"
@@ -45,10 +44,10 @@ tracker = "https://github.com/spacetelescope/stcal/issues"
 
 [build-system]
 requires = [
-  "setuptools >=61",
-  "setuptools_scm[toml] >=3.4",
-  "Cython >=0.29.21",
-  "numpy >=2.0.0",
+  "Cython>=0.29.21",
+  "numpy>=2.0.0",
+  "setuptools>=61",
+  "setuptools_scm[toml]>=3.4",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ allowlist_externals =
     jwst,romancal: bash
 deps =
     xdist: pytest-xdist
+    cov: pytest-cov
     oldestdeps: minimum_dependencies
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
@@ -26,7 +27,6 @@ deps =
     devdeps: astropy>=0.0.dev0
     devdeps: requests>=0.0.dev0
     devdeps: tweakwcs @ git+https://github.com/spacetelescope/tweakwcs.git
-    devdeps: asdf @ git+https://github.com/asdf-format/asdf.git
     devdeps: drizzle @ git+https://github.com/spacetelescope/drizzle.git
     devdeps: gwcs @ git+https://github.com/spacetelescope/gwcs.git
 use_develop = true


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [SCSB-223](https://jira.stsci.edu/browse/SCSB-223)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
used [`valimdep`](https://github.com/zacharyburnett/valimdep) to find unimported dependencies and undepended imports:
- move `asdf` to test deps
- remove `psutil` from test deps
- remove `pytest-cov` from test deps

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
