### PR TITLE
Skip python 3.14t wheels for all oses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,10 +200,12 @@ line_length = 110
 [tool.codespell]
 skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 
-[tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+[tool.cibuildwheel]
 # Disable free-threading builds on all platforms
 skip = "cp3??t-*"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]


### PR DESCRIPTION
https://github.com/spacetelescope/stcal/pull/451 only skipped building python 3.14t wheels for macos. This fixes that mistake and skips for all oses.

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
