### PR TITLE
JP-4272: Use last 25% of the ramp for dark extrapolation

### DIFF
--- a/changes/532.dark_current.rst
+++ b/changes/532.dark_current.rst
@@ -1,0 +1,1 @@
+Fix extrapolation of short darks to use the last 25% of the ramp instead of the last two groups to minimize extrapolation problems for noisy darks while still ignoring artifacts at the start of the ramp.

--- a/src/stcal/dark_current/dark_sub.py
+++ b/src/stcal/dark_current/dark_sub.py
@@ -412,8 +412,10 @@ def extrapolate_dark(dark_data, ngroups):
     """
 
     def _extrapolate_int(arr, ngroups):
-        """Extrapolate using rate derived from difference of last two groups."""
-        rate_arr = arr[-1, :, :] - arr[-2, :, :]
+        """Extrapolate using rate derived from the last 25% of the ramp."""
+        ngroups_orig = arr.shape[0]
+        group_75pct = int(0.75 * ngroups_orig)
+        rate_arr = (arr[-1, :, :] - arr[group_75pct, :, :]) / (ngroups_orig - group_75pct)
         new_groups = (
             np.broadcast_to(np.arange(1, ngroups + 1).reshape(-1, 1, 1), (ngroups, *rate_arr.shape))
             * rate_arr


### PR DESCRIPTION
Resolves [JP-4272](https://jira.stsci.edu/browse/JP-4272)

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
