### PR TITLE
Dependabot: Add cooldown and labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     target-branch: "main"
+    labels:
+      - automation
+      - dependencies
+      - github_actions
+      - no-changelog-entry-needed
     schedule:
       interval: "monthly"
     groups:
@@ -12,6 +17,8 @@ updates:
           - "*"
     reviewers:
       - "zacharyburnett"
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for pip
   - package-ecosystem: "pip"
@@ -25,3 +32,5 @@ updates:
           - "*"
     reviewers:
       - "zacharyburnett"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

GH won't let me edit https://github.com/spacetelescope/stcal/pull/475 due to insufficient access, so here is a separate PR to update Dependabot behavior:

* Add cooldown to harden supply-chain security
* Auto labels for GHA updates

No need for change log nor RT

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
