### PR TITLE
Prepare for moving `construct_wcs_corrector` out to pipelines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "shapely>=2.1.1",
   "spherical-geometry>=1.3,<1.5",
   "stsci.imagestats>=1.8.3,<1.9",
-  "tweakwcs>=0.8.8,<0.9",
+  "tweakwcs>=0.9",
 ]
 license-files = ["LICENSE"]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "shapely>=2.1.1",
   "spherical-geometry>=1.3,<1.5",
   "stsci.imagestats>=1.8.3,<1.9",
-  "tweakwcs>=0.9",
+  "tweakwcs>=0.9,<0.10",
 ]
 license-files = ["LICENSE"]
 dynamic = ["version"]

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -68,6 +68,10 @@ def relative_align(  # noqa: D103
         yoffset=yoffset,
     )
 
+    # save sky coordinates of the bounding box computed with the original WCS:
+    for corrector in correctors:
+        corrector.meta["original_skycoord"] = _wcs_to_skycoord(corrector.wcs)
+
     try:
         align_wcs(
             correctors,
@@ -175,7 +179,10 @@ def absolute_align(  # noqa: D103
     # easy to recognize when alignment to GAIA was being performed
     # as opposed to the group_id values used for relative alignment
     # earlier in this step.
+    # Also save sky coordinates of the bounding box computed with
+    # the original WCS.
     for corrector in correctors:
+        corrector.meta["original_skycoord"] = _wcs_to_skycoord(corrector.wcs)
         corrector.meta["group_id"] = 987654
         if "fit_info" in corrector.meta and "REFERENCE" in corrector.meta["fit_info"]["status"]:
             del corrector.meta["fit_info"]
@@ -408,6 +415,5 @@ def construct_wcs_corrector(
             "catalog": catalog,
             "name": catalog.meta.get("name"),
             "group_id": group_id,
-            "original_skycoord": _wcs_to_skycoord(wcs),
         },
     )

--- a/src/stcal/tweakreg/tweakreg.py
+++ b/src/stcal/tweakreg/tweakreg.py
@@ -68,10 +68,6 @@ def relative_align(  # noqa: D103
         yoffset=yoffset,
     )
 
-    # save sky coordinates of the bounding box computed with the original WCS:
-    for corrector in correctors:
-        corrector.meta["original_skycoord"] = _wcs_to_skycoord(corrector.wcs)
-
     try:
         align_wcs(
             correctors,
@@ -182,7 +178,6 @@ def absolute_align(  # noqa: D103
     # Also save sky coordinates of the bounding box computed with
     # the original WCS.
     for corrector in correctors:
-        corrector.meta["original_skycoord"] = _wcs_to_skycoord(corrector.wcs)
         corrector.meta["group_id"] = 987654
         if "fit_info" in corrector.meta and "REFERENCE" in corrector.meta["fit_info"]["status"]:
             del corrector.meta["fit_info"]
@@ -356,7 +351,7 @@ def _is_wcs_correction_small(
         max_corr = 2 * (max(abs(xoffset), abs(yoffset)) + tolerance) * u.arcsec
     for corrector in correctors:
         aligned_skycoord = _wcs_to_skycoord(corrector.wcs)
-        original_skycoord = corrector.meta["original_skycoord"]
+        original_skycoord = _wcs_to_skycoord(corrector.original_wcs)
         separation = original_skycoord.separation(aligned_skycoord)
         if not (separation < max_corr).all():
             # Large corrections are typically a result of source

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -149,15 +149,11 @@ def fake_correctors(offset):
     twcs.bounding_box = wcs.bounding_box
 
     class FakeCorrector:
-        def __init__(self, wcs, original_skycoord):
+        def __init__(self, original_wcs, wcs):
+            self.original_wcs = original_wcs
             self.wcs = wcs
-            self._original_skycoord = original_skycoord
 
-        @property
-        def meta(self):
-            return {"original_skycoord": self._original_skycoord}
-
-    return [FakeCorrector(twcs, _wcs_to_skycoord(wcs))]
+    return [FakeCorrector(wcs, twcs)]
 
 
 @pytest.mark.parametrize(("offset", "is_good"), [(1 / 3600, True), (11 / 3600, False)])

--- a/tests/test_tweakreg.py
+++ b/tests/test_tweakreg.py
@@ -20,7 +20,6 @@ from stcal.tweakreg.tweakreg import (
     _is_wcs_correction_small,
     _parse_refcat,
     _parse_sky_centroid,
-    _wcs_to_skycoord,
     absolute_align,
     construct_wcs_corrector,
     relative_align,


### PR DESCRIPTION
This PR is the first step of moving `construct_wcs_corrector ` to pipelines. This is the approach that I favor for fixing https://github.com/spacetelescope/stcal/issues/528 in conjunction with a new release (0.9.0) of `tweakwcs` after https://github.com/spacetelescope/tweakwcs/pull/243 is merged.

Associated Prs:
https://github.com/spacetelescope/romancal/pull/2219
https://github.com/spacetelescope/jwst/pull/10306

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
