### PR TITLE
JP-4174: Fix point_inside_ellipse returns True for points outside the ellipse

### DIFF
--- a/changes/456.bugfix.rst
+++ b/changes/456.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where ``point_inside_ellipse()`` sometimes returning True for a point outside of the given ellipse.

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -19,31 +19,7 @@ from stcal.multiprocessing import compute_num_cores
 
 log = logging.getLogger(__name__)
 
-__all__ = [
-    "detect_jumps_data",
-    "twopoint_diff_multi",
-    "reassemble_sliced_data",
-    "slice_data",
-    "setup_pdq",
-    "flag_large_events",
-    "extend_saturation",
-    "ellipse_subim",
-    "extend_ellipses",
-    "find_ellipses",
-    "make_snowballs",
-    "point_inside_ellipse",
-    "near_edge",
-    "find_faint_extended",
-    "max_flux_showers",
-    "count_dnu_groups",
-    "compute_axes",
-    "get_bigellipses",
-    "convolve_fast",
-    "diff_meddiff_int",
-    "diff_meddiff_grp",
-    "nan_invalid_data",
-    "find_first_good_group"
-]
+__all__ = []  # No public API
 
 
 def detect_jumps_data(jump_data):

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -96,7 +96,6 @@ def detect_jumps_data(jump_data):
     readnoise_2d = jump_data.rnoise_2d * jump_data.gain_2d
 
     # also apply to the after_jump thresholds
-    # Ken M: Maybe move this computation
     jump_data.after_jump_flag_e1 = jump_data.after_jump_flag_dn1 * np.nanmedian(jump_data.gain_2d)
     jump_data.after_jump_flag_e2 = jump_data.after_jump_flag_dn2 * np.nanmedian(jump_data.gain_2d)
 
@@ -111,7 +110,7 @@ def detect_jumps_data(jump_data):
 
     twopt_params = TwoPointParams(jump_data)
     if n_slices == 1:
-        twopt_params.minimum_groups = 3  # Ken M: Should this be hard coded as 3?
+        twopt_params.minimum_groups = 3
         gdq, row_below_dq, row_above_dq, total_primary_crs = twopt.find_crs(
                     data, gdq, readnoise_2d, twopt_params)
     else:

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -19,6 +19,32 @@ from stcal.multiprocessing import compute_num_cores
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "detect_jumps_data",
+    "twopoint_diff_multi",
+    "reassemble_sliced_data",
+    "slice_data",
+    "setup_pdq",
+    "flag_large_events",
+    "extend_saturation",
+    "ellipse_subim",
+    "extend_ellipses",
+    "find_ellipses",
+    "make_snowballs",
+    "point_inside_ellipse",
+    "near_edge",
+    "find_faint_extended",
+    "max_flux_showers",
+    "count_dnu_groups",
+    "compute_axes",
+    "get_bigellipses",
+    "convolve_fast",
+    "diff_meddiff_int",
+    "diff_meddiff_grp",
+    "nan_invalid_data",
+    "find_first_good_group"
+]
+
 
 def detect_jumps_data(jump_data):
     """

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -723,7 +723,7 @@ def point_inside_ellipse(point, ellipse):
     Parameters
     ----------
     point : tuple
-        Point of interest.
+        Point of interest in the format of ``(x, y)``.
 
     ellipse : tuple
         Ellipse for testing in the format of
@@ -734,10 +734,29 @@ def point_inside_ellipse(point, ellipse):
     bool
         Boolean decision if point is in ellipse.
     """
-    delta_center = np.sqrt((point[0] - ellipse[0][0]) ** 2 + (point[1] - ellipse[0][1]) ** 2)
-    major_axis = max(ellipse[1][0], ellipse[1][1])
+    # https://stackoverflow.com/questions/37031356/check-if-points-are-inside-ellipse-faster-than-contains-point-method
 
-    return delta_center < major_axis
+    angle = np.radians(180 - ellipse[2])
+    cos_angle = np.cos(angle)
+    sin_angle = np.sin(angle)
+
+    xc = point[0] - ellipse[0][0]
+    yc = point[1] - ellipse[0][1]
+
+    xct = xc * cos_angle - yc * sin_angle
+    yct = xc * sin_angle + yc * cos_angle
+
+    if ellipse[1][1] >= ellipse[1][0]:
+        semi_major_axis = ellipse[1][1]
+        semi_minor_axis = ellipse[1][0]
+    else:
+        semi_major_axis = ellipse[1][0]
+        semi_minor_axis = ellipse[1][1]
+
+    rad_cc = ((xct**2 / semi_major_axis**2) +
+              (yct**2 / semi_minor_axis**2))
+
+    return rad_cc <= 1
 
 
 def near_edge(jump, low_threshold, high_threshold):

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -747,11 +747,11 @@ def point_inside_ellipse(point, ellipse):
     yct = xc * sin_angle + yc * cos_angle
 
     if ellipse[1][1] >= ellipse[1][0]:
-        semi_major_axis = ellipse[1][1]
-        semi_minor_axis = ellipse[1][0]
+        semi_major_axis = ellipse[1][1] * 0.5
+        semi_minor_axis = ellipse[1][0] * 0.5
     else:
-        semi_major_axis = ellipse[1][0]
-        semi_minor_axis = ellipse[1][1]
+        semi_major_axis = ellipse[1][0] * 0.5
+        semi_minor_axis = ellipse[1][1] * 0.5
 
     rad_cc = ((xct**2 / semi_major_axis**2) +
               (yct**2 / semi_minor_axis**2))
@@ -1326,7 +1326,7 @@ def _sk_filter_areas(image, threshold):
         region encoded as is a 3 element list of values.
         The first element is a tuple of 2 floats encoding the
         center column and row. Element 2 is a tuple of 2 floats encoding
-        the area minor and major axis lengths. Element 3 is a float
+        the area minor and major axis full lengths. Element 3 is a float
         encoding the rotation angle of the area in degrees. Format:
         ``[((cen_x, cen_y), (minor_axis, major_axis), theta_deg), ...]``
     """
@@ -1335,8 +1335,9 @@ def _sk_filter_areas(image, threshold):
     for region in skimage.measure.regionprops(lim):
         if region.area_filled < threshold:
             continue
-        # wait until after area check so calculating the more expensive
-        # region properties is only done for areas that pass threshold
+        # Wait until after area check so calculating the more expensive
+        # region properties is only done for areas that pass threshold.
+        # https://scikit-image.org/docs/stable/auto_examples/segmentation/plot_regionprops.html#measure-region-properties
         w = region.axis_major_length - 1
         h = region.axis_minor_length - 1
         min_areas.append((

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from astropy.io import fits
+
 from stcal.jump.jump_class import JumpData
 from stcal.jump.jump import (
     extend_saturation,
@@ -486,29 +487,17 @@ def test_find_faint_extended_sigclip():
     assert np.all(gdq[0, 4, 12:22, 14:23]) == 0
 
 
-def test_inside_ellipse5():
-    ellipse = ((0, 0), (1, 2), -10)
-    point = (1, 0.6)
-    result = point_inside_ellipse(point, ellipse)
-    assert result
+@pytest.mark.parametrize(
+    ("ellipse", "point"),
+    [(((0, 0), (1, 2), -10), (1, 0.6)),
+     (((0, 0), (1, 2), 0), (1, 0.5)),
+     (((1111.0001220703125, 870.5000610351562), (10.60660171508789, 10.60660171508789), 45.0), (1110.5, 870.5))])
+def test_point_inside_ellipse(ellipse, point):
+    assert point_inside_ellipse(point, ellipse)
 
 
-def test_inside_ellipse4():
-    ellipse = ((0, 0), (1, 2), 0)
-    point = (1, 0.5)
-    result = point_inside_ellipse(point, ellipse)
-    assert result
-
-
-def test_inside_ellipse6():
-    ellipse = ((0, 0), (1, 2), 0)
-    point = (3, 0.5)
-    result = point_inside_ellipse(point, ellipse)
-    assert not result
-
-
-def test_inside_ellipes5():
-    point = (1110.5, 870.5)
-    ellipse = ((1111.0001220703125, 870.5000610351562), (10.60660171508789, 10.60660171508789), 45.0)
-    result = point_inside_ellipse(point, ellipse)
-    assert result
+@pytest.mark.parametrize(
+    ("ellipse", "point"),
+    [(((0, 0), (1, 2), 0), (3, 0.5))])
+def test_point_outside_ellipse(ellipse, point):
+    assert not point_inside_ellipse(point, ellipse)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -397,7 +397,6 @@ def test_find_faint_extended(tmp_path):
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
 
-    # Ken M: Probably should not generate random data for CI tests.
     rng = np.random.default_rng(12345)
     data[0, 1:, 14:20, 15:20] = 6 * gain * 6.0 * np.sqrt(2)
     data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
@@ -450,7 +449,6 @@ def test_find_faint_extended_sigclip():
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
 
-    # Ken M: Probably should not generate random data for CI tests.
     rng = np.random.default_rng(12345)
     data[0, 1:, 14:20, 15:20] = 6 * gain * 1.7
     data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -491,7 +491,9 @@ def test_find_faint_extended_sigclip():
     ("ellipse", "point"),
     [(((0, 0), (1, 2), -10), (1, 0.6)),
      (((0, 0), (1, 2), 0), (1, 0.5)),
-     (((1111.0001220703125, 870.5000610351562), (10.60660171508789, 10.60660171508789), 45.0), (1110.5, 870.5))])
+     (((1111.0001220703125, 870.5000610351562), (10.60660171508789, 10.60660171508789), 45.0), (1110.5, 870.5)),
+     (((0, 0), (10, 5), 0), (0, 0)),
+     (((0, 0), (10, 5), 0), (8, 0))])
 def test_point_inside_ellipse(ellipse, point):
     assert point_inside_ellipse(point, ellipse)
 
@@ -499,8 +501,6 @@ def test_point_inside_ellipse(ellipse, point):
 @pytest.mark.parametrize(
     ("ellipse", "point"),
     [(((0, 0), (1, 2), 0), (3, 0.5)),
-     (((0, 0), (10, 5), 0), (0, 0)),
-     (((0, 0), (10, 5), 0), (8, 0)),
      (((0, 0), (10, 5), 0), (0, 8))])
 def test_point_outside_ellipse(ellipse, point):
     assert not point_inside_ellipse(point, ellipse)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -498,6 +498,9 @@ def test_point_inside_ellipse(ellipse, point):
 
 @pytest.mark.parametrize(
     ("ellipse", "point"),
-    [(((0, 0), (1, 2), 0), (3, 0.5))])
+    [(((0, 0), (1, 2), 0), (3, 0.5)),
+     (((0, 0), (10, 5), 0), (0, 0)),
+     (((0, 0), (10, 5), 0), (8, 0)),
+     (((0, 0), (10, 5), 0), (0, 8))])
 def test_point_outside_ellipse(ellipse, point):
     assert not point_inside_ellipse(point, ellipse)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -490,18 +490,19 @@ def test_find_faint_extended_sigclip():
 
 @pytest.mark.parametrize(
     ("ellipse", "point"),
-    [(((0, 0), (1, 2), -10), (1, 0.6)),
-     (((0, 0), (1, 2), 0), (1, 0.5)),
+    [(((0, 0), (2, 4), -10), (1, 0.6)),
+     (((0, 0), (2, 4), 0), (1, 0.5)),
      (((1111.0001220703125, 870.5000610351562), (10.60660171508789, 10.60660171508789), 45.0), (1110.5, 870.5)),
      (((0, 0), (10, 5), 0), (0, 0)),
-     (((0, 0), (10, 5), 0), (8, 0))])
+     (((0, 0), (10, 5), 0), (5, 0))])
 def test_point_inside_ellipse(ellipse, point):
     assert point_inside_ellipse(point, ellipse)
 
 
 @pytest.mark.parametrize(
     ("ellipse", "point"),
-    [(((0, 0), (1, 2), 0), (3, 0.5)),
-     (((0, 0), (10, 5), 0), (0, 8))])
+    [(((0, 0), (2, 4), 0), (3, 0.5)),
+     (((0, 0), (10, 5), 0), (0, 8)),
+     (((0, 0), (10, 5), 0), (8, 0))])
 def test_point_outside_ellipse(ellipse, point):
     assert not point_inside_ellipse(point, ellipse)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -8,7 +8,6 @@ from stcal.jump.jump import (
     find_faint_extended,
     flag_large_events,
     point_inside_ellipse,
-    detect_jumps_data
 )
 
 DQFLAGS = {
@@ -39,7 +38,7 @@ def create_jump_data(dims, gain, rnoise, tm):
 
     pdq = np.zeros(shape=(nrows, ncols), dtype=np.uint8)
     gain2d = np.ones(shape=(nrows, ncols), dtype=np.float32) * gain
-    rnoise2d = np.ones(shape=(nrows, ncols) , dtype=np.float32) * rnoise
+    rnoise2d = np.ones(shape=(nrows, ncols), dtype=np.float32) * rnoise
 
     jump_data = JumpData(gain2d=gain2d, rnoise2d=rnoise2d, dqflags=DQFLAGS)
     jump_data.init_arrays_from_arrays(data, gdq, pdq)
@@ -63,21 +62,23 @@ def test_nirspec_saturated_pix():
     frame_time, nframes, groupgap = 10.6, 1, 0
 
     dims = nints, ngroups, nrows, ncols
-    var = rnval, gval
     tm = frame_time, nframes, groupgap
 
     jump_data = create_jump_data(dims, gval, rnval, tm)
 
     # Setup the needed input pixel and DQ values
-    jump_data.data[0, :, 1, 1] = [639854.75, 4872.451, -17861.791, 14022.15, 22320.176,
-                              1116.3828, 1936.9746]
+    jump_data.data[0, :, 1, 1] = [
+        639854.75, 4872.451, -17861.791, 14022.15, 22320.176,
+        1116.3828, 1936.9746]
     jump_data.gdq[0, :, 1, 1] = [0, 0, 0, 0, 0, SAT, SAT]
-    jump_data.data[0, :, 0, 1] = [8.25666812e+05, -1.10471914e+05, 1.95755371e+02, 1.83118457e+03,
-                              1.72250879e+03, 1.81733496e+03, 1.65188281e+03]
+    jump_data.data[0, :, 0, 1] = [
+        8.25666812e+05, -1.10471914e+05, 1.95755371e+02, 1.83118457e+03,
+        1.72250879e+03, 1.81733496e+03, 1.65188281e+03]
     # 2 non-sat groups means only 1 non-sat diff, so no jumps should be flagged
     jump_data.gdq[0, :, 0, 1] = [0, 0, SAT, SAT, SAT, SAT, SAT]
-    jump_data.data[0, :, 1, 0] = [1228767., 46392.234, -3245.6553, 7762.413,
-                              37190.76, 266611.62, 5072.4434]
+    jump_data.data[0, :, 1, 0] = [
+        1228767., 46392.234, -3245.6553, 7762.413,
+        37190.76, 266611.62, 5072.4434]
     jump_data.gdq[0, :, 1, 0] = [0, 0, 0, 0, 0, 0, SAT]
 
     jump_data.nframes = nframes
@@ -148,7 +149,7 @@ def test_multiprocessing():
     gdq, pdq, total_primary_crs, number_extended_events = detect_jumps_data(jump_data)
 
     assert gdq[0, 4, 5, 1] == JUMP
-    assert gdq[0, 4, 6, 1] == DNU  #This value would have been DNU | JUMP without the fix.
+    assert gdq[0, 4, 6, 1] == DNU  # This value would have been DNU | JUMP without the fix.
 
 
 def test_multiprocessing_big():
@@ -157,7 +158,6 @@ def test_multiprocessing_big():
     frame_time, nframes, groupgap = 10.6, 1, 0
 
     dims = nints, ngroups, nrows, ncols
-    var = rnval, gval
     tm = frame_time, nframes, groupgap
 
     jump_data = create_jump_data(dims, gval, rnval, tm)
@@ -200,7 +200,7 @@ def test_multiprocessing_big():
 
     assert gdq[0, 4, 204, 5] == JUMP
     assert gdq[0, 4, 205, 5] == JUMP
-    assert gdq[0, 4, 204, 6] == DNU  #This value would have been 5 without the fix.
+    assert gdq[0, 4, 204, 6] == DNU  # This value would have been 5 without the fix.
 
 
 def test_find_simple_ellipse():
@@ -237,7 +237,6 @@ def test_extend_saturation_simple():
     cube = np.zeros(shape=(5, 7, 7), dtype=np.uint8)
     persist_jumps = np.zeros(shape=(7, 7), dtype=np.uint8)
     grp = 1
-    min_sat_radius_extend = 1
     cube[1, 3, 3] = SAT
     cube[1, 2, 3] = SAT
     cube[1, 3, 4] = SAT
@@ -249,7 +248,6 @@ def test_extend_saturation_simple():
 
     jump_data = JumpData(dqflags=DQFLAGS)
     jump_data.min_sat_radius_extend = 1.1
-
 
     new_cube, persist_jumps = extend_saturation(
         cube, grp, sat_circles, jump_data, persist_jumps)
@@ -397,7 +395,7 @@ def test_find_faint_extended(tmp_path):
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
 
-    # XXX Probably should not generate random data for CI tests.
+    # Ken M: Probably should not generate random data for CI tests.
     rng = np.random.default_rng(12345)
     data[0, 1:, 14:20, 15:20] = 6 * gain * 6.0 * np.sqrt(2)
     data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
@@ -417,8 +415,8 @@ def test_find_faint_extended(tmp_path):
     readnoise = readnoise * np.sqrt(2)
     gdq, num_showers = find_faint_extended(data, gdq, pdq, readnoise, jump_data)
 
-    #  Check that all the expected samples in group 2 are flagged as jump and
-    #  that they are not flagged outside.  This should not be in tests.
+    # Check that all the expected samples in group 2 are flagged as jump and
+    # that they are not flagged outside.  This should not be in tests.
 
     # assert num_showers == 1
     assert np.all(gdq[0, 1, 22, 14:23] == 0)
@@ -426,7 +424,7 @@ def test_find_faint_extended(tmp_path):
     assert np.all(gdq[0, 1, 12:21, 16:19] == JUMP)
     assert np.all(gdq[0, 1, 22, 16:19] == 0)
     assert np.all(gdq[0, 1, 10, 16:19] == 0)
-    #  Check that the same area is flagged in the first group after the event
+    # Check that the same area is flagged in the first group after the event
     assert np.all(gdq[0, 2, 22, 14:23] == 0)
     assert gdq[0, 2, 16, 18] == JUMP
     assert np.all(gdq[0, 2, 12:21, 16:19] == JUMP)
@@ -435,7 +433,7 @@ def test_find_faint_extended(tmp_path):
 
     assert np.all(gdq[0, 3:, :, :]) == 0
 
-    #  Check that the flags are not applied in the 3rd group after the event
+    # Check that the flags are not applied in the 3rd group after the event
     assert np.all(gdq[0, 4, 12:22, 14:23]) == 0
 
 
@@ -450,7 +448,7 @@ def test_find_faint_extended_sigclip():
     gain = 4
     readnoise = np.ones(shape=(nrows, ncols), dtype=np.float32) * 6.0 * gain
 
-    # XXX Probably should not generate random data for CI tests.
+    # Ken M: Probably should not generate random data for CI tests.
     rng = np.random.default_rng(12345)
     data[0, 1:, 14:20, 15:20] = 6 * gain * 1.7
     data = data + rng.normal(size=(nint, ngrps, nrows, ncols)) * readnoise
@@ -467,8 +465,8 @@ def test_find_faint_extended_sigclip():
 
     gdq, num_showers = find_faint_extended(data, gdq, pdq, readnoise, jump_data)
 
-    #  Check that all the expected samples in group 2 are flagged as jump and
-    #  that they are not flagged outside
+    # Check that all the expected samples in group 2 are flagged as jump and
+    # that they are not flagged outside
     assert num_showers == 0
     assert np.all(gdq[0, 1, 22, 14:23] == 0)
     assert np.all(gdq[0, 1, 21, 16:20] == 0)
@@ -484,7 +482,7 @@ def test_find_faint_extended_sigclip():
     assert np.all(gdq[0, 1, 12:23, 24] == 0)
     assert np.all(gdq[0, 1, 12:23, 13] == 0)
 
-    #  Check that the flags are not applied in the 3rd group after the event
+    # Check that the flags are not applied in the 3rd group after the event
     assert np.all(gdq[0, 4, 12:22, 14:23]) == 0
 
 

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -9,6 +9,7 @@ from stcal.jump.jump import (
     find_faint_extended,
     flag_large_events,
     point_inside_ellipse,
+    detect_jumps_data
 )
 
 DQFLAGS = {


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4174](https://jira.stsci.edu/browse/JP-4174)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

This PR addresses 

* https://github.com/spacetelescope/jwst/issues/9969

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`"stcal@git+https://github.com/pllim/stcal@total-ellipse-of-my-points"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/20146487129 and https://github.com/spacetelescope/RegressionTests/actions/runs/20279384974
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/20146506582 and https://github.com/spacetelescope/RegressionTests/actions/runs/20279389429
