### PR TITLE
removed unused num_int argument

### DIFF
--- a/src/stcal/ramp_fitting/likely_fit.py
+++ b/src/stcal/ramp_fitting/likely_fit.py
@@ -133,7 +133,7 @@ def likely_ramp_fit(ramp_data, readnoise_2d, gain_2d):
             )
             integ_class.get_results(result, integ, row)
 
-        pdq = utils.dq_compress_sect(ramp_data, integ, gdq, pdq)
+        pdq = utils.dq_compress_sect(ramp_data, gdq, pdq)
         integ_class.dq[integ, :, :] = pdq
 
         del gdq

--- a/src/stcal/ramp_fitting/utils.py
+++ b/src/stcal/ramp_fitting/utils.py
@@ -71,7 +71,7 @@ def set_if_total_integ(final_dq, integ_dq, flag, set_flag):
     final_dq[all_set] = np.bitwise_or(final_dq[all_set], set_flag)
 
 
-def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):  # noqa: ARG001
+def dq_compress_sect(ramp_data, gdq_sect, pixeldq_sect):
     """
     Set the integration level flags for DO_NOT_USE, JUMP_DET, and SATURATED.
 
@@ -85,9 +85,6 @@ def dq_compress_sect(ramp_data, num_int, gdq_sect, pixeldq_sect):  # noqa: ARG00
     ----------
     ramp_data : RampData
         Contains the DQ flag information.
-
-    num_int : int
-        The current integration number.
 
     gdq_sect : ndarray
         The current 3-D (ngroups, nrows, ncols) integration DQ array.


### PR DESCRIPTION
Closes https://github.com/spacetelescope/stcal/issues/467

Remove unused `num_int` argument from `dq_compress_sec`. This is not used downstream so marking this as "no changelog".

jwst regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/20621768013
roman regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/20621771474

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
