### PR TITLE
unpin gwcs

### DIFF
--- a/changes/507.other.rst
+++ b/changes/507.other.rst
@@ -1,0 +1,1 @@
+Allow gwcs 1.0.1 and higher.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "scikit-image>=0.21.0",
   "numpy >=1.25.0",
   "asdf >=3.3.0",
-  "gwcs >=0.25.2,!=1.0.0,<2.0.0",
+  "gwcs >=1.0.1,<2.0.0",
   "tweakwcs >=0.8.8",
   "requests >=2.22",
   "spherical-geometry >=1.2.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "scikit-image>=0.21.0",
   "numpy >=1.25.0",
   "asdf >=3.3.0",
-  "gwcs >=0.25.2,<1.0.0",
+  "gwcs >=0.25.2,!=1.0.0,<2.0.0",
   "tweakwcs >=0.8.8",
   "requests >=2.22",
   "spherical-geometry >=1.2.22",


### PR DESCRIPTION
Adjust the gwcs upper pin to pull in 1.0.1 (which has the bugfix to allow the tests to pass) and move it to `<2.0.0`.

Fixes https://github.com/spacetelescope/stcal/issues/498

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
