### PR TITLE
JP-3164: Removing skipped or xfailed tests.

### DIFF
--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -258,7 +258,6 @@ def get_fake_wcs():
     [
         (1000, 2000, np.array(2000), np.array(4000)),  # string input test
         ([1000], [2000], np.array(2000), np.array(4000)),  # array input test
-        pytest.param(1, 2, 3, 4, marks=pytest.mark.xfail),  # expected failure test
     ],
 )
 def test_reproject(x_inp, y_inp, x_expected, y_expected):

--- a/tests/test_jump_twopoint_difference.py
+++ b/tests/test_jump_twopoint_difference.py
@@ -653,43 +653,6 @@ def test_11grps_0cr_3donotuse():
     assert np.array_equal([0, 0, 0, 0, 0, 0, 0, 0], out_gdq[0, 1:-2, 100, 100])
 
 
-@pytest.mark.skip("Copied, but checks nothing and is named wrong")
-def test_5grps_nocr():
-    nints, ngroups, nrows, ncols = 1, 6, 204, 204
-    dims = nints, ngroups, nrows, ncols
-    rnoise = 10
-
-    data, gdq, read_noise = setup_data(dims, rnoise)
-    data[0, 0, 100, 100] = 0
-    data[0, 1, 100, 100] = 10
-    data[0, 2, 100, 100] = 21
-    data[0, 3, 100, 100] = 33
-    data[0, 4, 100, 100] = 46
-
-    twopt_p = default_twopt_p(rej=3, _1drej=3, _3drej=3, nframes=1, _4n=False, mx_flag=200, mn_flag=10)
-
-    out_gdq, row_below_gdq, rows_above_gdq, total_crs = find_crs(data, gdq, read_noise, twopt_p)
-
-
-@pytest.mark.skip("Copied, but checks nothing")
-def test_6grps_nocr():
-    nints, ngroups, nrows, ncols = 1, 6, 204, 204
-    dims = nints, ngroups, nrows, ncols
-    rnoise = 10
-
-    data, gdq, read_noise = setup_data(dims, rnoise)
-    data[0, 0, 100, 100] = 0
-    data[0, 1, 100, 100] = 10
-    data[0, 2, 100, 100] = 21
-    data[0, 3, 100, 100] = 33
-    data[0, 4, 100, 100] = 46
-    data[0, 5, 100, 100] = 60
-
-    twopt_p = default_twopt_p(rej=3, _1drej=3, _3drej=3, nframes=1, _4n=False, mx_flag=200, mn_flag=10)
-
-    out_gdq, row_below_gdq, rows_above_gdq, total_crs = find_crs(data, gdq, read_noise, twopt_p)
-
-
 def test_10grps_cr2_gt3sigma():
     crmag = 16
     nints, ngroups, nrows, ncols = 1, 10, 204, 204
@@ -726,9 +689,8 @@ def test_10grps_cr2_3sigma_nocr():
     assert np.array_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], out_gdq[0, :, 100, 100])
 
 
-@pytest.mark.skip("Fails for some reason")
 def test_10grps_cr2_gt3sigma_2frames():
-    crmag = 16
+    crmag = 32
     nints, ngroups, nrows, ncols = 1, 10, 204, 204
     dims = nints, ngroups, nrows, ncols
     rnoise = 5 * np.sqrt(2)
@@ -745,9 +707,8 @@ def test_10grps_cr2_gt3sigma_2frames():
     assert np.array_equal([0, 4, 0, 0, 0, 0, 0, 0, 0, 0], out_gdq[0, :, 100, 100])
 
 
-@pytest.mark.skip("Fails for some reason")
 def test_10grps_cr2_gt3sigma_2frames_offdiag():
-    crmag = 16
+    crmag = 32
     nints, ngroups, nrows, ncols = 1, 10, 204, 204
     dims = nints, ngroups, nrows, ncols
     rnoise = 5 * np.sqrt(2)

--- a/tests/test_jump_twopoint_difference.py
+++ b/tests/test_jump_twopoint_difference.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from stcal.jump.twopoint_difference import find_crs
 from stcal.jump.twopoint_difference_class import TwoPointParams


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3164](https://jira.stsci.edu/browse/JP-3164)

<!-- describe the changes comprising this PR here -->

This PR addresses skipped or xfailed tests. The tests were either removed or modified to work properly.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
