### PR TITLE
JP-4209: Fix compute_axes comparison to enforce jump_data.max_extended_radius correctly

### DIFF
--- a/changes/459.bugfix.rst
+++ b/changes/459.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in ``compute_axes`` used in jump detection where it was not enforcing ``jump_data.max_extended_radius`` correctly.

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -118,7 +118,7 @@ def detect_jumps_data(jump_data):
 def twopoint_diff_multi(jump_data, twopt_params, data, gdq, readnoise_2d, n_slices):
     """
     Split data for jump detection multiprocessing.
-    
+
     Parameters
     ----------
     jump_data : JumpData
@@ -130,7 +130,7 @@ def twopoint_diff_multi(jump_data, twopt_params, data, gdq, readnoise_2d, n_slic
     data : ndarray
         The science data, 4D array float.
 
-    gdq : ndarray 
+    gdq : ndarray
         The group DQ, 4D array uint8.
 
     readnoise_2d : ndarray
@@ -236,7 +236,7 @@ def slice_data(twopt_params, data, gdq, readnoise_2d, n_slices):
     data : ndarray
         The science data, 4D array float.
 
-    gdq : ndarray 
+    gdq : ndarray
         The group DQ, 4D array uint8.
 
     readnoise_2d : ndarray
@@ -357,7 +357,7 @@ def flag_large_events(gdq, jump_flag, sat_flag, jump_data):
             # find the ellipse parameters for jump regions
             jump_ellipses = find_ellipses(
                 gdq[integration, group, :, :], jump_flag, jump_data.min_jump_area)
-            
+
             if jump_data.sat_required_snowball:
                 gdq, snowballs, persist_jumps = make_snowballs(
                     gdq, integration, group, jump_ellipses, sat_ellipses,
@@ -389,7 +389,7 @@ def flag_large_events(gdq, jump_flag, sat_flag, jump_data):
 def extend_saturation(cube, grp, sat_ellipses, jump_data, persist_jumps):
     """
     Extend the saturated ellipses that are larger than the min_sat_radius.
-    
+
     Parameters
     ----------
     cube : ndarray
@@ -564,7 +564,7 @@ def extend_ellipses(
         indx, jump_ellipse = ellipse_subim(
             ceny, cenx, axis1, axis2, alpha, jump_data.fl_jump, (nrows, ncols))
         (iy1, iy2, ix1, ix2) = indx
-        
+
         # Propagate forward by num_grps_masked groups.
 
         for flg_grp in range(grp, min(grp + num_grps_masked + 1, ngroups)):
@@ -593,7 +593,7 @@ def find_ellipses(dqplane, bitmask, min_area):
         The minimum area of saturated pixels at the center of a snowball. Only
         contours with area above the minimum will create snowballs.
 
-    Returns 
+    Returns
     -------
     list of computed ellipses
     """
@@ -641,7 +641,7 @@ def make_snowballs(
     -------
     gdq : ndarray
         The 4-D group DQ array.
-        
+
     snowballs : list
         List of snowballs found.
 
@@ -720,7 +720,7 @@ def near_edge(jump, low_threshold, high_threshold):
         Low threshold distance from the edge of the detector where saturated cores are not
         required for snowball detection.
 
-    high_threshold : 
+    high_threshold :
         High threshold distance from the edge of the detector where saturated cores are not
         required for snowball detection.
 
@@ -912,7 +912,7 @@ def count_dnu_groups(gdq, jump_data):
     ----------
     gdq : ndarray
         The group DQ 4D uint8.
-        
+
     jump_data : JumpData
         Class containing parameters and methods to detect jumps.
 
@@ -942,7 +942,8 @@ def compute_axes(expand_by_ratio, ellipse, expansion, jump_data):
     Parameters
     ----------
     expand_by_ratio : bool
-        Should the axes be expanded?
+        Should the axes be expanded using ``expansion`` as a ratio?
+        If `False`, ``expansion`` is added directly.
 
     ellipse : cv2.ellipse
         Ellipse to expand.
@@ -955,8 +956,9 @@ def compute_axes(expand_by_ratio, ellipse, expansion, jump_data):
 
     Returns
     -------
-    axes : tuple
-        Expanded and rounded ellipse axes.
+    axes : tuple of int
+        Expanded and rounded ellipse semi axes.
+        They will never exceed ``jump_data.max_extended_radius``.
     """
     if expand_by_ratio:
         if ellipse[1][1] < ellipse[1][0]:
@@ -968,10 +970,10 @@ def compute_axes(expand_by_ratio, ellipse, expansion, jump_data):
     else:
         axis1 = ellipse[1][0] + expansion
         axis2 = ellipse[1][1] + expansion
-    axis1 = min(axis1, jump_data.max_extended_radius)
-    axis2 = min(axis2, jump_data.max_extended_radius)
+    axis1 = min(axis1 / 2, jump_data.max_extended_radius)
+    axis2 = min(axis2 / 2, jump_data.max_extended_radius)
 
-    return (round(axis1 / 2), round(axis2 / 2))
+    return round(axis1), round(axis2)
 
 
 def get_bigellipses(ratio, intg, grp, gdq, pdq, jump_data, ring_2D_kernel):
@@ -1013,12 +1015,12 @@ def get_bigellipses(ratio, intg, grp, gdq, pdq, jump_data, ring_2D_kernel):
 
     jump_sat_or_dnu = np.bitwise_and(combined_pixel_mask, jump_flag|sat_flag|dnu_flag) != 0
     masked_ratio[jump_sat_or_dnu] = np.nan
-    
+
     kernel = ring_2D_kernel.array
-    
+
     # Equivalent to but faster than
     # masked_smoothed_ratio = convolve(masked_ratio, ring_2D_kernel, preserve_nan=True)
-    
+
     masked_smoothed_ratio = convolve_fast(masked_ratio, kernel)
 
     extended_emission = (masked_smoothed_ratio > jump_data.extend_snr_threshold).astype(np.uint8)

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -3,6 +3,7 @@ import pytest
 from astropy.io import fits
 from stcal.jump.jump_class import JumpData
 from stcal.jump.jump import (
+    compute_axes,
     extend_saturation,
     find_ellipses,
     find_faint_extended,
@@ -26,6 +27,22 @@ SAT = DQFLAGS["SATURATED"]
 JUMP = DQFLAGS["JUMP_DET"]
 NGV = DQFLAGS["NO_GAIN_VALUE"]
 REF = DQFLAGS["REFERENCE_PIXEL"]
+
+
+def test_ellipse_compute_axes_max_radius():
+    jd = JumpData()
+    jd.max_extended_radius = 4
+    ellipse = [
+        [0, 0],  # x, y
+        [10, 5],  # h, w
+        0,  # angle
+    ]
+
+    # We are not testing expansion itself, so set to effectively no-op.
+    half_axes = compute_axes(False, ellipse, 0, jd)
+
+    ans = (4, 2)  # (max_extended_radius, round(5 / 2))
+    np.testing.assert_array_equal(half_axes, ans)
 
 
 def create_jump_data(dims, gain, rnoise, tm):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4209](https://jira.stsci.edu/browse/JP-4209)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

This PR addresses https://github.com/spacetelescope/jwst/issues/10090

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`"stcal@git+https://github.com/pllim/stcal@full-and-a-half-width"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/20313673878 (all passed)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/20313700698 (all passed)
