### PR TITLE
skymatch updates: add tests and docs remove unused code

### DIFF
--- a/changes/504.breaking.rst
+++ b/changes/504.breaking.rst
@@ -1,0 +1,1 @@
+Remove unused reduce_memory_usage SkyImage mode.

--- a/changes/504.skymatch.rst
+++ b/changes/504.skymatch.rst
@@ -1,0 +1,1 @@
+Remove unused reduce_memory_usage SkyImage mode and other unused code.

--- a/docs/stcal/skymatch/description.rst
+++ b/docs/stcal/skymatch/description.rst
@@ -1,4 +1,254 @@
 Description
 ============
 
-This sub-package contains the functions and objects useful for skymatch.
+Overview
+--------
+The `stcal.skymatch` module can be used to compute sky values in a collection of
+input images that contain both sky and source signal. The sky values can be
+computed for each image separately or in a way that matches the sky levels
+amongst the collection of images so as to minimize their differences.
+This operation is typically applied before doing cosmic-ray rejection and
+combining multiple images into a mosaic.
+When running `skymatch.skymatch.skymatch` in a matching mode,
+it compares *total* signal levels in *the overlap regions* of a set of input
+images and computes the signal offsets either for each image *or a set/group of
+images* (see Image Groups section below) that will
+minimize -- in a least squares sense -- the residuals across
+the entire set. This comparison is performed directly on the input images
+without resampling them onto a common grid. The overlap regions are computed
+directly on the sky (celestial sphere) for each pair of input images.
+Matching based on total signal level is especially useful for images that
+are dominated by large, diffuse sources, where it is
+difficult -- if not impossible -- to find and measure true sky.
+
+Note that the meaning of "sky background" depends on the chosen sky computation
+method. When the matching method is used, for example, the reported "sky" value
+is only the offset in levels between images and does not necessarily include
+the true total sky level.
+
+.. note::
+   Throughout this document the term "sky" is used in a generic sense,
+   referring to any kind of non-source background signal, which may include
+   actual sky, as well as instrumental (e.g. thermal) background, etc.
+
+Sky background
+--------------
+Some components (e.g., in-field zodiacal light)
+result in reproducible background structures in all detectors when they are
+exposed simultaneously, while other components (e.g. stray light, thermal
+emission) can produce varying background from one exposure to the next
+exposure. The type of background structure that dominates a particular dataset
+affects the optimal way to group images for skymatch.
+
+Image Groups
+------------
+When computing and matching sky background on a set of input images, a *single
+sky level* (or offset, depending on selected ``skymethod``) can be computed
+either for each input image or for groups of two or more input images.
+
+When background is dominated by zodiacal light, images taken at the same time
+can be sky matched together; that is, a single background
+level can be computed and applied to all these images because we can assume
+that for the next exposure we will get a similar background structure, albeit
+with an offset level (common to all images in an exposure). Using grouped
+images with a common background level offers several advantages:
+more data are used to compute the single sky level, and the
+background level of images that do not overlap individually
+with any other images in other exposures can still be adjusted (as long as they
+belong to a group).
+
+Algorithms
+----------
+The `stcal.skymatch.skymatch` module provides several methods for constant sky background
+value computations.
+
+The first method, called "local", essentially is an enhanced version of the
+original sky subtraction method used in older versions of
+`AstroDrizzle <https://drizzlepac.readthedocs.io/en/latest/drizzlepac_api/astrodrizzle.html>`_.
+This method simply computes the mean/median/mode/etc. value of the sky
+separately in each input image. This method was upgraded to be able to use masks
+to remove bad pixels from being used in the computations of sky
+statistics.
+
+In addition to the classic "local" method, two other methods have been
+introduced: "global" and "match", as well as a combination of the
+two -- "global+match".
+
+#. The "global" method essentially uses the "local" method to first compute a
+   sky value for each image separately, and then assigns the minimum of those
+   results to all images in the collection. Hence after subtraction of the
+   sky values only one image will have a net sky of zero, while the remaining
+   images will have some small positive residual.
+
+#. The "match" algorithm computes only a correction value for each image, such
+   that, when applied to each image, the mismatch between *all* pairs of images
+   is minimized, in the least-squares sense. For each pair of images, the sky
+   mismatch is computed *only* in the regions in which the two images overlap
+   on the sky.
+
+   This makes the "match" algorithm particularly useful
+   for equalizing sky values in large mosaics in which one may have
+   only pair-wise intersection of adjacent images without having
+   a common intersection region (on the sky) in all images.
+
+   Note that if the argument "match_down=True", matching will be done to the
+   image with the lowest sky value, and if "match_down=False" it will be done
+   to the image with the highest value
+   (see `stcal.skymatch.skymatch` for full details).
+
+#. The "global+match" algorithm combines the "global" and "match" methods.
+   It uses the "global" algorithm to find a baseline sky value common to all
+   input images and the "match" algorithm to equalize sky values among images.
+   The direction of matching (to the lowest or highest) is again controlled by
+   the "match_down" argument.
+
+In the "local" and "global" methods, which find sky levels in each image,
+the calculation of the image statistics takes advantage of sigma clipping
+to remove contributions from isolated sources. This can work well for
+accurately determining the true sky level in images that contain semi-large
+regions of empty sky. The "match" algorithm, on the other hand, compares the
+*total* signal levels integrated over regions of overlap in each image pair.
+This method can produce better results when there are no large empty regions
+of sky in the images. This method cannot measure the true sky level, but
+instead provides additive corrections that can be used to equalize the signal
+between overlapping images.
+
+Examples
+--------
+To get a better idea of the behavior of these different methods, the tables
+below show the results for two hypothetical sets of images. The first example
+is for a set of 6 images that form a 2x3 mosaic, with every image having
+overlap with its immediate neighbors. The first column of the table gives the
+actual (fake) sky signal that was imposed in each image, and the subsequent
+columns show the results computed by each method.
+All results are for the case where the argument ``match_down = True``,
+which means matching is done to the image with the lowest sky value.
+Note that these examples are for the highly simplistic case where each example
+image contains nothing but the constant sky value. Hence the sky computations
+are not affected at all by any source content and are therefore able to
+determine the sky values exactly in each image. Results for real images will
+of course not be so exact.
+
++-------+-------+--------+-------+--------------+
+| Sky   | Local | Global | Match | Global+Match |
++=======+=======+========+=======+==============+
+| 100   |  100  |  100   |    0  |        100   |
++-------+-------+--------+-------+--------------+
+| 120   |  120  |  100   |   20  |        120   |
++-------+-------+--------+-------+--------------+
+| 105   |  105  |  100   |    5  |        105   |
++-------+-------+--------+-------+--------------+
+| 110   |  110  |  100   |   10  |        110   |
++-------+-------+--------+-------+--------------+
+| 105   |  105  |  100   |    5  |        105   |
++-------+-------+--------+-------+--------------+
+| 115   |  115  |  100   |   15  |        115   |
++-------+-------+--------+-------+--------------+
+
+local
+  finds the sky level of each image independently of the rest.
+global
+  uses the minimum sky level found by "local" and applies it to all images.
+match
+  with "match_down=True" finds the offset needed to match all images
+  to the level of the image with the lowest sky level.
+global+match
+  with "match_down=True" finds the offsets and global value
+  needed to set all images to a sky level of zero. In this trivial example,
+  the results are identical to the "local" method.
+
+The second example is for a set of 7 images, where the first 4 form a 2x2
+mosaic, with overlaps, and the second set of 3 images forms another mosaic,
+with internal overlap, but the 2 mosaics do *NOT* overlap one another.
+
++-------+-------+--------+-------+--------------+
+| Sky   | Local | Global | Match | Global+Match |
++=======+=======+========+=======+==============+
+| 100   |  100  |   90   |     0 |    86.25     |
++-------+-------+--------+-------+--------------+
+| 120   |  120  |   90   |    20 |   106.25     |
++-------+-------+--------+-------+--------------+
+| 105   |  105  |   90   |     5 |    91.25     |
++-------+-------+--------+-------+--------------+
+| 110   |  110  |   90   |    10 |    96.25     |
++-------+-------+--------+-------+--------------+
+|  95   |   95  |   90   |  8.75 |     95       |
++-------+-------+--------+-------+--------------+
+|  90   |   90  |   90   |  3.75 |     90       |
++-------+-------+--------+-------+--------------+
+| 100   |  100  |   90   | 13.75 |    100       |
++-------+-------+--------+-------+--------------+
+
+In this case, the "local" method again computes the sky in each image
+independently of the rest, and the "global" method sets the result for
+each image to the minimum value returned by "local". The matching results,
+however, require some explanation. With "match" only, all of the results
+give the proper offsets required to equalize the images contained within
+each mosaic, but the algorithm does not have the information needed to
+match the two (non-overlapping) mosaics to one another. Similarly, the
+"global+match" results again provide proper matching within each mosaic,
+but will leave an overall residual in one of the mosaics.
+
+Limitations and Discussions
+---------------------------
+As stated above, the best sky computation method depends on the nature
+of the data in the input images. If the input images contain mostly
+compact, isolated sources, the "local" and "global" algorithms can do a
+good job at finding the true sky level in each image. If the images contain
+large, diffuse sources, the "match" algorithm is more appropriate, assuming
+of course there is sufficient overlap between images from which to compute
+the matching values. In the event there is not overlap between all of the
+images, as illustrated in the second example above, the "match" method can
+still provide useful results for matching the levels within each
+non-contigous region covered by the images, but will not provide a good
+overall sky level across all of the images. In these situations it is more
+appropriate to either process the non-contiguous groups independently of
+one another or use the "local" or "global" methods to compute the sky
+separately in each image. The latter option will of course only work well
+if the images are not domimated by extended, diffuse sources.
+
+The primary reason for introducing the ``skymatch`` algorithm was to try to
+equalize the sky in large mosaics in which computation of the
+absolute sky is difficult, due to the presence of large diffuse
+sources in the image. As discussed above, the ``skymatch`` code
+accomplishes this by comparing the sky values in the
+overlap regions of each image pair. The quality of sky matching will
+obviously depend on how well these sky values can be estimated.
+True background may not be present at all in some images, in which case
+the computed "sky" may be the surface brightness of a large galaxy, nebula,
+etc.
+
+Here is a brief list of possible limitations and factors that can affect
+the outcome of the matching (sky subtraction in general) algorithm:
+
+#. Because sky computation is performed on *flat-fielded* but
+   *not distortion corrected* images, it is important to keep in mind
+   that flat-fielding is performed to obtain correct surface brightnesses.
+   Because the surface brightness of a pixel containing a point-like source
+   will change inversely with a change to the pixel area, it is advisable to
+   mask point-like sources through user-supplied mask files. Values
+   different from zero in user-supplied masks indicate good data pixels.
+   Alternatively, one can use the ``upper`` parameter to exclude the use of
+   pixels containing bright objects when performing the sky computations.
+
+#. The input images may contain cosmic rays. This
+   algorithm does not perform CR cleaning. A possible way of minimizing
+   the effect of the cosmic rays on sky computations is to use
+   clipping (\ ``nclip`` > 0) and/or set the ``upper`` parameter to a value
+   larger than most of the sky background (or extended sources) but
+   lower than the values of most CR-affected pixels.
+
+#. In general, clipping is a good way of eliminating bad pixels:
+   pixels affected by CR, hot/dead pixels, etc. However, for
+   images with complicated backgrounds (extended galaxies, nebulae,
+   etc.), affected by CR and noise, the clipping process may mask different
+   pixels in different images. If variations in the background are
+   too strong, clipping may converge to different sky values in
+   different images even when factoring in the true difference
+   in the sky background between the two images.
+
+#. In general images can have different true background values
+   (we could measure it if images were not affected by large diffuse
+   sources). However, arguments such as ``lower`` and ``upper`` will
+   apply to all images regardless of the intrinsic differences
+   in sky levels.

--- a/docs/stcal/skymatch/description.rst
+++ b/docs/stcal/skymatch/description.rst
@@ -24,7 +24,7 @@ difficult -- if not impossible -- to find and measure true sky.
 Note that the meaning of "sky background" depends on the chosen sky computation
 method. When the matching method is used, for example, the reported "sky" value
 is only the offset in levels between images and does not necessarily include
-the true total sky level.
+the true sky level.
 
 .. note::
    Throughout this document the term "sky" is used in a generic sense,
@@ -105,8 +105,7 @@ two -- "global+match".
 In the "local" and "global" methods, which find sky levels in each image,
 the calculation of the image statistics takes advantage of sigma clipping
 to remove contributions from isolated sources. This can work well for
-accurately determining the true sky level in images that contain semi-large
-regions of empty sky. The "match" algorithm, on the other hand, compares the
+accurately determining the true sky level in images dominated by pure background such as sparse star fields with few extended sources that do not dominate the scene. The "local" method would likely struggle in scenes dominated by extended non-uniform sources such as nebulae, large/extended galaxies, etc. The "match" algorithm, on the other hand, compares the
 *total* signal levels integrated over regions of overlap in each image pair.
 This method can produce better results when there are no large empty regions
 of sky in the images. This method cannot measure the true sky level, but

--- a/docs/stcal/skymatch/index.rst
+++ b/docs/stcal/skymatch/index.rst
@@ -1,11 +1,11 @@
-.. _skymatch:
+.. _skymatch_module:
 
-=======================
+========
 Skymatch
-=======================
+========
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    description.rst
 

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -114,7 +114,6 @@ class SkyImage:
 
         # initial sky value:
         self.sky = 0.0
-        self.sky_is_valid = False
 
         # create spherical polygon bounding the image
         self.calc_bounding_polygon(stepsize)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -363,28 +363,6 @@ class SkyImage:
 
         return skyval, npix, polyarea
 
-    def copy(self):
-        """Return a shallow copy of the `SkyImage` object."""
-        si = SkyImage(
-            image=None,
-            wcs_fwd=self.wcs_fwd,
-            wcs_inv=self.wcs_inv,
-            pix_area=self.pix_area,
-            convf=self.convf,
-            mask=None,
-            sky_id=self.sky_id,
-            stepsize=None,
-            meta=self.meta,
-        )
-
-        si.image = self.image
-        si.mask = self.mask
-
-        si._polygon = self._polygon
-        si._poly_area = self._poly_area
-        si.sky = self.sky
-        return si
-
 
 class SkyGroup:
     """

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -326,27 +326,11 @@ class SkyGroup:
 
     """
 
-    def __init__(self, images, sky_id=None, sky=0.0):
-        if isinstance(images, SkyImage):
-            self._images = [images]
-
-        elif hasattr(images, "__iter__"):
-            self._images = []
-            for im in images:
-                if not isinstance(im, SkyImage):
-                    raise TypeError("Each element of the 'images' parameter must be an 'SkyImage' object.")
-                self._images.append(im)
-
-        else:
-            raise TypeError(
-                "Parameter 'images' must be either a single 'SkyImage' object or a list of 'SkyImage' objects"
-            )
-
-        self.sky_id = sky_id
+    def __init__(self, images, sky_id=None):
+        self._images = images
         self._update_bounding_polygon()
-        self._sky = sky
-        for im in self._images:
-            im.sky += sky
+        self.sky_id = sky_id
+        self._sky = 0.0
 
     @property
     def sky(self):

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -81,10 +81,10 @@ def _calc_bounding_polygon(image, wcs_fwd, stepsize=None):
     bordery[-1] = bordery[0]
 
     ra, dec = wcs_fwd(borderx, bordery, with_bounding_box=False)
-    # TODO: for strange reasons, occasionally ra[0] != ra[-1] and/or
-    #       dec[0] != dec[-1] (even though we close the polygon in the
-    #       previous two lines). Then SphericalPolygon fails because
-    #       points are not closed. Therefore we force it to be closed:
+    # for strange reasons, occasionally ra[0] != ra[-1] and/or
+    # dec[0] != dec[-1] (even though we close the polygon in the
+    # previous two lines). Then SphericalPolygon fails because
+    # points are not closed. Therefore we force it to be closed:
     ra[-1] = ra[0]
     dec[-1] = dec[0]
 

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -114,6 +114,7 @@ class SkyImage:
 
         # initial sky value:
         self.sky = 0.0
+        self.is_sky_valid = False
 
         # create spherical polygon bounding the image
         self.calc_bounding_polygon(stepsize)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -38,7 +38,6 @@ class SkyImage:
         wcs_inv,
         skystat,
         pix_area=1.0,
-        convf=1.0,
         sky_id=None,
         stepsize=None,
         meta=None,
@@ -72,16 +71,6 @@ class SkyImage:
         pix_area : float, optional
             Average pixel's sky area.
 
-        convf : float, optional
-            Conversion factor that when multiplied to `image` data converts
-            the data to "uniform" (across multiple images) surface
-            brightness units.
-
-            .. note::
-
-              The functionality to support this conversion is not yet
-              implemented and at this moment `convf` is ignored.
-
         sky_id : typing.Any
             The value of this parameter is simple stored within the `SkyImage`
             object. While it can be of any type, it is preferable that `id` be
@@ -103,7 +92,6 @@ class SkyImage:
         self.image = image
         self.mask = mask = np.asanyarray(mask, dtype=bool)
 
-        self.convf = convf
         self.meta = meta
         self.sky_id = sky_id
         self.pix_area = pix_area

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -319,7 +319,7 @@ class SkyGroup:
 
     def __init__(self, images, sky_id=None):
         self._images = images
-        self._update_bounding_polygon()
+        self._polygon = SphericalPolygon.multi_union([im._polygon for im in self._images])  # noqa: SLF001
         self.sky_id = sky_id
         self._sky = 0.0
 
@@ -334,13 +334,6 @@ class SkyGroup:
         self._sky = sky
         for im in self._images:
             im.sky += delta_sky
-
-    def _update_bounding_polygon(self):
-        polygons = [im._polygon for im in self._images]  # noqa: SLF001
-        if len(polygons) == 0:
-            self._polygon = SphericalPolygon([])
-        else:
-            self._polygon = SphericalPolygon.multi_union(polygons)
 
     def __len__(self):
         return len(self._images)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -250,13 +250,8 @@ class SkyImage:
             sky statistics.
         """
         if overlap is None:
-            if self.mask is None:
-                data = self.image
-            else:
-                data = self.image[self.mask]
-
+            data = self.image[self.mask]
             polyarea = self._poly_area
-
         else:
             fill_mask = np.zeros(self.image.shape, dtype=bool)
 
@@ -290,9 +285,7 @@ class SkyImage:
                 polygon = region.Polygon(True, poly_vert)
                 fill_mask = polygon.scan(fill_mask)
 
-            if self.mask is not None:
-                fill_mask &= self.mask
-
+            fill_mask &= self.mask
             data = self.image[fill_mask]
 
             if data.size < 1:
@@ -388,9 +381,6 @@ class SkyGroup:
             sky statistics.
 
         """
-        if len(self._images) == 0:
-            return None, 0, 0.0
-
         wght = 0
         area = 0.0
 

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -205,12 +205,20 @@ class SkyImage:
             the intersection of this `SkyImage` and `skyimage`.
 
         """
-        # FIXME unused outside of this class
         other = skyimage._polygon  # noqa: SLF001
 
         pts1 = np.sort(list(self._polygon.points)[0], axis=0)
         pts2 = np.sort(list(other.points)[0], axis=0)
-        if np.allclose(pts1, pts2, rtol=0, atol=1e-8):
+
+        # replicates old behavior where a different tolerance
+        # is used when self is a SkyGroup. This means that if
+        # use have a SkyGroup "g" and SkyImage "i" the results of
+        # i.intersection(g) differs from g.intersection(i)
+        if isinstance(self, SkyGroup):
+            atol = 5e-9
+        else:
+            atol = 1e-8
+        if np.allclose(pts1, pts2, rtol=0, atol=atol):
             intersect_poly = self._polygon.copy()
         else:
             intersect_poly = self._polygon.intersection(other)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -213,11 +213,7 @@ class SkyImage:
         # is used when self is a SkyGroup. This means that if
         # use have a SkyGroup "g" and SkyImage "i" the results of
         # i.intersection(g) differs from g.intersection(i)
-        if isinstance(self, SkyGroup):
-            atol = 5e-9
-        else:
-            atol = 1e-8
-        if np.allclose(pts1, pts2, rtol=0, atol=atol):
+        if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
             intersect_poly = self._polygon.copy()
         else:
             intersect_poly = self._polygon.intersection(other)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -106,16 +106,6 @@ class SkyImage:
         # the number of pixels used after clipping)
         self.skystat = skystat
 
-    @property
-    def poly_area(self):
-        """Get bounding polygon area in srad units."""
-        return self._poly_area
-
-    @property
-    def polygon(self):
-        """Get image's bounding polygon."""
-        return self._polygon
-
     def intersection(self, skyimage):
         """
         Compute intersection of this `SkyImage`.
@@ -137,6 +127,7 @@ class SkyImage:
             the intersection of this `SkyImage` and `skyimage`.
 
         """
+        # FIXME unused outside of this class
         if isinstance(skyimage, (SkyImage, SkyGroup)):
             other = skyimage.polygon
         else:
@@ -256,7 +247,7 @@ class SkyImage:
             else:
                 data = self.image[self.mask]
 
-            polyarea = self.poly_area
+            polyarea = self._poly_area
 
         else:
             fill_mask = np.zeros(self.image.shape, dtype=bool)
@@ -347,6 +338,7 @@ class SkyGroup:
     @property
     def polygon(self):
         """Get image's bounding polygon."""
+        # FIXME unused outside of this class
         return self._polygon
 
     def intersection(self, skyimage):
@@ -370,6 +362,7 @@ class SkyGroup:
             the intersection of this `SkyImage` and `skyimage`.
 
         """
+        # FIXME unused outside of this class
         if isinstance(skyimage, (SkyImage, SkyGroup)):
             other = skyimage.polygon
         else:
@@ -384,7 +377,7 @@ class SkyGroup:
         return intersect_poly
 
     def _update_bounding_polygon(self):
-        polygons = [im.polygon for im in self._images]
+        polygons = [im._polygon for im in self._images]  # noqa: SLF001
         if len(polygons) == 0:
             self._polygon = SphericalPolygon([])
         else:

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -240,14 +240,12 @@ class SkyImage:
 
         Parameters
         ----------
-        overlap : SkyImage, SkyGroup, `SphericalPolygon`, list[tuple[typing.Any]], None, optional
-            Another `SkyImage`, `SkyGroup`,
-            :py:class:`spherical_geometry.polygon.SphericalPolygon`, or
-            a list of tuples of (RA, DEC) of vertices of a spherical
-            polygon. This parameter is used to indicate that sky statistics
+        overlap : SkyImage, SkyGroup, None, optional
+            This parameter is used to indicate that sky statistics
             should computed only in the region of intersection of *this*
-            image with the polygon indicated by `overlap`. When `overlap` is
-            `None`, sky statistics will be computed over the entire image.
+            image with the `SkyImage` or `SkyGroup` indicated by `overlap`.
+            When `overlap` is `None`, sky statistics will be computed over
+            the entire image.
 
         delta : bool, optional
             Should this function return absolute sky value or the difference
@@ -304,28 +302,6 @@ class SkyImage:
                         continue
                     polyarea += polyarea1
                     radec += list(intersection.to_radec())
-
-            elif isinstance(overlap, SphericalPolygon):
-                radec = []
-                polyarea = 0.0
-                for p in overlap._polygons:  # noqa: SLF001
-                    intersection = self.intersection(SphericalPolygon([p]))
-                    polyarea1 = np.fabs(intersection.area())
-                    if polyarea1 == 0.0:
-                        continue
-                    polyarea += polyarea1
-                    radec += list(intersection.to_radec())
-
-            else:  # assume a list of (ra, dec) tuples:
-                radec = []
-                polyarea = 0.0
-                for r, d in overlap:
-                    poly = SphericalPolygon.from_radec(r, d)
-                    polyarea1 = np.fabs(poly.area())
-                    if polyarea1 == 0.0 or len(r) < 4:
-                        continue
-                    polyarea += polyarea1
-                    radec.append(self.intersection(poly).to_radec())
 
             if polyarea == 0.0:
                 return None, 0, 0.0
@@ -501,14 +477,12 @@ class SkyGroup:
 
         Parameters
         ----------
-        overlap : SkyImage, SkyGroup, `SphericalPolygon`, list[tuple[typing.Any]], None, optional
-            Another `SkyImage`, `SkyGroup`,
-            :py:class:`spherical_geometry.polygon.SphericalPolygon`, or
-            a list of tuples of (RA, DEC) of vertices of a spherical
-            polygon. This parameter is used to indicate that sky statistics
+        overlap : SkyImage, SkyGroup, None, optional
+            This parameter is used to indicate that sky statistics
             should computed only in the region of intersection of *this*
-            image with the polygon indicated by `overlap`. When `overlap` is
-            `None`, sky statistics will be computed over the entire image.
+            image with the `SkyImage` or `SkyGroup` indicated by `overlap`.
+            When `overlap` is `None`, sky statistics will be computed over the
+            entire image.
 
         delta : bool, optional
             Should this function return absolute sky value or the difference

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -33,12 +33,12 @@ class SkyImage:
     def __init__(
         self,
         image,
+        mask,
         wcs_fwd,
         wcs_inv,
         skystat,
         pix_area=1.0,
         convf=1.0,
-        mask=None,
         sky_id=None,
         stepsize=None,
         meta=None,
@@ -49,6 +49,12 @@ class SkyImage:
         ----------
         image : numpy.ndarray
             A 2D array of image data.
+
+        mask : numpy.ndarray
+            A 2D array that indicates
+            which pixels in the input `image` should be used for sky
+            computations (``1``) and which pixels should **not** be used
+            for sky computations (``0``).
 
         wcs_fwd : collections.abc.Callable
             "forward" pixel-to-world transformation function.
@@ -75,12 +81,6 @@ class SkyImage:
 
               The functionality to support this conversion is not yet
               implemented and at this moment `convf` is ignored.
-
-        mask : numpy.ndarray
-            A 2D array that indicates
-            which pixels in the input `image` should be used for sky
-            computations (``1``) and which pixels should **not** be used
-            for sky computations (``0``).
 
         sky_id : typing.Any
             The value of this parameter is simple stored within the `SkyImage`

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -37,7 +37,6 @@ class SkyImage:
         wcs_fwd,
         wcs_inv,
         skystat,
-        pix_area=1.0,
         sky_id=None,
         stepsize=None,
         meta=None,
@@ -68,9 +67,6 @@ class SkyImage:
             median, etc.) and number of pixels/values from the input image
             used in computing that statistics.
 
-        pix_area : float, optional
-            Average pixel's sky area.
-
         sky_id : typing.Any
             The value of this parameter is simple stored within the `SkyImage`
             object. While it can be of any type, it is preferable that `id` be
@@ -94,7 +90,6 @@ class SkyImage:
 
         self.meta = meta
         self.sky_id = sky_id
-        self.pix_area = pix_area
 
         # WCS
         self.wcs_fwd = wcs_fwd
@@ -522,9 +517,8 @@ class SkyGroup:
             area += area1
 
             if sky is not None and npix > 0:
-                pix_area = npix * image.pix_area
-                wsky += sky * pix_area
-                wght += pix_area
+                wsky += sky * npix
+                wght += npix
 
         if wght == 0.0 or area == 0.0:
             return None, wght, area

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -108,7 +108,7 @@ class SkyImage:
 
     def intersection(self, skyimage):
         """
-        Compute intersection of this `SkyImage`.
+        Compute intersection.
 
         Compute intersection of this `SkyImage` object and another
         `SkyImage`, `SkyGroup`, or
@@ -135,7 +135,7 @@ class SkyImage:
 
         pts1 = np.sort(list(self._polygon.points)[0], axis=0)
         pts2 = np.sort(list(other.points)[0], axis=0)
-        if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
+        if np.allclose(pts1, pts2, rtol=0, atol=1e-8):
             intersect_poly = self._polygon.copy()
         else:
             intersect_poly = self._polygon.intersection(other)
@@ -334,41 +334,6 @@ class SkyGroup:
         self._sky = sky
         for im in self._images:
             im.sky += delta_sky
-
-    def intersection(self, skyimage):
-        """
-        Compute intersection.
-
-        Compute intersection of this `SkyImage` object and another
-        `SkyImage`, `SkyGroup`, or
-        :py:class:`~spherical_geometry.polygon.SphericalPolygon`
-        object.
-
-        Parameters
-        ----------
-        skyimage : SkyImage, SkyGroup, `SphericalPolygon`
-            Another object that should be intersected with this `SkyImage`.
-
-        Returns
-        -------
-        intersect_poly : `SphericalPolygon`
-            A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
-            the intersection of this `SkyImage` and `skyimage`.
-
-        """
-        # FIXME unused outside of this class
-        if isinstance(skyimage, (SkyImage, SkyGroup)):
-            other = skyimage._polygon  # noqa: SLF001
-        else:
-            other = skyimage
-
-        pts1 = np.sort(list(self._polygon.points)[0], axis=0)
-        pts2 = np.sort(list(other.points)[0], axis=0)
-        if np.allclose(pts1, pts2, rtol=0, atol=1e-8):
-            intersect_poly = self._polygon.copy()
-        else:
-            intersect_poly = self._polygon.intersection(other)
-        return intersect_poly
 
     def _update_bounding_polygon(self):
         polygons = [im._polygon for im in self._images]  # noqa: SLF001

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -129,7 +129,7 @@ class SkyImage:
         """
         # FIXME unused outside of this class
         if isinstance(skyimage, (SkyImage, SkyGroup)):
-            other = skyimage.polygon
+            other = skyimage._polygon  # noqa: SLF001
         else:
             other = skyimage
 
@@ -335,12 +335,6 @@ class SkyGroup:
         for im in self._images:
             im.sky += delta_sky
 
-    @property
-    def polygon(self):
-        """Get image's bounding polygon."""
-        # FIXME unused outside of this class
-        return self._polygon
-
     def intersection(self, skyimage):
         """
         Compute intersection.
@@ -364,7 +358,7 @@ class SkyGroup:
         """
         # FIXME unused outside of this class
         if isinstance(skyimage, (SkyImage, SkyGroup)):
-            other = skyimage.polygon
+            other = skyimage._polygon  # noqa: SLF001
         else:
             other = skyimage
 

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -348,38 +348,8 @@ class SkyGroup:
     def __getitem__(self, idx):
         return self._images[idx]
 
-    def __setitem__(self, idx, value):
-        if not isinstance(value, SkyImage):
-            raise TypeError("Item must be of 'SkyImage' type")
-        value.sky += self.sky
-        self._images[idx] = value
-        self._update_bounding_polygon()
-
-    def __delitem__(self, idx):
-        del self._images[idx]
-        if len(self._images) == 0:
-            self._sky = 0.0
-            self.sky_id = None
-        self._update_bounding_polygon()
-
     def __iter__(self):
         yield from self._images
-
-    def insert(self, idx, value):
-        """Insert a `SkyImage` into the group."""
-        if not isinstance(value, SkyImage):
-            raise TypeError("Item must be of 'SkyImage' type")
-        value.sky += self.sky
-        self._images.insert(idx, value)
-        self._update_bounding_polygon()
-
-    def append(self, value):
-        """Append a `SkyImage` to the group."""
-        if not isinstance(value, SkyImage):
-            raise TypeError("Item must be of 'SkyImage' type")
-        value.sky += self.sky
-        self._images.append(value)
-        self._update_bounding_polygon()
 
     def calc_sky(self, overlap=None, delta=True):
         """

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -111,13 +111,11 @@ class SkyImage:
         Compute intersection.
 
         Compute intersection of this `SkyImage` object and another
-        `SkyImage`, `SkyGroup`, or
-        :py:class:`~spherical_geometry.polygon.SphericalPolygon`
-        object.
+        `SkyImage` or `SkyGroup` object.
 
         Parameters
         ----------
-        skyimage : SkyImage, SkyGroup, spherical_geometry.polygon.SphericalPolygon
+        skyimage : SkyImage, SkyGroup
             Another object that should be intersected with this `SkyImage`.
 
         Returns
@@ -128,10 +126,7 @@ class SkyImage:
 
         """
         # FIXME unused outside of this class
-        if isinstance(skyimage, (SkyImage, SkyGroup)):
-            other = skyimage._polygon  # noqa: SLF001
-        else:
-            other = skyimage
+        other = skyimage._polygon  # noqa: SLF001
 
         pts1 = np.sort(list(self._polygon.points)[0], axis=0)
         pts2 = np.sort(list(other.points)[0], axis=0)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -164,7 +164,7 @@ class SkyImage:
             raise ValueError("'mask' must have the same shape as 'image'.")
 
         self.image = image
-        self.mask = mask = np.asanyarray(mask, dtype=bool)
+        self.mask = mask
 
         self.meta = meta
         self.sky_id = sky_id

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -118,7 +118,6 @@ class SkyImage:
         sky_id=None,
         stepsize=None,
         meta=None,
-        **kwargs,  # work-around downstream code # noqa: ARG002
     ):
         """Initialize the SkyImage object.
 

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -325,6 +325,8 @@ class SkyGroup:
     """
 
     def __init__(self, images, sky_id=None):
+        if not images:
+            raise ValueError("SkyGroup requires a list of images")
         self._images = images
         self._polygon = SphericalPolygon.multi_union([im._polygon for im in self._images])  # noqa: SLF001
         self.sky_id = sky_id

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -266,15 +266,6 @@ class SkyImage:
         polyarea : float
             Area (in srad) of the polygon that bounds data used to compute
             sky statistics.
-
-        Notes
-        -----
-        Due to a bug in the sphere package, see
-        https://github.com/spacetelescope/sphere/issues/74
-        intersections with polygons formed as union does not work.
-        For this reason I re-implement 'calc_sky' below with a workaround for
-        the bug. The original implementation should be used when the bug is
-        fixed.
         """
         if overlap is None:
             if self.mask is None:

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -129,16 +129,6 @@ class SkyImage:
         return self._poly_area
 
     @property
-    def radec(self):
-        """
-        Get RA and DEC of the bounding polygon.
-
-        Get RA and DEC of the vertices of the bounding polygon as a
-        `~numpy.ndarray` of shape (N, 2) where N is the number of vertices + 1.
-        """
-        return self._radec
-
-    @property
     def polygon(self):
         """Get image's bounding polygon."""
         return self._polygon
@@ -241,7 +231,6 @@ class SkyImage:
         ra[-1] = ra[0]
         dec[-1] = dec[0]
 
-        self._radec = [(ra, dec)]
         self._polygon = SphericalPolygon.from_radec(ra, dec)
         self._poly_area = np.fabs(self._polygon.area())
 
@@ -391,7 +380,6 @@ class SkyImage:
         si.image = self.image
         si.mask = self.mask
 
-        si._radec = self._radec
         si._polygon = self._polygon
         si._poly_area = self._poly_area
         si.sky = self.sky
@@ -445,17 +433,6 @@ class SkyGroup:
             im.sky += delta_sky
 
     @property
-    def radec(self):
-        """
-        RA and DEC of the bounding polygon.
-
-        Get RA and DEC of the vertices of the bounding polygon as a
-        `~numpy.ndarray` of shape (N, 2) where N is the number of vertices + 1.
-
-        """
-        return self._radec
-
-    @property
     def polygon(self):
         """Get image's bounding polygon."""
         return self._polygon
@@ -498,10 +475,8 @@ class SkyGroup:
         polygons = [im.polygon for im in self._images]
         if len(polygons) == 0:
             self._polygon = SphericalPolygon([])
-            self._radec = []
         else:
             self._polygon = SphericalPolygon.multi_union(polygons)
-            self._radec = list(self._polygon.to_radec())
 
     def __len__(self):
         return len(self._images)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -170,8 +170,8 @@ class SkyImage:
         self.sky_id = sky_id
 
         # WCS
-        self.wcs_fwd = wcs_fwd
-        self.wcs_inv = wcs_inv
+        self._wcs_fwd = wcs_fwd
+        self._wcs_inv = wcs_inv
 
         # initial sky value:
         self.sky = 0.0
@@ -283,7 +283,7 @@ class SkyImage:
                     continue
 
                 # set pixels in 'fill_mask' that are inside a polygon to True:
-                x, y = self.wcs_inv(ra, dec, with_bounding_box=False)
+                x, y = self._wcs_inv(ra, dec, with_bounding_box=False)
                 poly_vert = list(zip(x, y, strict=True))
 
                 polygon = region.Polygon(True, poly_vert)

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -209,10 +209,9 @@ class SkyImage:
         pts1 = np.sort(list(self._polygon.points)[0], axis=0)
         pts2 = np.sort(list(other.points)[0], axis=0)
 
-        # replicates old behavior where a different tolerance
-        # is used when self is a SkyGroup. This means that if
-        # use have a SkyGroup "g" and SkyImage "i" the results of
-        # i.intersection(g) differs from g.intersection(i)
+        # work-around spherical geometry raising an exception
+        # for some polygons that are nearly identical:
+        # https://github.com/spacetelescope/spherical_geometry/issues/168
         if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
             intersect_poly = self._polygon.copy()
         else:

--- a/src/stcal/skymatch/skyimage.py
+++ b/src/stcal/skymatch/skyimage.py
@@ -118,6 +118,7 @@ class SkyImage:
         sky_id=None,
         stepsize=None,
         meta=None,
+        **kwargs,  # work-around downstream code # noqa: ARG002
     ):
         """Initialize the SkyImage object.
 

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -264,20 +264,6 @@ drizzlepac/astrodrizzle.html>`_.
 
     log.debug(f"Total number of images to be sky-subtracted and/or matched: {nimages:d}")
 
-    # Print conversion factors
-    log.debug(" ")
-    log.debug("----  Image data conversion factors:")
-
-    for img in images:
-        img_type = "Image" if isinstance(img, SkyImage) else "Group"
-
-        if img_type == "Group":
-            log.debug(f"   *  Group ID={img.sky_id}. Conversion factors:")
-            for im in img:
-                log.debug(f"      - Image ID={im.sky_id}. Conversion factor = {im.convf:G}")
-        else:
-            log.debug(f"   *  Image ID={img.sky_id}. Conversion factor = {img.convf:G}")
-
     # 1. Method: "match" (or "global+match").
     #    Find sky "deltas" that will match sky across all
     #    (intersecting) images.
@@ -383,14 +369,13 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             log.info(f"   *  Group ID={img.sky_id}. Sky background of component images:")
 
             for im, old_sky, new_sky in zip(img, old_img_sky, new_img_sky, strict=True):
-                c = 1.0 / im.convf
                 if show_old:
                     log.info(
                         f"      - Image ID={im.sky_id}. Sky background: "
-                        f"{c * new_sky:G} (old={c * old_sky:G}, delta={c * sky:G})"
+                        f"{new_sky:G} (old={old_sky:G}, delta={sky:G})"
                     )
                 else:
-                    log.info(f"      - Image ID={im.sky_id}. Sky background: {c * new_sky:G}")
+                    log.info(f"      - Image ID={im.sky_id}. Sky background: {new_sky:G}")
 
                 im.is_sky_valid = valid
 
@@ -403,14 +388,13 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             new_sky = img.sky
 
             # log sky values:
-            c = 1.0 / img.convf
             if show_old:
                 log.info(
-                    f"   *  Image ID={img.sky_id}. Sky background: {c * new_sky:G} "
-                    f"(old={c * old_sky:G}, delta={c * sky:G})"
+                    f"   *  Image ID={img.sky_id}. Sky background: {new_sky:G} "
+                    f"(old={old_sky:G}, delta={sky:G})"
                 )
             else:
-                log.info(f"   *  Image ID={img.sky_id}. Sky background: {c * new_sky:G}")
+                log.info(f"   *  Image ID={img.sky_id}. Sky background: {new_sky:G}")
 
             img.is_sky_valid = valid
 

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 import numpy as np
 
-# LOCAL
 from .skyimage import SkyGroup, SkyImage
 
 __all__ = ["skymatch"]

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -55,11 +55,7 @@ def skymatch(images, skymethod="global+match", match_down=True, subtract=False):
           inputs that overlap. The reported sky values will be relative to
           one of the input images (which will have a sky value of 0).
           This setting will "equalize" sky values between the images in large
-          mosaics. This method is not recommended when used in conjunction with
-          `astrodrizzle <http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/\
-drizzlepac/astrodrizzle.html>`_
-          because it computes relative sky values while `astrodrizzle` needs
-          "absolute" sky values for median image generation and CR rejection.
+          mosaics.
 
         * **'global+match'** : first compute sky values using the above
           **'match'** method, then (temporarily) apply the relative

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -16,9 +16,6 @@ from .skyimage import SkyGroup, SkyImage
 __all__ = ["skymatch"]
 
 
-# DEBUG
-__local_debug__ = True
-
 log = logging.getLogger(__name__)
 
 
@@ -379,7 +376,7 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             old_img_sky = [im.sky for im in img]
             if do_skysub:
                 for im in img:
-                    im._image.set_data(im._image.get_data() - sky)  # noqa: SLF001
+                    im.image -= sky
             img.sky += sky
             new_img_sky = [im.sky for im in img]
 
@@ -402,7 +399,7 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             # apply sky change:
             old_sky = img.sky
             if do_skysub:
-                img._image.set_data(img._image.get_data() - sky)  # noqa: SLF001
+                img.image -= sky
             img.sky += sky
             new_sky = img.sky
 

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -57,11 +57,10 @@ def skymatch(images, skymethod="global+match", match_down=True, subtract=False):
           This setting will "equalize" sky values between the images in large
           mosaics.
 
-        * **'global+match'** : first compute sky values using the above
-          **'match'** method, then (temporarily) apply the relative
-          sky values to each input and then compute the minimum sky
-          using the above **'global'** method. The final sky values will
-          be a combination of the results of these two methods.
+        * **'global+match'** : first compute sky values using the above match
+          method, then compute a global sky value after accounting for the
+          match-computed sky values. The final sky values will be a
+          combination of the two methods.
 
           .. note::
             This is the *recommended* setting for images

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -415,46 +415,8 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             img.is_sky_valid = valid
 
 
-# TODO: due to a bug in the sphere package, see
-#       https://github.com/spacetelescope/sphere/issues/74
-#       intersections with polygons formed as union does not work.
-#       For this reason I re-implement '_overlap_matrix' below with
-#       a workaround for the bug.
-#       The original implementation should be uncommented once the bug
-#       is fixed.
-#
-
-# Original version:
-# def _overlap_matrix(images, apply_sky=True):
-#     # TODO: to improve performance, the nested loops could be parallelized
-#     # since _calc_sky() here can be called independently from previous steps.
-#     ns = len(images)
-#     A = np.zeros((ns, ns), dtype=float)
-#     W = np.zeros((ns, ns), dtype=float)
-#     for i in range(ns):
-#         for j in range(i+1, ns):
-#             overlap = images[i].intersection(images[j])
-#             s1, w1, area1 = images[i].calc_sky(
-#                 overlap=overlap,
-#                 delta=apply_sky
-#             )
-#             s2, w2, area2 = images[j].calc_sky(
-#                 overlap=overlap,
-#                 delta=apply_sky
-#             )
-#             if area1 == 0.0 or area2 == 0.0 or s1 is None or s2 is None:
-#                 continue
-#             A[j,i] = s1
-#             W[j,i] = w1
-#             A[i,j] = s2
-#             W[i,j] = w2
-#     return A, W
-
-
 # bug workaround version:
 def _overlap_matrix(images, apply_sky=True):
-    # TODO: to improve performance, the nested loops could be parallelized
-    # since _calc_sky() here can be called independently from previous steps.
     ns = len(images)
     A = np.zeros((ns, ns), dtype=float)  # noqa: N806
     W = np.zeros((ns, ns), dtype=float)  # noqa: N806

--- a/src/stcal/skymatch/skymatch.py
+++ b/src/stcal/skymatch/skymatch.py
@@ -36,37 +36,36 @@ def skymatch(images, skymethod="global+match", match_down=True, subtract=False):
         Available methods: {'local', 'global+match', 'global', 'match'}
         Select the algorithm for sky computation:
 
-        * **'local'** : compute sky background values of each input image or
-          group of images (members of the same "exposure"). A single sky value
-          is computed for each group of images.
+        * **'local'** : independently compute the sky background for each
+          input (either image or group). This method does not involve any
+          special treatment of overlaps between inputs.
 
           .. note::
             This setting is recommended when regions of overlap between images
             are dominated by "pure" sky (as opposed to extended, diffuse
             sources).
 
-        * **'global'** : compute a common sky value for all input images and
-          groups of images. With this setting `local` will compute
-          sky values for each input image/group, find the minimum sky value,
-          and then it will set (and/or subtract) the sky value of each input
-          image to this minimum value. This method *may* be
+        * **'global'** : similar to `local` first compute an independent
+          sky background for each input (either image or group), then take
+          the minimum of these computed sky values. This minimum will be
+          assigned to the sky value of all inputs. This method *may* be
           useful when the input images have been already matched.
 
-        * **'match'** : compute differences in sky values between images
-          and/or groups in (pair-wise) common sky regions. In this case
-          the computed sky values will be relative (delta) to the sky computed
-          in one of the input images whose sky value will be set to
-          (reported to be) 0. This setting will "equalize" sky values between
-          the images in large mosaics. However, this method is not recommended
-          when used in conjunction with
+        * **'match'** : compute pair-wise differences in sky values between
+          inputs that overlap. The reported sky values will be relative to
+          one of the input images (which will have a sky value of 0).
+          This setting will "equalize" sky values between the images in large
+          mosaics. This method is not recommended when used in conjunction with
           `astrodrizzle <http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/\
 drizzlepac/astrodrizzle.html>`_
           because it computes relative sky values while `astrodrizzle` needs
           "absolute" sky values for median image generation and CR rejection.
 
-        * **'global+match'** : first use the **'match'** method to
-          equalize sky values between images and then find a minimum
-          "global" sky value amongst all input images.
+        * **'global+match'** : first compute sky values using the above
+          **'match'** method, then (temporarily) apply the relative
+          sky values to each input and then compute the minimum sky
+          using the above **'global'** method. The final sky values will
+          be a combination of the results of these two methods.
 
           .. note::
             This is the *recommended* setting for images
@@ -399,7 +398,6 @@ def _apply_sky(images, sky_deltas, do_global, do_skysub, show_old):
             img.is_sky_valid = valid
 
 
-# bug workaround version:
 def _overlap_matrix(images, apply_sky=True):
     ns = len(images)
     A = np.zeros((ns, ns), dtype=float)  # noqa: N806

--- a/src/stcal/skymatch/skystatistics.py
+++ b/src/stcal/skymatch/skystatistics.py
@@ -31,7 +31,7 @@ class SkyStats:
         Parameters
         ----------
         skystat : optional
-            possible values are'mode', 'median', 'mode', 'midpt".
+            possible values are 'mean', 'median', 'mode', 'midpt".
             Sets the statistics that will be returned by `~stcal.skymatch.skystatistics.SkyStats.calc_sky`.
             The following statistics are supported: 'mean', 'mode', 'midpt',
             and 'median'. First three statistics have the same meaning as in

--- a/src/stcal/skymatch/skystatistics.py
+++ b/src/stcal/skymatch/skystatistics.py
@@ -83,24 +83,7 @@ cgi-bin/gethelp.cgi?gstatistics>`_
         self._kwargs["usig"] = usig
         self._kwargs["binwidth"] = binwidth
 
-        self._skystat = {
-            "mean": self._extract_mean,
-            "mode": self._extract_mode,
-            "median": self._extract_median,
-            "midpt": self._extract_midpt,
-        }[skystat]
-
-    def _extract_mean(self, imstat):
-        return imstat.mean
-
-    def _extract_median(self, imstat):
-        return imstat.median
-
-    def _extract_mode(self, imstat):
-        return imstat.mode
-
-    def _extract_midpt(self, imstat):
-        return imstat.midpt
+        self._skystat = skystat
 
     def calc_sky(self, data):
         """Compute statistics on data.
@@ -121,9 +104,7 @@ cgi-bin/gethelp.cgi?gstatistics>`_
 
         """
         imstat = ImageStats(image=data, fields=self._fields, **(self._kwargs))
-        self.skyval = self._skystat(imstat)
-        self.npix = imstat.npix
-        return self.skyval, self.npix
+        return getattr(imstat, self._skystat), imstat.npix
 
     def __call__(self, data):  # noqa: D102
         return self.calc_sky(data)

--- a/src/stcal/skymatch/skystatistics.py
+++ b/src/stcal/skymatch/skystatistics.py
@@ -5,7 +5,6 @@ Used by :py:func:`~stcal.skymatch.skymatch.skymatch`
 and :py:class:`~stcal.skymatch.skyimage.SkyImage`.
 """
 
-# THIRD PARTY
 from copy import deepcopy
 
 from stsci.imagestats import ImageStats

--- a/src/stcal/skymatch/skystatistics.py
+++ b/src/stcal/skymatch/skystatistics.py
@@ -5,8 +5,6 @@ Used by :py:func:`~stcal.skymatch.skymatch.skymatch`
 and :py:class:`~stcal.skymatch.skyimage.SkyImage`.
 """
 
-from copy import deepcopy
-
 from stsci.imagestats import ImageStats
 
 __all__ = ["SkyStats"]
@@ -23,9 +21,7 @@ class SkyStats:
 
     """
 
-    def __init__(
-        self, skystat="mean", lower=None, upper=None, nclip=5, lsig=4.0, usig=4.0, binwidth=0.1, **kwargs
-    ):
+    def __init__(self, skystat="mean", lower=None, upper=None, nclip=5, lsig=4.0, usig=4.0, binwidth=0.1):
         """Initialize the SkyStats object.
 
         Parameters
@@ -61,27 +57,19 @@ cgi-bin/gethelp.cgi?gstatistics>`_
             Bin width, in sigma, used to sample the distribution of pixel
             brightness values in order to compute the sky background
             statistics.
-
-        kwargs : dict
-            A dictionary of optional arguments to be passed to `ImageStats`.
-
         """
         self.npix = None
         self.skyval = None
 
-        self._fields = f"npix,{skystat}"
-
-        self._kwargs = deepcopy(kwargs)
-        if "fields" in self._kwargs:
-            del self._kwargs["fields"]
-        if "image" in self._kwargs:
-            del self._kwargs["image"]
-        self._kwargs["lower"] = lower
-        self._kwargs["upper"] = upper
-        self._kwargs["nclip"] = nclip
-        self._kwargs["lsig"] = lsig
-        self._kwargs["usig"] = usig
-        self._kwargs["binwidth"] = binwidth
+        self._kwargs = {
+            "fields": f"npix,{skystat}",
+            "lower": lower,
+            "upper": upper,
+            "nclip": nclip,
+            "lsig": lsig,
+            "usig": usig,
+            "binwidth": binwidth,
+        }
 
         self._skystat = skystat
 
@@ -103,7 +91,7 @@ cgi-bin/gethelp.cgi?gstatistics>`_
             of pixels used in computing the statistics reported in `skyvalue`.
 
         """
-        imstat = ImageStats(image=data, fields=self._fields, **(self._kwargs))
+        imstat = ImageStats(image=data, **(self._kwargs))
         return getattr(imstat, self._skystat), imstat.npix
 
     def __call__(self, data):  # noqa: D102

--- a/tests/skymatch/test_skyimage.py
+++ b/tests/skymatch/test_skyimage.py
@@ -1,0 +1,144 @@
+import copy
+
+import gwcs
+import numpy as np
+import pytest
+from astropy.modeling.models import Scale, Shift
+
+from stcal.skymatch import SkyGroup, SkyImage, SkyStats
+
+IMAGE_SIZE = (10, 10)
+
+
+@pytest.fixture
+def wcs():
+    # a simple 1 arcminute FOV wcs
+    scales = [1 / (s * 60) for s in IMAGE_SIZE]
+    return gwcs.WCS([["pixel", Scale(scales[0]) & Scale(scales[1])], ["world", None]])
+
+
+@pytest.fixture
+def image():
+    return np.zeros(IMAGE_SIZE, dtype="f4")
+
+
+@pytest.fixture
+def mask(image):
+    return np.ones(IMAGE_SIZE, dtype=bool)
+
+
+@pytest.fixture
+def meta():
+    return {}
+
+
+@pytest.fixture
+def skystats():
+    return SkyStats(skystat="mean")
+
+
+@pytest.fixture
+def skyimage(image, mask, wcs, skystats, meta):
+    return SkyImage(image, mask, wcs.forward_transform, wcs.backward_transform, skystats, meta=meta)
+
+
+@pytest.fixture
+def skygroup(skyimage):
+    return SkyGroup([skyimage])
+
+
+@pytest.fixture(params=["skyimage", "skygroup"])
+def skyinstance(request):
+    yield request.getfixturevalue(request.param)
+
+
+def test_sky_init(skyinstance):
+    assert skyinstance.sky == 0.0
+
+
+@pytest.mark.parametrize("value", [1, -1, 42])
+def test_set_sky(skyinstance, value):
+    skyinstance.sky = value
+    assert skyinstance.sky == value
+    if isinstance(skyinstance, SkyGroup):
+        assert skyinstance[0].sky == value
+
+
+@pytest.mark.parametrize("attr", ["meta", "image", "mask"])
+def test_passthrough_attr(skyimage, attr, request):
+    """Test __init__ arguments that become attributes are correctly assigned"""
+    assert getattr(skyimage, attr) is request.getfixturevalue(attr)
+
+
+def test_skyimage_is_sky_valid(skyimage):
+    assert not skyimage.is_sky_valid
+
+
+@pytest.mark.parametrize(
+    "fill_value, initial_sky, expected_sky, delta",
+    [
+        (42, 0, 42, False),
+        (42, 21, 42, False),
+        (42, 21, 21, True),
+    ],
+)
+def test_calc_sky(skyinstance, fill_value, initial_sky, expected_sky, delta):
+    if isinstance(skyinstance, SkyImage):
+        skyinstance.image[:] = fill_value
+        expected_npix = skyinstance.image.size
+    else:
+        skyinstance[0].image[:] = fill_value
+        expected_npix = skyinstance[0].image.size
+    skyinstance.sky = initial_sky
+    skyval, npix, polyarea = skyinstance.calc_sky(delta=delta)
+    assert skyval == expected_sky
+    assert npix == expected_npix
+    assert np.isclose(polyarea, skyinstance._polygon.area())
+
+
+@pytest.mark.parametrize("other_class", [SkyImage, SkyGroup])
+def test_calc_sky_overlap(skyinstance, wcs, other_class):
+    # make a partially overlapping skyimage
+    offset_wcs = gwcs.WCS(
+        (Shift(1) & Shift(0)) | wcs.forward_transform,
+        input_frame="pixel",
+        output_frame="word",
+    )
+    if isinstance(skyinstance, SkyGroup):
+        reference = skyinstance[0]
+    else:
+        reference = skyinstance
+    other = SkyImage(
+        reference.image.copy(),
+        reference.mask.copy(),
+        offset_wcs.forward_transform,
+        offset_wcs.backward_transform,
+        copy.copy(reference.skystat),
+    )
+    # fill half image with one value
+    reference.image[:, 1:] = 42
+    other.image[:] = 42
+    if other_class is SkyGroup:
+        other = SkyGroup([other])
+    skyval, npix, _ = skyinstance.calc_sky(overlap=other)
+    assert skyval == 42
+    assert npix == (IMAGE_SIZE[1] - 1) * IMAGE_SIZE[0]
+
+
+def test_no_images_skygroup():
+    with pytest.raises(ValueError, match="SkyGroup requires a list of images"):
+        SkyGroup([])
+
+
+def test_skygroup_len(skygroup):
+    assert len(skygroup) == len(skygroup._images)
+
+
+def test_skygroup_iter(skygroup):
+    for i0, i1 in zip(skygroup, skygroup._images, strict=True):
+        assert i0 is i1
+
+
+def test_skygroup_getitem(skygroup):
+    for i in range(len(skygroup)):
+        assert skygroup[i] is skygroup._images[i]

--- a/tests/skymatch/test_skymatch.py
+++ b/tests/skymatch/test_skymatch.py
@@ -1,0 +1,70 @@
+import copy
+
+import gwcs
+import numpy as np
+import pytest
+from astropy.modeling.models import Scale, Shift
+
+from stcal.skymatch import SkyGroup, SkyImage, SkyStats, skymatch
+
+IMAGE_SIZE = (10, 10)
+FILL_VALUES = [21, 42]
+
+
+@pytest.fixture()
+def images():
+    # a simple 1 arcminute FOV wcs
+    scales = [1 / (s * 60) for s in IMAGE_SIZE]
+    # shifted 1 degree to avoid dealing with RA wrapping
+    wcs = gwcs.WCS(
+        [["pixel", (Scale(scales[0]) & Scale(scales[1])) | (Shift(1) & Shift(1))], ["world", None]]
+    )
+    im = SkyImage(
+        np.zeros(IMAGE_SIZE, dtype="f4"),
+        np.ones(IMAGE_SIZE, dtype=bool),
+        wcs.forward_transform,
+        wcs.backward_transform,
+        SkyStats("mean"),
+    )
+    images = [im, SkyGroup([copy.deepcopy(im)])]
+    images[0].image[:] = FILL_VALUES[0]
+    images[1][0].image[:] = FILL_VALUES[1]
+    return images
+
+
+@pytest.mark.parametrize(
+    "method, skys, match_down",
+    [
+        ("local", FILL_VALUES, True),
+        ("local", FILL_VALUES, False),
+        ("match", [0, 21], True),
+        ("match", [-21, 0], False),
+        ("global", [21, 21], True),
+        ("global", [21, 21], False),
+        ("global+match", FILL_VALUES, True),
+        ("global+match", FILL_VALUES, False),
+    ],
+)
+@pytest.mark.parametrize("subtract", [True, False])
+def test_skymatch(images, method, skys, match_down, subtract):
+    skymatch(images, method, match_down, subtract)
+    assert np.allclose([i.sky for i in images], skys)
+    if subtract:
+        assert np.allclose(images[0].image, FILL_VALUES[0] - skys[0])
+        assert np.allclose(images[1][0].image, FILL_VALUES[1] - skys[1])
+    else:
+        assert np.allclose(images[0].image, FILL_VALUES[0])
+        assert np.allclose(images[1][0].image, FILL_VALUES[1])
+
+
+@pytest.mark.parametrize(
+    "input_images, method, error_class, error_match",
+    [
+        ([], "foo", ValueError, "Unsupported 'skymethod'"),
+        ([1, 2], "global", TypeError, "Each element of the 'images' must be"),
+        ([], "global", ValueError, "Argument 'images' must contain at least one image"),
+    ],
+)
+def test_skymatch_errors(input_images, method, error_class, error_match):
+    with pytest.raises(error_class, match=error_match):
+        skymatch(input_images, method)

--- a/tests/skymatch/test_skymatch.py
+++ b/tests/skymatch/test_skymatch.py
@@ -41,8 +41,8 @@ def images():
         ("match", False, [-21, 0]),
         ("global", True, [21, 21]),
         ("global", False, [21, 21]),
-        ("global+match", True , FILL_VALUES),
-        ("global+match", False , FILL_VALUES),
+        ("global+match", True, FILL_VALUES),
+        ("global+match", False, FILL_VALUES),
     ],
 )
 @pytest.mark.parametrize("subtract", [True, False])

--- a/tests/skymatch/test_skymatch.py
+++ b/tests/skymatch/test_skymatch.py
@@ -33,20 +33,20 @@ def images():
 
 
 @pytest.mark.parametrize(
-    "method, skys, match_down",
+    "method, match_down, skys",
     [
-        ("local", FILL_VALUES, True),
-        ("local", FILL_VALUES, False),
-        ("match", [0, 21], True),
-        ("match", [-21, 0], False),
-        ("global", [21, 21], True),
-        ("global", [21, 21], False),
-        ("global+match", FILL_VALUES, True),
-        ("global+match", FILL_VALUES, False),
+        ("local", True, FILL_VALUES),
+        ("local", False, FILL_VALUES),
+        ("match", True, [0, 21]),
+        ("match", False, [-21, 0]),
+        ("global", True, [21, 21]),
+        ("global", False, [21, 21]),
+        ("global+match", True , FILL_VALUES),
+        ("global+match", False , FILL_VALUES),
     ],
 )
 @pytest.mark.parametrize("subtract", [True, False])
-def test_skymatch(images, method, skys, match_down, subtract):
+def test_skymatch(images, method, match_down, skys, subtract):
     skymatch(images, method, match_down, subtract)
     assert np.allclose([i.sky for i in images], skys)
     if subtract:

--- a/tests/skymatch/test_skystats.py
+++ b/tests/skymatch/test_skystats.py
@@ -1,0 +1,33 @@
+import numpy as np
+import numpy.testing
+import pytest
+
+from stcal.skymatch import SkyStats
+
+
+@pytest.mark.parametrize("skystat", ["mean", "median", "mode"])
+def test_skystat(skystat):
+    data = np.full((10, 10), 1.0, dtype="f8")
+    stats = SkyStats(skystat=skystat)
+    sky_value, npix = stats.calc_sky(data)
+    numpy.testing.assert_allclose(sky_value, 1.0)
+    assert npix == 100
+
+
+def test_midpt():
+    data = np.array([0, 1, 2, 3], dtype="f8")
+    stats = SkyStats(skystat="midpt")
+    sky_value, npix = stats.calc_sky(data)
+    # TODO shouldn't this be closer to 1.5
+    numpy.testing.assert_allclose(sky_value, 1.032796, rtol=1e-6)
+    assert npix == 4
+
+
+def test_limit():
+    # TODO why does this fail for lower=0.5 upper=1.5 and data=1.0?
+    data = np.full((10, 10), 10.0, dtype="f8")
+    data[:5, :] = 0
+    stats = SkyStats(skystat="mean", lower=5.0, upper=15.0)
+    sky_value, npix = stats.calc_sky(data)
+    numpy.testing.assert_allclose(sky_value, 10.0)
+    assert npix == 50

--- a/tests/skymatch/test_skystats.py
+++ b/tests/skymatch/test_skystats.py
@@ -18,13 +18,11 @@ def test_midpt():
     data = np.array([0, 1, 2, 3], dtype="f8")
     stats = SkyStats(skystat="midpt")
     sky_value, npix = stats.calc_sky(data)
-    # TODO shouldn't this be closer to 1.5
     numpy.testing.assert_allclose(sky_value, 1.032796, rtol=1e-6)
     assert npix == 4
 
 
 def test_limit():
-    # TODO why does this fail for lower=0.5 upper=1.5 and data=1.0?
     data = np.full((10, 10), 10.0, dtype="f8")
     data[:5, :] = 0
     stats = SkyStats(skystat="mean", lower=5.0, upper=15.0)


### PR DESCRIPTION
Update the skymatch submodule to:
- clarify the public API: `skymatch` `SkyImage` `SkyGroup` `SkyStats`
- update documentation to describe algorithms, etc (started as a copy of jwst [docs](https://jwst-pipeline.readthedocs.io/en/stable/jwst/skymatch/description.html))
- remove unused code
- remove unused `reduce_memory_usage` option (which is currently default on but both pipelines disable it since previous testing showed that it overwrote input data) and remove the code that supports it
- remove `convf` and `pix_area` arguments which are hard-coded in both pipelines
- add unit tests (currently over 90% coverage of skymatch submodule without including downstream tests)

Requires coordinated merging of this PR alongside:
- https://github.com/spacetelescope/jwst/pull/10200
- https://github.com/spacetelescope/romancal/pull/2154

Regtests (with paired PRs):
jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/21488244911
with https://github.com/spacetelescope/jwst/pull/10200
all pass

romancal: https://github.com/spacetelescope/RegressionTests/actions/runs/21488254530
with https://github.com/spacetelescope/romancal/pull/2154
all pass

Closes https://github.com/spacetelescope/stcal/issues/502

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
