### PR TITLE
BUG: Fix crash when there is no catalog match

### DIFF
--- a/changes/517.tweakreg.rst
+++ b/changes/517.tweakreg.rst
@@ -1,0 +1,1 @@
+Fixed a bug to avoid ``get_catalog()`` from crashing when there are no sources found.

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -205,7 +205,7 @@ def get_catalog(
     if r_contents.startswith("No data records"):
         r_contents = "\n"
     catalog = Table.read(r_contents, format="csv", comment="#")
-    if epoch and catalog.mask and len(catalog) > 0:
+    if epoch and catalog.has_masked_columns and len(catalog) > 0:
         # When provided with an epoch gsss returns corrected and non-corrected
         # sources. Filter out the non-corrected ones.
         catalog = catalog[~(catalog["pmra"].mask & catalog["pmdec"].mask)]

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -205,7 +205,7 @@ def get_catalog(
     if r_contents.startswith("No data records"):
         r_contents = "\n"
     catalog = Table.read(r_contents, format="csv", comment="#")
-    if epoch and len(catalog) > 0:
+    if epoch and catalog.masked and len(catalog) > 0:
         # When provided with an epoch gsss returns corrected and non-corrected
         # sources. Filter out the non-corrected ones.
         catalog = catalog[~(catalog["pmra"].mask & catalog["pmdec"].mask)]

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -205,7 +205,7 @@ def get_catalog(
     if r_contents.startswith("No data records"):
         r_contents = "\n"
     catalog = Table.read(r_contents, format="csv", comment="#")
-    if epoch and catalog.masked and len(catalog) > 0:
+    if epoch and catalog.mask and len(catalog) > 0:
         # When provided with an epoch gsss returns corrected and non-corrected
         # sources. Filter out the non-corrected ones.
         catalog = catalog[~(catalog["pmra"].mask & catalog["pmdec"].mask)]

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -205,7 +205,7 @@ def get_catalog(
     if r_contents.startswith("No data records"):
         r_contents = "\n"
     catalog = Table.read(r_contents, format="csv", comment="#")
-    if epoch and catalog:
+    if epoch and len(catalog) > 0:
         # When provided with an epoch gsss returns corrected and non-corrected
         # sources. Filter out the non-corrected ones.
         catalog = catalog[~(catalog["pmra"].mask & catalog["pmdec"].mask)]

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -205,7 +205,7 @@ def get_catalog(
     if r_contents.startswith("No data records"):
         r_contents = "\n"
     catalog = Table.read(r_contents, format="csv", comment="#")
-    if epoch and catalog.has_masked_columns and len(catalog) > 0:
+    if epoch and catalog.mask and len(catalog) > 0:
         # When provided with an epoch gsss returns corrected and non-corrected
         # sources. Filter out the non-corrected ones.
         catalog = catalog[~(catalog["pmra"].mask & catalog["pmdec"].mask)]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

This PR addresses problem reported by @Rplesha on Slack.

```
    210     # sources. Filter out the non-corrected ones.
--> 211     catalog = catalog[~(catalog["pmra"].mask & catalog["pmdec"].mask)]
    212 return catalog

AttributeError: 'Column' object has no attribute 'mask'
```

Alternative:

* #519

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
