### PR TITLE
JP-4097: Allow 4-D reference file arrays to support multistripe data

### DIFF
--- a/changes/526.saturation.rst
+++ b/changes/526.saturation.rst
@@ -1,0 +1,1 @@
+Allow 4D input arrays in the saturation step, matching the dimensions of the input data. This is intended for support of striping modes that may cover different areas of the detector in each integration.

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -30,6 +30,12 @@ def flag_saturated_pixels(
     for 0 DN values. For A/D floor flagged groups, the DO_NOT_USE flag is also
     set.
 
+    Some input arrays may be provided as 2-D arrays, intended to match
+    all integrations and all groups, or 4-D arrays that may have different
+    values for each integration and group.  4-D arrays are intended to support
+    multi-striping modes which may sample different detector regions in
+    each integration.
+
     Parameters
     ----------
     data : np.ndarray
@@ -40,12 +46,12 @@ def flag_saturated_pixels(
 
     pdq : np.ndarray
         2-D pixel dq array matching the image dimensions (ny, nx).
-        For superstripe data, a 3-D array may be provided,
-        where the first dimension is the number of stripes (nstripe, ny, nx).
+        Alternately, a 4-D array may be provided,
+        matching the data dimensions (nint, ngroup, ny, nx).
 
     sat_thresh : np.ndarray
         2-D pixel-wise threshold for saturation, matching the image
-        dimensions (ny, nx).  For superstripe data, a 4-D array may
+        dimensions (ny, nx). Alternately, a 4-D array may
         be provided, matching the data dimensions (nint, ngroup, ny, nx).
 
     sat_dq : np.ndarray
@@ -71,7 +77,7 @@ def flag_saturated_pixels(
 
     bias : np.ndarray
         2-D superbias array (ny, nx) for use in group 2 saturation flagging
-        for frame-averaged groups. For superstripe data, a 4-D array may
+        for frame-averaged groups. Alternately, a 4-D array may
         be provided, matching the data dimensions (nint, ngroup, ny, nx).
 
     Returns
@@ -80,7 +86,7 @@ def flag_saturated_pixels(
         Updated 4-D group dq array
 
     pdq : np.ndarray
-        Updated 2-D pixel dq array
+        Updated pixel dq array
     """
     nints, ngroups, nrows, ncols = data.shape
     dnu = int(dqflags["DO_NOT_USE"])
@@ -175,12 +181,18 @@ def flag_saturated_pixels(
             # flagged as saturated or do not use, *and* the next group
             # was flagged as saturated.  Result of the line below is a
             # boolean array.
-
-            partial_sat = (
-                (plane >= sat_thresh * dilution_factor)
-                & (thisdq & (saturated | dnu) == 0)
-                & (nextdq & saturated != 0)
-            )
+            if sat_thresh.ndim == 4:
+                partial_sat = (
+                    (plane >= sat_thresh[ints, group, :, :] * dilution_factor)
+                    & (thisdq & (saturated | dnu) == 0)
+                    & (nextdq & saturated != 0)
+                )
+            else:
+                partial_sat = (
+                    (plane >= sat_thresh * dilution_factor)
+                    & (thisdq & (saturated | dnu) == 0)
+                    & (nextdq & saturated != 0)
+                )
 
             flagarray = (partial_sat * dnu).astype(np.uint32)
 
@@ -247,11 +259,7 @@ def flag_saturated_pixels(
     n_floor = np.any(np.any(np.bitwise_and(gdq, ad_floor), axis=0), axis=0).sum()
     log.info("Detected %i A/D floor pixels", n_floor)
 
-    if pdq.ndim == 3:
-        num_superstripe = pdq.shape[0]
-        pdq = np.bitwise_or(pdq, sat_dq[0:num_superstripe, 0, :, :])
-    else:
-        pdq = np.bitwise_or(pdq, sat_dq)
+    pdq = np.bitwise_or(pdq, sat_dq)
 
     return gdq, pdq, zframe
 

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -183,7 +183,7 @@ def flag_saturated_pixels(
             # boolean array.
             if sat_thresh.ndim == 4:
                 partial_sat = (
-                    (plane >= sat_thresh[ints, group, :, :] * dilution_factor)
+                    (plane >= sat_thresh[ints, group, :, :] * dilution_factor[ints, group, :, :])
                     & (thisdq & (saturated | dnu) == 0)
                     & (nextdq & saturated != 0)
                 )
@@ -239,15 +239,16 @@ def flag_saturated_pixels(
             flagarray = (mask * dnu).astype(np.uint32)
 
             # Add them to the gdq array
-            if flagarray.ndim == 4:
-                np.bitwise_or(gdq[ints, 1, :, :], flagarray[ints, 1, :, :], gdq[ints, 1, :, :])
-            else:
-                np.bitwise_or(gdq[ints, 1, :, :], flagarray, gdq[ints, 1, :, :])
+            np.bitwise_or(gdq[ints, 1, :, :], flagarray, gdq[ints, 1, :, :])
 
         # Check ZEROFRAME.
         if zframe is not None:
             plane = zframe[ints, :, :]
-            flagarray, flaglowarray = _plane_saturation(plane, sat_thresh, dqflags)
+            if sat_thresh.ndim == 4:
+                thresh = sat_thresh[ints, 0, :, :]
+            else:
+                thresh = sat_thresh
+            flagarray, flaglowarray = _plane_saturation(plane, thresh, dqflags)
             zdq = flagarray | flaglowarray
             if n_pix_grow_sat > 0:
                 _adjacent_pixels(zdq, saturated, n_pix_grow_sat, inplace=True)

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -33,22 +33,26 @@ def flag_saturated_pixels(
     Parameters
     ----------
     data : np.ndarray
-        4-D science array
+        4-D science array (nint, ngroup, ny, nx).
 
     gdq : np.ndarray
-        4-D group dq array
+        4-D group dq array (nint, ngroup, ny, nx).
 
     pdq : np.ndarray
-        2-D pixel dq array
+        2-D pixel dq array matching the image dimensions (ny, nx).
+        For superstripe data, a 3-D array may be provided,
+        where the first dimension is the number of stripes (nstripe, ny, nx).
 
     sat_thresh : np.ndarray
-        Pixel-wise threshold for saturation, same shape `data`
+        2-D pixel-wise threshold for saturation, matching the image
+        dimensions (ny, nx).  For superstripe data, a 4-D array may
+        be provided, matching the data dimensions (nint, ngroup, ny, nx).
 
     sat_dq : np.ndarray
-        Data quality flags associated with `sat_thresh`
+        Data quality flags associated with `sat_thresh`.
 
     atod_limit : int
-        Hard DN limit of 16-bit A-to-D converter
+        Hard DN limit of 16-bit A-to-D converter.
 
     dqflags : dict
         A dictionary with at least the following keywords:
@@ -66,7 +70,9 @@ def flag_saturated_pixels(
         The times or indices of the frames composing each group.
 
     bias : np.ndarray
-        2-D superbias array.  For use in group 2 saturation flagging for frame-averaged groups.
+        2-D superbias array (ny, nx) for use in group 2 saturation flagging
+        for frame-averaged groups. For superstripe data, a 4-D array may
+        be provided, matching the data dimensions (nint, ngroup, ny, nx).
 
     Returns
     -------
@@ -115,10 +121,10 @@ def flag_saturated_pixels(
 
             # Update the running tally of all pixels that have ever
             # experienced saturation to account for this.
-            if len(sat_thresh.shape) == 4:
-                previously_saturated |= plane >= sat_thresh[ints, group, :, :]
+            if sat_thresh.ndim == 4:
+                previously_saturated |= (plane >= sat_thresh[ints, group, :, :])
             else:
-                previously_saturated |= plane >= sat_thresh
+                previously_saturated |= (plane >= sat_thresh)
 
             flagarray = (previously_saturated * saturated).astype(np.uint32)
 
@@ -188,12 +194,12 @@ def flag_saturated_pixels(
         # Add an additional pass to look for things saturating in the second group
         # that can be particularly tricky to identify
         if (read_pattern is not None) & (ngroups > 2):
-            if len(bias.shape) == 4:
+            if not np.isscalar(bias) and bias.ndim == 4:
                 bias_grp2 = bias[ints, 0, :, :]
             else:
                 bias_grp2 = bias
 
-            if len(sat_thresh.shape) == 4:
+            if sat_thresh.ndim == 4:
                 sat_thresh_grp2 = sat_thresh[ints, 0, :, :]
             else:
                 sat_thresh_grp2 = sat_thresh
@@ -204,7 +210,8 @@ def flag_saturated_pixels(
             # Identify groups which we wouldn't expect to saturate by the third group,
             # on the basis of the first group
             scigp1 = data[ints, 0, :, :] - bias_grp2
-            mask = ((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1]) + bias_grp2 < sat_thresh_grp2
+            mask = (((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1])
+                    + bias_grp2 < sat_thresh_grp2)
 
             # Identify groups with suspiciously large values in the second group
             # by comparing the change between group 1 and 2 to the dynamic range between
@@ -221,7 +228,7 @@ def flag_saturated_pixels(
             flagarray = (mask * dnu).astype(np.uint32)
 
             # Add them to the gdq array
-            if len(flagarray.shape) == 4:
+            if flagarray.ndim == 4:
                 np.bitwise_or(gdq[ints, 1, :, :], flagarray[ints, 1, :, :], gdq[ints, 1, :, :])
             else:
                 np.bitwise_or(gdq[ints, 1, :, :], flagarray, gdq[ints, 1, :, :])
@@ -241,7 +248,7 @@ def flag_saturated_pixels(
     n_floor = np.any(np.any(np.bitwise_and(gdq, ad_floor), axis=0), axis=0).sum()
     log.info("Detected %i A/D floor pixels", n_floor)
 
-    if len(pdq.shape) == 3:
+    if pdq.ndim == 3:
         num_superstripe = pdq.shape[0]
         pdq = np.bitwise_or(pdq, sat_dq[0:num_superstripe, 0, :, :])
     else:

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -116,9 +116,9 @@ def flag_saturated_pixels(
             # Update the running tally of all pixels that have ever
             # experienced saturation to account for this.
             if len(sat_thresh.shape) == 4:
-                previously_saturated |= (plane >= sat_thresh[ints, group, :, :])
+                previously_saturated |= plane >= sat_thresh[ints, group, :, :]
             else:
-                previously_saturated |= (plane >= sat_thresh)
+                previously_saturated |= plane >= sat_thresh
 
             flagarray = (previously_saturated * saturated).astype(np.uint32)
 
@@ -204,8 +204,7 @@ def flag_saturated_pixels(
             # Identify groups which we wouldn't expect to saturate by the third group,
             # on the basis of the first group
             scigp1 = data[ints, 0, :, :] - bias_grp2
-            mask = (((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1])
-                    + bias_grp2 < sat_thresh_grp2)
+            mask = ((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1]) + bias_grp2 < sat_thresh_grp2
 
             # Identify groups with suspiciously large values in the second group
             # by comparing the change between group 1 and 2 to the dynamic range between

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -122,9 +122,9 @@ def flag_saturated_pixels(
             # Update the running tally of all pixels that have ever
             # experienced saturation to account for this.
             if sat_thresh.ndim == 4:
-                previously_saturated |= (plane >= sat_thresh[ints, group, :, :])
+                previously_saturated |= plane >= sat_thresh[ints, group, :, :]
             else:
-                previously_saturated |= (plane >= sat_thresh)
+                previously_saturated |= plane >= sat_thresh
 
             flagarray = (previously_saturated * saturated).astype(np.uint32)
 
@@ -210,8 +210,7 @@ def flag_saturated_pixels(
             # Identify groups which we wouldn't expect to saturate by the third group,
             # on the basis of the first group
             scigp1 = data[ints, 0, :, :] - bias_grp2
-            mask = (((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1])
-                    + bias_grp2 < sat_thresh_grp2)
+            mask = ((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1]) + bias_grp2 < sat_thresh_grp2
 
             # Identify groups with suspiciously large values in the second group
             # by comparing the change between group 1 and 2 to the dynamic range between

--- a/src/stcal/saturation/saturation.py
+++ b/src/stcal/saturation/saturation.py
@@ -115,8 +115,11 @@ def flag_saturated_pixels(
 
             # Update the running tally of all pixels that have ever
             # experienced saturation to account for this.
+            if len(sat_thresh.shape) == 4:
+                previously_saturated |= (plane >= sat_thresh[ints, group, :, :])
+            else:
+                previously_saturated |= (plane >= sat_thresh)
 
-            previously_saturated |= plane >= sat_thresh
             flagarray = (previously_saturated * saturated).astype(np.uint32)
 
             gdq[ints, group, :, :] |= flagarray
@@ -185,20 +188,31 @@ def flag_saturated_pixels(
         # Add an additional pass to look for things saturating in the second group
         # that can be particularly tricky to identify
         if (read_pattern is not None) & (ngroups > 2):
+            if len(bias.shape) == 4:
+                bias_grp2 = bias[ints, 0, :, :]
+            else:
+                bias_grp2 = bias
+
+            if len(sat_thresh.shape) == 4:
+                sat_thresh_grp2 = sat_thresh[ints, 0, :, :]
+            else:
+                sat_thresh_grp2 = sat_thresh
+
             dq2 = gdq[ints, 1, :, :]
             dq3 = gdq[ints, 2, :, :]
 
             # Identify groups which we wouldn't expect to saturate by the third group,
             # on the basis of the first group
-            scigp1 = data[ints, 0, :, :] - bias
-            mask = ((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1]) + bias < sat_thresh
+            scigp1 = data[ints, 0, :, :] - bias_grp2
+            mask = (((scigp1 / np.mean(read_pattern[0])) * read_pattern[2][-1])
+                    + bias_grp2 < sat_thresh_grp2)
 
             # Identify groups with suspiciously large values in the second group
             # by comparing the change between group 1 and 2 to the dynamic range between
             # the group 1 and saturation threshold.  Flag any differences sufficiently large
             # that they could come from a saturating event in the last frame of the group.
             scigp2 = data[ints, 1, :, :] - data[ints, 0, :, :]
-            mask &= scigp2 > (sat_thresh - data[ints, 0, :, :]) / len(read_pattern[1])
+            mask &= scigp2 > (sat_thresh_grp2 - data[ints, 0, :, :]) / len(read_pattern[1])
 
             # Identify groups that are saturated in the third group but not yet flagged in the second
             gp3mask = (np.bitwise_and(dq3, saturated) != 0) & (np.bitwise_and(dq2, saturated) == 0)
@@ -208,7 +222,10 @@ def flag_saturated_pixels(
             flagarray = (mask * dnu).astype(np.uint32)
 
             # Add them to the gdq array
-            np.bitwise_or(gdq[ints, 1, :, :], flagarray, gdq[ints, 1, :, :])
+            if len(flagarray.shape) == 4:
+                np.bitwise_or(gdq[ints, 1, :, :], flagarray[ints, 1, :, :], gdq[ints, 1, :, :])
+            else:
+                np.bitwise_or(gdq[ints, 1, :, :], flagarray, gdq[ints, 1, :, :])
 
         # Check ZEROFRAME.
         if zframe is not None:
@@ -225,7 +242,11 @@ def flag_saturated_pixels(
     n_floor = np.any(np.any(np.bitwise_and(gdq, ad_floor), axis=0), axis=0).sum()
     log.info("Detected %i A/D floor pixels", n_floor)
 
-    pdq = np.bitwise_or(pdq, sat_dq)
+    if len(pdq.shape) == 3:
+        num_superstripe = pdq.shape[0]
+        pdq = np.bitwise_or(pdq, sat_dq[0:num_superstripe, 0, :, :])
+    else:
+        pdq = np.bitwise_or(pdq, sat_dq)
 
     return gdq, pdq, zframe
 

--- a/tests/test_saturation.py
+++ b/tests/test_saturation.py
@@ -6,8 +6,8 @@ Unit tests for saturation flagging
 
 from enum import IntEnum
 
-import pytest
 import numpy as np
+import pytest
 
 from stcal.saturation.saturation import flag_saturated_pixels
 
@@ -16,7 +16,7 @@ DQFLAGS = {"DO_NOT_USE": 1, "SATURATED": 2, "AD_FLOOR": 64, "NO_SAT_CHECK": 2097
 ATOD_LIMIT = 65535.0  # Hard DN limit of 16-bit A-to-D converter
 
 
-@pytest.mark.parametrize('use_4d', [True, False])
+@pytest.mark.parametrize("use_4d", [True, False])
 def test_basic_saturation_flagging(use_4d):
     # Create inputs, data, and saturation maps
     data = np.zeros((1, 5, 20, 20)).astype("float32")
@@ -48,7 +48,7 @@ def test_basic_saturation_flagging(use_4d):
     assert np.all(gdq[0, satindex:, 5, 5] == DQFLAGS["SATURATED"])
 
 
-@pytest.mark.parametrize('use_4d', [True, False])
+@pytest.mark.parametrize("use_4d", [True, False])
 def test_read_pattern_saturation_flagging(use_4d):
     """Check that the saturation threshold varies depending on how the reads
     are allocated into resultants."""
@@ -95,7 +95,7 @@ def test_read_pattern_saturation_flagging(use_4d):
     assert gdq[0, 2, 5, 5] == DQFLAGS["DO_NOT_USE"]
 
 
-@pytest.mark.parametrize('use_4d', [True, False])
+@pytest.mark.parametrize("use_4d", [True, False])
 def test_read_pattern_saturation_flagging_dnu(use_4d):
     """Check that the saturation threshold varies depending on how the reads
     are allocated into resultants. First resultant expected to have DNU while
@@ -140,7 +140,7 @@ def test_read_pattern_saturation_flagging_dnu(use_4d):
     assert np.all(gdq[0, 2:, 5, 5] == [DQFLAGS["DO_NOT_USE"], DQFLAGS["SATURATED"], DQFLAGS["SATURATED"]])
 
 
-@pytest.mark.parametrize('use_4d', [True, False])
+@pytest.mark.parametrize("use_4d", [True, False])
 def test_group2_saturation_flagging_with_bias(use_4d):
     """Flag group 2 saturation in frame-averaged data with significant bias.
 
@@ -217,7 +217,7 @@ def test_group2_saturation_flagging_with_bias(use_4d):
     assert np.all(gdq[0, :, 15, 15] == 0)
 
 
-@pytest.mark.parametrize('use_4d', [True, False])
+@pytest.mark.parametrize("use_4d", [True, False])
 def test_no_sat_check_at_limit(use_4d):
     """Test to verify that pixels at the A-to-D limit (65535), but flagged with
     NO_SAT_CHECK do NOT get flagged as saturated, and that their neighbors
@@ -257,7 +257,7 @@ def test_no_sat_check_at_limit(use_4d):
     assert np.all(pdq[..., 5, 5] == DQFLAGS["NO_SAT_CHECK"])
 
 
-@pytest.mark.parametrize('use_4d', [True, False])
+@pytest.mark.parametrize("use_4d", [True, False])
 def test_adjacent_pixel_flagging(use_4d):
     """Test to see if specified number of adjacent pixels next to a saturated
     pixel are also flagged, and that the edges of the dq array are treated
@@ -317,7 +317,7 @@ def test_adjacent_pixel_flagging(use_4d):
     )
 
 
-@pytest.mark.parametrize('use_4d', [True, False])
+@pytest.mark.parametrize("use_4d", [True, False])
 def test_zero_frame(use_4d):
     """
     Pixel 0 has fully saturated ramp with saturated frame 0.

--- a/tests/test_saturation.py
+++ b/tests/test_saturation.py
@@ -6,6 +6,7 @@ Unit tests for saturation flagging
 
 from enum import IntEnum
 
+import pytest
 import numpy as np
 
 from stcal.saturation.saturation import flag_saturated_pixels
@@ -15,13 +16,19 @@ DQFLAGS = {"DO_NOT_USE": 1, "SATURATED": 2, "AD_FLOOR": 64, "NO_SAT_CHECK": 2097
 ATOD_LIMIT = 65535.0  # Hard DN limit of 16-bit A-to-D converter
 
 
-def test_basic_saturation_flagging():
+@pytest.mark.parametrize('use_4d', [True, False])
+def test_basic_saturation_flagging(use_4d):
     # Create inputs, data, and saturation maps
     data = np.zeros((1, 5, 20, 20)).astype("float32")
     gdq = np.zeros((1, 5, 20, 20)).astype("uint32")
-    pdq = np.zeros((20, 20)).astype("uint32")
-    sat_thresh = np.ones((20, 20)) * 100000.0
-    sat_dq = np.zeros((20, 20)).astype("uint32")
+    if use_4d:
+        pdq = np.zeros((1, 5, 20, 20)).astype("uint32")
+        sat_thresh = np.ones((1, 5, 20, 20)) * 100000.0
+        sat_dq = np.zeros((1, 5, 20, 20)).astype("uint32")
+    else:
+        pdq = np.zeros((20, 20)).astype("uint32")
+        sat_thresh = np.ones((20, 20)) * 100000.0
+        sat_dq = np.zeros((20, 20)).astype("uint32")
 
     # Add ramp values up to the saturation limit
     data[0, 0, 5, 5] = 0
@@ -32,7 +39,7 @@ def test_basic_saturation_flagging():
 
     # Set saturation value in the saturation model
     satvalue = 60000
-    sat_thresh[5, 5] = satvalue
+    sat_thresh[..., 5, 5] = satvalue
 
     gdq, pdq, _ = flag_saturated_pixels(data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, DQFLAGS)
 
@@ -41,16 +48,22 @@ def test_basic_saturation_flagging():
     assert np.all(gdq[0, satindex:, 5, 5] == DQFLAGS["SATURATED"])
 
 
-def test_read_pattern_saturation_flagging():
+@pytest.mark.parametrize('use_4d', [True, False])
+def test_read_pattern_saturation_flagging(use_4d):
     """Check that the saturation threshold varies depending on how the reads
     are allocated into resultants."""
 
     # Create inputs, data, and saturation maps
     data = np.zeros((1, 5, 20, 20)).astype("float32")
     gdq = np.zeros((1, 5, 20, 20)).astype("uint32")
-    pdq = np.zeros((20, 20)).astype("uint32")
-    sat_thresh = np.ones((20, 20)) * 100000.0
-    sat_dq = np.zeros((20, 20)).astype("uint32")
+    if use_4d:
+        pdq = np.zeros((1, 5, 20, 20)).astype("uint32")
+        sat_thresh = np.ones((1, 5, 20, 20)) * 100000.0
+        sat_dq = np.zeros((1, 5, 20, 20)).astype("uint32")
+    else:
+        pdq = np.zeros((20, 20)).astype("uint32")
+        sat_thresh = np.ones((20, 20)) * 100000.0
+        sat_dq = np.zeros((20, 20)).astype("uint32")
 
     # Add ramp values up to the saturation limit
     data[0, 0, 5, 5] = 0
@@ -61,7 +74,7 @@ def test_read_pattern_saturation_flagging():
 
     # Set saturation value in the saturation model
     satvalue = 60000
-    sat_thresh[5, 5] = satvalue
+    sat_thresh[..., 5, 5] = satvalue
 
     # set read_pattern to have many reads in the third resultant, so that
     # its mean exposure time is much smaller than its last read time
@@ -82,7 +95,8 @@ def test_read_pattern_saturation_flagging():
     assert gdq[0, 2, 5, 5] == DQFLAGS["DO_NOT_USE"]
 
 
-def test_read_pattern_saturation_flagging_dnu():
+@pytest.mark.parametrize('use_4d', [True, False])
+def test_read_pattern_saturation_flagging_dnu(use_4d):
     """Check that the saturation threshold varies depending on how the reads
     are allocated into resultants. First resultant expected to have DNU while
     PR#321 band-aid still in place."""
@@ -90,9 +104,14 @@ def test_read_pattern_saturation_flagging_dnu():
     # Create inputs, data, and saturation maps
     data = np.zeros((1, 5, 20, 20)).astype("float32")
     gdq = np.zeros((1, 5, 20, 20)).astype("uint32")
-    pdq = np.zeros((20, 20)).astype("uint32")
-    sat_thresh = np.ones((20, 20)) * 100000.0
-    sat_dq = np.zeros((20, 20)).astype("uint32")
+    if use_4d:
+        pdq = np.zeros((1, 5, 20, 20)).astype("uint32")
+        sat_thresh = np.ones((1, 5, 20, 20)) * 100000.0
+        sat_dq = np.zeros((1, 5, 20, 20)).astype("uint32")
+    else:
+        pdq = np.zeros((20, 20)).astype("uint32")
+        sat_thresh = np.ones((20, 20)) * 100000.0
+        sat_dq = np.zeros((20, 20)).astype("uint32")
 
     # Add ramp values up to the saturation limit
     data[0, 0, 5, 5] = 0
@@ -103,7 +122,7 @@ def test_read_pattern_saturation_flagging_dnu():
 
     # Set saturation value in the saturation model
     satvalue = 60000
-    sat_thresh[5, 5] = satvalue
+    sat_thresh[..., 5, 5] = satvalue
 
     # set read_pattern to have many reads in the third resultant, so that
     # its mean exposure time is much smaller than its last read time
@@ -121,7 +140,8 @@ def test_read_pattern_saturation_flagging_dnu():
     assert np.all(gdq[0, 2:, 5, 5] == [DQFLAGS["DO_NOT_USE"], DQFLAGS["SATURATED"], DQFLAGS["SATURATED"]])
 
 
-def test_group2_saturation_flagging_with_bias():
+@pytest.mark.parametrize('use_4d', [True, False])
+def test_group2_saturation_flagging_with_bias(use_4d):
     """Flag group 2 saturation in frame-averaged data with significant bias.
 
     Saturation in frame-averaged groups may not exceed the saturation threshold
@@ -133,10 +153,16 @@ def test_group2_saturation_flagging_with_bias():
     # Create inputs, data, and saturation maps
     data = np.zeros((1, 5, 20, 20)).astype("float32")
     gdq = np.zeros((1, 5, 20, 20)).astype("uint32")
-    pdq = np.zeros((20, 20)).astype("uint32")
-    sat_thresh = np.ones((20, 20)) * 100000.0
-    sat_dq = np.zeros((20, 20)).astype("uint32")
-    bias = np.zeros((20, 20))
+    if use_4d:
+        pdq = np.zeros((1, 5, 20, 20)).astype("uint32")
+        sat_thresh = np.ones((1, 5, 20, 20)) * 100000.0
+        sat_dq = np.zeros((1, 5, 20, 20)).astype("uint32")
+        bias = np.zeros((1, 5, 20, 20))
+    else:
+        pdq = np.zeros((20, 20)).astype("uint32")
+        sat_thresh = np.ones((20, 20)) * 100000.0
+        sat_dq = np.zeros((20, 20)).astype("uint32")
+        bias = np.zeros((20, 20))
 
     # Add ramp values up to the saturation limit
     # Bias is 15000
@@ -146,7 +172,7 @@ def test_group2_saturation_flagging_with_bias():
     # averaged over 5 frames this only looks like a 8000 count jump in group 2
     # but group 3 signal saturates
 
-    bias[5, 5] = 15000
+    bias[..., 5, 5] = 15000
 
     data[0, 0, 5, 5] = 18000
     data[0, 1, 5, 5] = 31000
@@ -157,14 +183,14 @@ def test_group2_saturation_flagging_with_bias():
     # Add another pixel with bias of 15000, but no source flux
     # pixel counts are 15000 > sat_thresh/5, but should not be flagged as
     # saturated.
-    bias[15, 15] = 15000
+    bias[..., 15, 15] = 15000
 
     data[0, :, 15, 15] = 15000
 
     # Set saturation value in the saturation model
     satvalue = 60000
-    sat_thresh[5, 5] = satvalue
-    sat_thresh[15, 15] = satvalue
+    sat_thresh[..., 5, 5] = satvalue
+    sat_thresh[..., 15, 15] = satvalue
 
     # set read_pattern to have 5 reads per group.
     read_pattern = [
@@ -191,7 +217,8 @@ def test_group2_saturation_flagging_with_bias():
     assert np.all(gdq[0, :, 15, 15] == 0)
 
 
-def test_no_sat_check_at_limit():
+@pytest.mark.parametrize('use_4d', [True, False])
+def test_no_sat_check_at_limit(use_4d):
     """Test to verify that pixels at the A-to-D limit (65535), but flagged with
     NO_SAT_CHECK do NOT get flagged as saturated, and that their neighbors
     also do NOT get flagged."""
@@ -199,9 +226,14 @@ def test_no_sat_check_at_limit():
     # Create inputs, data, and saturation maps
     data = np.zeros((1, 5, 10, 10)).astype("float32")
     gdq = np.zeros((1, 5, 10, 10)).astype("uint32")
-    pdq = np.zeros((10, 10)).astype("uint32")
-    sat_thresh = np.ones((10, 10)) * 50000.0
-    sat_dq = np.zeros((10, 10)).astype("uint32")
+    if use_4d:
+        pdq = np.zeros((1, 5, 10, 10)).astype("uint32")
+        sat_thresh = np.ones((1, 5, 10, 10)) * 50000.0
+        sat_dq = np.zeros((1, 5, 10, 10)).astype("uint32")
+    else:
+        pdq = np.zeros((10, 10)).astype("uint32")
+        sat_thresh = np.ones((10, 10)) * 50000.0
+        sat_dq = np.zeros((10, 10)).astype("uint32")
 
     # Add ramp values that are flat-lined at the A-to-D limit,
     # which is well above the sat_thresh of 50,000.
@@ -212,7 +244,7 @@ def test_no_sat_check_at_limit():
     data[0, 4, 5, 5] = ATOD_LIMIT
 
     # Set a DQ value of NO_SAT_CHECK
-    sat_dq[5, 5] = DQFLAGS["NO_SAT_CHECK"]
+    sat_dq[..., 5, 5] = DQFLAGS["NO_SAT_CHECK"]
 
     # Run the saturation flagging
     gdq, pdq, _ = flag_saturated_pixels(data, gdq, pdq, sat_thresh, sat_dq, ATOD_LIMIT, DQFLAGS, 1)
@@ -222,10 +254,11 @@ def test_no_sat_check_at_limit():
     # Also make sure that NO_SAT_CHECK has been propagated to the
     # pixeldq array.
     assert np.all(gdq[0, :, 4:6, 4:6] != DQFLAGS["SATURATED"])
-    assert pdq[5, 5] == DQFLAGS["NO_SAT_CHECK"]
+    assert np.all(pdq[..., 5, 5] == DQFLAGS["NO_SAT_CHECK"])
 
 
-def test_adjacent_pixel_flagging():
+@pytest.mark.parametrize('use_4d', [True, False])
+def test_adjacent_pixel_flagging(use_4d):
     """Test to see if specified number of adjacent pixels next to a saturated
     pixel are also flagged, and that the edges of the dq array are treated
     correctly when this is done."""
@@ -233,9 +266,14 @@ def test_adjacent_pixel_flagging():
     # Create inputs, data, and saturation maps
     data = np.ones((1, 2, 5, 5)).astype("float32")
     gdq = np.zeros((1, 2, 5, 5)).astype("uint32")
-    pdq = np.zeros((5, 5)).astype("uint32")
-    sat_thresh = np.ones((5, 5)) * 60000  # sat. thresh is 60000
-    sat_dq = np.zeros((5, 5)).astype("uint32")
+    if use_4d:
+        pdq = np.zeros((1, 2, 5, 5)).astype("uint32")
+        sat_thresh = np.ones((1, 2, 5, 5)) * 60000  # sat. thresh is 60000
+        sat_dq = np.zeros((1, 2, 5, 5)).astype("uint32")
+    else:
+        pdq = np.zeros((5, 5)).astype("uint32")
+        sat_thresh = np.ones((5, 5)) * 60000  # sat. thresh is 60000
+        sat_dq = np.zeros((5, 5)).astype("uint32")
 
     nints, ngroups, nrows, ncols = data.shape
 
@@ -279,7 +317,8 @@ def test_adjacent_pixel_flagging():
     )
 
 
-def test_zero_frame():
+@pytest.mark.parametrize('use_4d', [True, False])
+def test_zero_frame(use_4d):
     """
     Pixel 0 has fully saturated ramp with saturated frame 0.
     Pixel 1 has fully saturated ramp with good frame 0.
@@ -301,10 +340,15 @@ def test_zero_frame():
     # Create inputs, data, and saturation maps
     data = np.zeros(dims, dtype=float)
     gdq = np.zeros(dims, dtype=np.uint32)
-    pdq = np.zeros((nrows, ncols), dtype=np.uint32)
     zfrm = np.zeros((nints, nrows, ncols), dtype=float)
-    ref = np.zeros((nrows, ncols), dtype=float)
-    rdq = np.zeros((nrows, ncols), dtype=np.uint32)
+    if use_4d:
+        pdq = np.zeros(dims, dtype=np.uint32)
+        ref = np.zeros(dims, dtype=float)
+        rdq = np.zeros(dims, dtype=np.uint32)
+    else:
+        pdq = np.zeros((nrows, ncols), dtype=np.uint32)
+        ref = np.zeros((nrows, ncols), dtype=float)
+        rdq = np.zeros((nrows, ncols), dtype=np.uint32)
 
     data[0, :, 0, 0] = np.array(darr1)
     data[0, :, 0, 1] = np.array(darr2)
@@ -316,7 +360,7 @@ def test_zero_frame():
 
     zfrm[0, 0, :] = np.array(zarr)
     zfrm[1, 0, :] = np.array([zarr[1], zarr[0], zarr[2]])
-    ref[0, :] = np.array(rarr)
+    ref[..., 0, :] = np.array(rarr)
 
     # dictionary with required DQ flags
     dqflags = {"DO_NOT_USE": 1, "SATURATED": 2, "AD_FLOOR": 64, "NO_SAT_CHECK": 2097152}


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Partially resolves [JP-4097](https://jira.stsci.edu/browse/JP-4097)
<!-- If this PR closes a GitHub issue, reference it here by its number -->

This PR makes changes to level 1 step algorithms to allow 4-dimensional reference file arrays where 2-dimensional arrays were assumed up to this point. This is meant to solve issues caused by multistripe data from JWST, where distinct, possibly disjoint regions of detector space are read separately, such that each integration will not be situated at the same location in the detector frame. A 2-d reference array could be used, but the complex logic needed to reproduce the multistripe detector readout pattern would need to be replicated in stcal code, which I wanted to avoid.

The simplest solution I could find was to build a 4-d reference array in JWST step code which should be useable in a 1:1 fashion to the science data array. This required modifying some steps which to this point could assume that the reference array would always be of a shape representing the two-dimensional detector array.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
