### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
   "sphinx-rtd-theme",
   "tomli; python_version <=\"3.11\"",
 ]
-test = ["psutil", "pytest >=6", "pytest-cov", "pytest-doctestplus"]
+test = ["psutil", "pytest>=9.0", "pytest-cov", "pytest-doctestplus"]
 
 [project.urls]
 repository = "https://github.com/spacetelescope/stcal"
@@ -62,12 +62,12 @@ zip-safe = true
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.pytest.ini_options]
-minversion = 6
+[tool.pytest]
+minversion = "9.0"
 log_cli_level = "INFO"
 xfail_strict = true
-doctest_plus = true
-doctest_rst = true
+doctest_plus = "enabled"
+doctest_rst = "enabled"
 text_file_format = "rst"
 addopts = [
   "--color=yes",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
