### PR TITLE
JP-3964: Filter out bad proper motion from get_catalog

### DIFF
--- a/changes/446.tweakreg.rst
+++ b/changes/446.tweakreg.rst
@@ -1,0 +1,1 @@
+``create_astrometric_catalog()`` and ``get_catalog()`` now throws out rows with invalid proper motion. You can get back the old behavior by setting ``strict_cols=None`` when calling it.

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -29,7 +29,7 @@ from stcal.tweakreg.utils import _wcsinfo_from_wcs_transform
 
 # Define input GWCS specification to be used for these tests
 WCS_NAME = "mosaic_long_i2d_gwcs.asdf"  # Derived using B7.5 Level 3 product
-EXPECTED_NUM_SOURCES = {"GAIAREFCAT": 1991, "GAIADR3_S3": 1991}
+EXPECTED_NUM_SOURCES = {"GAIAREFCAT": 1991, "GAIADR3_S3": 2469}
 EXPECTED_NUM_SOURCES_BAD_PM = {"GAIAREFCAT": 2469, "GAIADR3_S3": 1991}
 
 # more recent WCS with a defined input frame is necessary for some tests

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -29,8 +29,8 @@ from stcal.tweakreg.utils import _wcsinfo_from_wcs_transform
 
 # Define input GWCS specification to be used for these tests
 WCS_NAME = "mosaic_long_i2d_gwcs.asdf"  # Derived using B7.5 Level 3 product
-EXPECTED_NUM_SOURCES = {"GAIAREFCAT": 1991, "GAIADR3_S3": 2469}
-EXPECTED_NUM_SOURCES_BAD_PM = {"GAIAREFCAT": 2469, "GAIADR3_S3": 2469}
+EXPECTED_NUM_SOURCES = {"GAIAREFCAT": 1991, "GAIADR3_S3": 1991}
+EXPECTED_NUM_SOURCES_BAD_PM = {"GAIAREFCAT": 2469, "GAIADR3_S3": 1991}
 
 # more recent WCS with a defined input frame is necessary for some tests
 WCS_NAME_2 = "nrcb1-wcs.asdf"
@@ -403,7 +403,7 @@ def test_get_catalog_raises_connection_error(monkeypatch):
 
 @pytest.mark.parametrize("epoch", [None, 2025.1])
 def test_catalogs_match(epoch):
-    gsss = amutils.get_catalog(10, 10, search_radius=0.1, epoch=epoch, catalog="GAIADR3")
+    gsss = amutils.get_catalog(10, 10, search_radius=0.1, epoch=epoch, catalog="GAIADR3", strict_cols=None)
     s3 = amutils.get_catalog(10, 10, search_radius=0.1, epoch=epoch, catalog="GAIADR3_S3")
     if epoch:
         gsss = gsss[~(gsss["pmra"].mask)]

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -29,8 +29,8 @@ from stcal.tweakreg.utils import _wcsinfo_from_wcs_transform
 
 # Define input GWCS specification to be used for these tests
 WCS_NAME = "mosaic_long_i2d_gwcs.asdf"  # Derived using B7.5 Level 3 product
-EXPECTED_NUM_SOURCES = 1991
-EXPECTED_NUM_SOURCES_BAD_PM = 2469
+EXPECTED_NUM_SOURCES = {"GAIAREFCAT": 1991, "GAIADR3_S3": 2469}
+EXPECTED_NUM_SOURCES_BAD_PM = {"GAIAREFCAT": 2469, "GAIADR3_S3": 2469}
 
 # more recent WCS with a defined input frame is necessary for some tests
 WCS_NAME_2 = "nrcb1-wcs.asdf"
@@ -93,13 +93,13 @@ def test_get_catalog(wcsobj, abs_catalog):
         catalog=abs_catalog,
     )
 
-    assert len(cat) == EXPECTED_NUM_SOURCES
+    assert len(cat) == EXPECTED_NUM_SOURCES[abs_catalog]
 
     cat2 = amutils.get_catalog(
         fiducial[0], fiducial[1], search_radius=radius, catalog=abs_catalog, strict_cols=None
     )
 
-    assert len(cat2) == EXPECTED_NUM_SOURCES_BAD_PM
+    assert len(cat2) == EXPECTED_NUM_SOURCES_BAD_PM[abs_catalog]
 
 
 def test_create_catalog(wcsobj, abs_catalog):
@@ -111,7 +111,7 @@ def test_create_catalog(wcsobj, abs_catalog):
         output=None,
     )
     # check that we got expected number of sources
-    assert len(gcat) == EXPECTED_NUM_SOURCES
+    assert len(gcat) == EXPECTED_NUM_SOURCES[abs_catalog]
 
 
 def test_create_catalog_graceful_failure(wcsobj, abs_catalog):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3964](https://jira.stsci.edu/browse/JP-3964)

Closes #441

<!-- If this PR closes a GitHub issue, reference it here by its number -->

This PR allows `get_catalog` to filter out rows with bad proper motion info. This would be the new default behavior. ref https://github.com/spacetelescope/jwst/issues/8168

Might get superseded by https://jira.stsci.edu/browse/AL-1006 anyway in the future.

## TODO

- [x] Buy-in from INS; they have to find edge cases and perform science case testing, etc.
- [ ] Are romancal RT failures acceptable? Eddie and/or Mihai should review.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`stcal@git+https://github.com/pllim/stcal.git@tweak-and-shout-less`) 
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/19516312167, https://github.com/spacetelescope/RegressionTests/actions/runs/20979629034
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/19516360882, https://github.com/spacetelescope/RegressionTests/actions/runs/20979652406
