### PR TITLE
Deprecate unused functions

### DIFF
--- a/changes/485.removal.rst
+++ b/changes/485.removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``reproject`` from both ``alignment.util`` and ``outlier_detection.utils``, deprecate ``calc_pixmap`` from ``alignment.util`` and ``calc_gwcs_pixmap`` from ``outlier_detection.utils`` in favor of ``drizzle.utils.calc_pixmap``

--- a/changes/485_removal.rst
+++ b/changes/485_removal.rst
@@ -1,1 +1,0 @@
-Deprecate ``reproject`` from both ``alignment.util`` and ``outlier_detection.utils``, deprecate ``calc_pixmap`` from ``alignment.util`` and ``calc_gwcs_pixmap`` from ``outlier_detection.utils`` in favor of ``drizzle.utils.calc_pixmap``

--- a/changes/485_removal.rst
+++ b/changes/485_removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``reproject`` from both ``alignment.util`` and ``outlier_detection.utils``, deprecate ``calc_pixmap`` from ``alignment.util`` and ``calc_gwcs_pixmap`` from ``outlier_detection.utils`` in favor of ``drizzle.utils.calc_pixmap``

--- a/src/stcal/alignment/resample_utils.py
+++ b/src/stcal/alignment/resample_utils.py
@@ -29,7 +29,11 @@ def calc_pixmap(in_wcs, out_wcs, shape=None):
         Reprojected pixel grid map. `pixmap[xin, yin]` returns `xout,
         yout` indices in the output image.
     """
-    warnings.warn("calc_pixmap is deprecated in favor of drizzle.utils.calc_pixmap", DeprecationWarning)
+    warnings.warn(
+        "calc_pixmap is deprecated in favor of drizzle.utils.calc_pixmap",
+        DeprecationWarning,
+        stacklevel=2
+    )
 
     return calc_pixmap_drizzle(in_wcs, out_wcs, shape=shape)
 

--- a/src/stcal/alignment/resample_utils.py
+++ b/src/stcal/alignment/resample_utils.py
@@ -30,9 +30,7 @@ def calc_pixmap(in_wcs, out_wcs, shape=None):
         yout` indices in the output image.
     """
     warnings.warn(
-        "calc_pixmap is deprecated in favor of drizzle.utils.calc_pixmap",
-        DeprecationWarning,
-        stacklevel=2
+        "calc_pixmap is deprecated in favor of drizzle.utils.calc_pixmap", DeprecationWarning, stacklevel=2
     )
 
     return calc_pixmap_drizzle(in_wcs, out_wcs, shape=shape)

--- a/src/stcal/alignment/resample_utils.py
+++ b/src/stcal/alignment/resample_utils.py
@@ -3,8 +3,9 @@ import logging
 import numpy as np
 import shapely.geometry  # type: ignore[import-untyped]
 from gwcs.wcstools import grid_from_bounding_box
-
+from drizzle.utils import calc_pixmap as calc_pixmap_drizzle
 from stcal.alignment import util
+import warnings
 
 log = logging.getLogger(__name__)
 
@@ -28,19 +29,11 @@ def calc_pixmap(in_wcs, out_wcs, shape=None):
         Reprojected pixel grid map. `pixmap[xin, yin]` returns `xout,
         yout` indices in the output image.
     """
-    if shape:
-        bb = util.wcs_bbox_from_shape(shape)
-        log.debug("Bounding box from data shape: %s", bb)
-    else:
-        bb = util.wcs_bbox_from_shape(in_wcs.pixel_shape)
-        log.debug("Bounding box from WCS: %s", bb)
 
-    # creates 2 grids, one with rows of all x values * len(y) rows,
-    # and the reverse for all y columns
-    grid = grid_from_bounding_box(bb)
-    transform_function = util.reproject(in_wcs, out_wcs)
-    return np.dstack(transform_function(grid[0], grid[1]))
+    warnings.warn("calc_pixmap is deprecated in favor of "
+                  "drizzle.utils.calc_pixmap", DeprecationWarning)
 
+    return calc_pixmap_drizzle(in_wcs, out_wcs, shape=shape)
 
 def combine_sregions(sregion_list, det2world, intersect_footprint=None):
     """

--- a/src/stcal/alignment/resample_utils.py
+++ b/src/stcal/alignment/resample_utils.py
@@ -1,11 +1,11 @@
 import logging
+import warnings
 
 import numpy as np
 import shapely.geometry  # type: ignore[import-untyped]
-from gwcs.wcstools import grid_from_bounding_box
 from drizzle.utils import calc_pixmap as calc_pixmap_drizzle
+
 from stcal.alignment import util
-import warnings
 
 log = logging.getLogger(__name__)
 
@@ -29,11 +29,10 @@ def calc_pixmap(in_wcs, out_wcs, shape=None):
         Reprojected pixel grid map. `pixmap[xin, yin]` returns `xout,
         yout` indices in the output image.
     """
-
-    warnings.warn("calc_pixmap is deprecated in favor of "
-                  "drizzle.utils.calc_pixmap", DeprecationWarning)
+    warnings.warn("calc_pixmap is deprecated in favor of drizzle.utils.calc_pixmap", DeprecationWarning)
 
     return calc_pixmap_drizzle(in_wcs, out_wcs, shape=shape)
+
 
 def combine_sregions(sregion_list, det2world, intersect_footprint=None):
     """

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -661,7 +661,7 @@ def reproject(wcs1: gwcs.wcs.WCS, wcs2: gwcs.wcs.WCS) -> Callable:
         "which has been deprecated in favor of "
         "drizzle.utils.calc_pixmap",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
 
     def _get_forward_transform_func(wcs1):

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -657,6 +657,10 @@ def reproject(wcs1: gwcs.wcs.WCS, wcs2: gwcs.wcs.WCS) -> Callable:
         positions in ``wcs1`` and returns x, y positions in ``wcs2``.
     """
 
+    warnings.warn("reproject is deprecated. It was called by calc_pixmap, "
+                  "which has been deprecated in favor of "
+                  "drizzle.utils.calc_pixmap", DeprecationWarning)
+
     def _get_forward_transform_func(wcs1):
         """
         Get the forward transform function from the input WCS.

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -661,6 +661,7 @@ def reproject(wcs1: gwcs.wcs.WCS, wcs2: gwcs.wcs.WCS) -> Callable:
         "which has been deprecated in favor of "
         "drizzle.utils.calc_pixmap",
         DeprecationWarning,
+        stacklevel=2
     )
 
     def _get_forward_transform_func(wcs1):

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -656,10 +656,12 @@ def reproject(wcs1: gwcs.wcs.WCS, wcs2: gwcs.wcs.WCS) -> Callable:
         Function to compute the transformations.  It takes x, y
         positions in ``wcs1`` and returns x, y positions in ``wcs2``.
     """
-
-    warnings.warn("reproject is deprecated. It was called by calc_pixmap, "
-                  "which has been deprecated in favor of "
-                  "drizzle.utils.calc_pixmap", DeprecationWarning)
+    warnings.warn(
+        "reproject is deprecated. It was called by calc_pixmap, "
+        "which has been deprecated in favor of "
+        "drizzle.utils.calc_pixmap",
+        DeprecationWarning,
+    )
 
     def _get_forward_transform_func(wcs1):
         """

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -296,7 +296,11 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, in_shape):
     pixmap : numpy.ndarray
         Computed pixmap.
     """
-    warnings.warn("calc_gwcs_pixmap is deprecated in favor of drizzle.utils.calc_pixmap", DeprecationWarning)
+    warnings.warn(
+        "calc_gwcs_pixmap is deprecated in favor of drizzle.utils.calc_pixmap",
+        DeprecationWarning,
+        stacklevel=2
+    )
 
     return calc_pixmap(in_wcs, out_wcs, shape=in_shape)
 
@@ -328,6 +332,7 @@ def reproject(wcs1, wcs2):
         "which has been deprecated in favor of "
         "drizzle.utils.calc_pixmap",
         DeprecationWarning,
+        stacklevel=2
     )
 
     try:

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -249,7 +249,7 @@ def gwcs_blot(median_data, median_wcs, blot_shape, blot_wcs, pix_ratio, fillval=
         Datamodel containing header and WCS to define the 'blotted' image
     """
     # Compute the mapping between the input and output pixel coordinates
-    pixmap = calc_gwcs_pixmap(blot_wcs, median_wcs, blot_shape)
+    pixmap = calc_pixmap(blot_wcs, median_wcs, blot_shape)
     log.debug(f"Pixmap shape: {pixmap[:, :, 0].shape}")
     log.debug(f"Sci shape: {blot_shape}")
     log.info(f"Blotting {blot_shape} <-- {median_data.shape}")

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -3,16 +3,12 @@
 import logging
 import warnings
 
-import gwcs
 import numpy as np
-import warnings
 from astropy.stats import sigma_clip
 from drizzle.cdrizzle import tblot
 from drizzle.utils import calc_pixmap
 from scipy import ndimage
 from skimage.util import view_as_windows
-
-from stcal.alignment.util import wcs_bbox_from_shape
 
 log = logging.getLogger(__name__)
 
@@ -300,9 +296,7 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, in_shape):
     pixmap : numpy.ndarray
         Computed pixmap.
     """
-
-    warnings.warn("calc_gwcs_pixmap is deprecated in favor of "
-                             "drizzle.utils.calc_pixmap", DeprecationWarning)
+    warnings.warn("calc_gwcs_pixmap is deprecated in favor of drizzle.utils.calc_pixmap", DeprecationWarning)
 
     return calc_pixmap(in_wcs, out_wcs, shape=in_shape)
 
@@ -329,10 +323,12 @@ def reproject(wcs1, wcs2):
         Function to compute the transformations.  It takes x, y
         positions in ``wcs1`` and returns x, y positions in ``wcs2``.
     """
-
-    warnings.warn("reproject is deprecated. It was called by calc_gwcs_pixmap, "
-                  "which has been deprecated in favor of "
-                  "drizzle.utils.calc_pixmap", DeprecationWarning)
+    warnings.warn(
+        "reproject is deprecated. It was called by calc_gwcs_pixmap, "
+        "which has been deprecated in favor of "
+        "drizzle.utils.calc_pixmap",
+        DeprecationWarning,
+    )
 
     try:
         forward_transform = wcs1.pixel_to_world_values

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -299,7 +299,7 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, in_shape):
     warnings.warn(
         "calc_gwcs_pixmap is deprecated in favor of drizzle.utils.calc_pixmap",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
 
     return calc_pixmap(in_wcs, out_wcs, shape=in_shape)
@@ -332,7 +332,7 @@ def reproject(wcs1, wcs2):
         "which has been deprecated in favor of "
         "drizzle.utils.calc_pixmap",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
 
     try:

--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -5,8 +5,10 @@ import warnings
 
 import gwcs
 import numpy as np
+import warnings
 from astropy.stats import sigma_clip
 from drizzle.cdrizzle import tblot
+from drizzle.utils import calc_pixmap
 from scipy import ndimage
 from skimage.util import view_as_windows
 
@@ -298,11 +300,11 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, in_shape):
     pixmap : numpy.ndarray
         Computed pixmap.
     """
-    bb = wcs_bbox_from_shape(in_shape)
-    log.debug(f"Bounding box from data shape: {bb}")
 
-    grid = gwcs.wcstools.grid_from_bounding_box(bb)
-    return np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
+    warnings.warn("calc_gwcs_pixmap is deprecated in favor of "
+                             "drizzle.utils.calc_pixmap", DeprecationWarning)
+
+    return calc_pixmap(in_wcs, out_wcs, shape=in_shape)
 
 
 def reproject(wcs1, wcs2):
@@ -327,6 +329,11 @@ def reproject(wcs1, wcs2):
         Function to compute the transformations.  It takes x, y
         positions in ``wcs1`` and returns x, y positions in ``wcs2``.
     """
+
+    warnings.warn("reproject is deprecated. It was called by calc_gwcs_pixmap, "
+                  "which has been deprecated in favor of "
+                  "drizzle.utils.calc_pixmap", DeprecationWarning)
+
     try:
         forward_transform = wcs1.pixel_to_world_values
         backward_transform = wcs2.world_to_pixel_values


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4216](https://jira.stsci.edu/browse/JP-4216)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes #347 

<!-- describe the changes comprising this PR here -->

This PR deprecates unused functions in `stcal.alignment` and `stcal.outlier_detection`.  For computing a pixel transformation map, `drizzle.utils.calc_pixmap` is now used, matching the behavior in `stcal.resample`.  Functions `reproject` should now be unused either in `stcal`, `jwst`, or `romancal` and have been deprecated.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
