### PR TITLE
fix extra tests workflow to trigger on label changes

### DIFF
--- a/.github/workflows/tests_extra.yml
+++ b/.github/workflows/tests_extra.yml
@@ -1,6 +1,14 @@
 name: extra tests
 
 on:
+  pull_request:
+    branches:
+      - main
+      - "*x"
+    # To trigger on label changes
+    types:
+      - synchronize
+      - labeled
   schedule:
     # Weekly Monday midnight build
     - cron: "0 0 * * 1"


### PR DESCRIPTION
Fixes the extra tests workflow to trigger on PRs when labels change.

Adding the label to this PR triggered the workflow:
https://github.com/spacetelescope/stcal/actions/runs/22406261142/job/64866858043

Given the scope of the changes I don't think we need regtests (or to wait for all the CI to finish).

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
