### PR TITLE
add python 3.14 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,10 @@ jobs:
         - linux: py311-oldestdeps-cov-xdist
         - linux: py311-xdist
         - linux: py312-xdist
-        - linux: py313-cov-xdist
+        - linux: py313-xdist
+        - linux: py314-cov-xdist
           coverage: codecov
-        - macos: py313-xdist
+        - macos: py314-xdist
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1fedda61294df4c004c05519a3fbf3b8e1f32f # v2.3.1
     with:

--- a/.github/workflows/tests_extra.yml
+++ b/.github/workflows/tests_extra.yml
@@ -19,8 +19,8 @@ jobs:
         - macos: py311-xdist
         - macos: py312-xdist
         - macos: py313-xdist
-        - linux: py313-devdeps-xdist
-        - macos: py313-devdeps-xdist
+        - linux: py314-devdeps-xdist
+        - macos: py314-devdeps-xdist
   test_downstream:
     if: (github.repository == 'spacetelescope/stcal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run extra tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1fedda61294df4c004c05519a3fbf3b8e1f32f # v2.3.1
@@ -30,5 +30,5 @@ jobs:
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
-        - linux: py313-jwst-devdeps
+        - linux: py314-jwst-devdeps
         - linux: py313-romancal-devdeps


### PR DESCRIPTION
Updates the CI to run 3.14 tests.

Will require branch protection updates.

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
