### PR TITLE
DOC: Remove API, reorg index

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,0 @@
-stcal API
-==========
-
-.. automodapi:: stcal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ html_sidebars = {"**": ["globaltoc.html", "relations.html", "searchbox.html"]}
 html_use_index = True
 
 # A list of ignored prefixes for module index sorting.
-modindex_common_prefix = ['stcal.']
+modindex_common_prefix = ["stcal."]
 
 # Enable nitpicky mode - which ensures that all references in the docs resolve.
 nitpicky = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,9 @@ html_domain_indices = True
 html_sidebars = {"**": ["globaltoc.html", "relations.html", "searchbox.html"]}
 html_use_index = True
 
+# A list of ignored prefixes for module index sorting.
+modindex_common_prefix = ['stcal.']
+
 # Enable nitpicky mode - which ensures that all references in the docs resolve.
 nitpicky = True
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,18 +1,22 @@
+=================================
 Welcome to stcal's documentation!
 =================================
 
+Package Documentation
+=====================
+
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
-API
-===
+   stcal/package_index.rst
+
+Change Log
+==========
 
 .. toctree::
    :maxdepth: 1
 
-   api.rst
-
+   stcal/changes.rst
 
 Indices and tables
 ==================
@@ -20,13 +24,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-=====================
-Package Documentation
-=====================
-
-.. toctree::
-   :maxdepth: 1
-
-   stcal/package_index.rst
-   stcal/changes.rst


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
<!-- If this PR closes a GitHub issue, reference it here by its number -->

* Closes #479
* Closes #457 

No need for RT.

Before: https://stcal.readthedocs.io/en/latest/
After: https://stcal--484.org.readthedocs.build/en/484/

<!-- describe the changes comprising this PR here -->

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
