### PR TITLE
Fix tweakreg handling of catalogs without masked values

### DIFF
--- a/changes/519.tweakreg.rst
+++ b/changes/519.tweakreg.rst
@@ -1,0 +1,1 @@
+Fix handling of catalogs without any non-pm sources.

--- a/changes/519.tweakreg.rst
+++ b/changes/519.tweakreg.rst
@@ -1,1 +1,1 @@
-Fix handling of catalogs without any non-pm sources.
+Fix handling of catalogs with all sources containing valid proper motion.

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -1,5 +1,6 @@
 import os
 
+import numpy as np
 import requests
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -208,5 +209,10 @@ def get_catalog(
     if epoch and catalog:
         # When provided with an epoch gsss returns corrected and non-corrected
         # sources. Filter out the non-corrected ones.
-        catalog = catalog[~(catalog["pmra"].mask & catalog["pmdec"].mask)]
+        mask = np.zeros(len(catalog), dtype="bool")
+        for colname in ("pmra", "pmdec"):
+            if not hasattr(catalog[colname], "mask"):
+                continue
+            mask |= catalog[colname].mask
+        catalog = catalog[~mask]
     return catalog

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -433,3 +433,8 @@ def test_gaia_dr2(epoch, n_sources):
     cat_dr2 = amutils.get_catalog(ra, dec, epoch=epoch, search_radius=sr, catalog=cn)
 
     assert len(cat_dr2) == n_sources
+
+
+def test_single_source_with_pm():
+    table = amutils.get_catalog(0, 0, epoch=2017.0, search_radius=0.01, catalog="GAIADR3")
+    assert len(table) == 1


### PR DESCRIPTION
gsss queries that return all sources with measured proper motion the `pmra` and `pmdec` columns will not contain the required `mask` attribute. This results in a crash when masking of non-pm sources is attempted. This fixes the issue and adds a test (that returns a single pm-corrected source) for the failure.

Regtests all pass:
roman: https://github.com/spacetelescope/RegressionTests/actions/runs/21837432178
jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/21837440205

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
    - if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
