### PR TITLE
AL-991: Add support for DQ flag propagation in resample

### DIFF
--- a/changes/516.resample.rst
+++ b/changes/516.resample.rst
@@ -1,0 +1,1 @@
+Added support for propagating DQ flags in resampling. DQ flags are propagated by bitwise OR of all input DQ flags that contribute to a given output pixel.

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -534,6 +534,11 @@ class Resample:
         """Indicates whether error array is computed and how it is computed."""
         return self._compute_err
 
+    @property
+    def propagate_dq(self):
+        """Indicates whether DQ flags are propagated and output model has DQ array."""
+        return self._propagate_dq
+
     def _get_intensity_scale(self, model):
         """
         Compute intensity scale.

--- a/tests/resample/conftest.py
+++ b/tests/resample/conftest.py
@@ -76,7 +76,7 @@ def nrcb5_many_fluxes(nrcb5_wcs_wcsinfo):
             rdnoise = mean_noise * np.random.random((patch_size, patch_size))
 
             model["data"][sl] = psf
-            model["dq"][sl] = 0
+            model["dq"][sl] = 2 ** np.random.randint(3, 16, size=(patch_size, patch_size), dtype=np.uint32)
 
             model["var_rnoise"][sl] = rdnoise
             model["var_poisson"][sl] = psf
@@ -85,5 +85,6 @@ def nrcb5_many_fluxes(nrcb5_wcs_wcsinfo):
 
             stars.append((xc, yc, sl))
 
+    model["var_sky"] = np.full_like(model["data"], mean_noise)
     model["stars"] = stars
     return model

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -10,6 +10,7 @@ from stcal.resample.utils import (
     build_driz_weight,
     resample_range,
 )
+from tests.test_ramp_fitting_cases import GOOD
 
 from .helpers import (
     JWST_DQ_FLAG_DEF,
@@ -251,7 +252,8 @@ def test_resample_add_model_hook():
 @pytest.mark.parametrize("kernel", ["square", "turbo", "point"])
 @pytest.mark.parametrize("pscale_ratio", [0.55, 1.0, 1.2])
 @pytest.mark.parametrize("weight_type", ["exptime", "ivm", "ivm-sky"])
-def test_resample_photometry(nrcb5_many_fluxes, pscale_ratio, kernel, weight_type):
+@pytest.mark.parametrize("propagate_dq", [True, False])
+def test_resample_photometry(nrcb5_many_fluxes, pscale_ratio, kernel, weight_type, propagate_dq):
     """test surface-brightness photometry"""
     model = nrcb5_many_fluxes
 
@@ -259,19 +261,34 @@ def test_resample_photometry(nrcb5_many_fluxes, pscale_ratio, kernel, weight_typ
     wcsinfo = model["wcsinfo"]
     stars = model["stars"]
 
-    output_wcs = wcs_from_sregions([compute_s_region_imaging(wcs)], wcs, wcsinfo, pscale_ratio=pscale_ratio)
+    output_wcs = wcs_from_sregions(
+        [compute_s_region_imaging(wcs)],
+        wcs,
+        wcsinfo,
+        pscale_ratio=pscale_ratio,
+    )
 
-    weight = build_driz_weight(model, weight_type=weight_type, good_bits=0, flag_name_map=JWST_DQ_FLAG_DEF)
+    good_bits = sum([2**i for i in range(3, 16)])
+
+    weight = build_driz_weight(
+        model,
+        weight_type=weight_type,
+        good_bits=good_bits,
+        flag_name_map=JWST_DQ_FLAG_DEF,
+    )
 
     resample = Resample(
         n_input_models=1,
         output_wcs={"wcs": output_wcs},
         weight_type=weight_type,
+        good_bits=good_bits,
         enable_var=False,
         compute_err=False,
         fillval="NAN",
         kernel=kernel,
+        propagate_dq=propagate_dq,
     )
+
     resample.dq_flag_name_map = JWST_DQ_FLAG_DEF
     resample.add_model(model)
     resample.finalize()
@@ -280,6 +297,13 @@ def test_resample_photometry(nrcb5_many_fluxes, pscale_ratio, kernel, weight_typ
     # multiply resampled data by resampled image weight
     out_wht = resample.output_model["wht"]
     out_wdata = resample.output_model["data"] * out_wht
+    out_dq = resample.output_model["dq"]
+
+    # test dq propagation
+    if propagate_dq:
+        assert out_dq is not None
+        assert np.any(out_dq)
+        assert np.bitwise_or.reduce(out_dq, axis=(0, 1)) == good_bits
 
     in_wdata = model["data"] * weight
 

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -10,7 +10,6 @@ from stcal.resample.utils import (
     build_driz_weight,
     resample_range,
 )
-from tests.test_ramp_fitting_cases import GOOD
 
 from .helpers import (
     JWST_DQ_FLAG_DEF,


### PR DESCRIPTION
Resolves [AL-991](https://jira.stsci.edu/browse/AL-991)

This PR adds support for propagating DQ flags in resample. It is off by default so it will not affect JWST.

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
