### PR TITLE
force anonymous s3 access

### DIFF
--- a/changes/535.tweakreg.rst
+++ b/changes/535.tweakreg.rst
@@ -1,0 +1,1 @@
+Force anonymous S3 access when fetching S3 hosted GAIA data.

--- a/src/stcal/tweakreg/_s3_catalog.py
+++ b/src/stcal/tweakreg/_s3_catalog.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import functools
+import urllib.parse
 
 import numpy as np
 import pyarrow.csv as csv
@@ -69,8 +70,10 @@ def _correct_for_proper_motion(catalog, epoch):
 
 @functools.lru_cache
 def _get_partition_info(uri):
+    parsed = urllib.parse.urlparse(uri)
     # open the filesystem here to allow this to be cached (FileSystem instances aren't hashable)
-    fs, fs_path = pyarrow.fs.FileSystem.from_uri(uri)
+    fs = pyarrow.fs.S3FileSystem(anonymous=True)
+    fs_path = (parsed.netloc + parsed.path).rstrip("/")
     csv_file = csv.read_csv(fs.open_input_file(fs_path + "/partition_info.csv"))
     return fs, fs_path, np.vstack((csv_file["Norder"].to_numpy(), csv_file["Npix"].to_numpy())).T
 


### PR DESCRIPTION
Change s3 catalog access to force anonymous authentication. For some systems that have configured (e.g. user-wide) credentials non-anonymous access can result in an authentication failure if the configured credentials do not have access to the stpubdata bucket or are otherwise invalid. Forcing anonymous access fixes these failures by ignoring user configuration.

roman all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/23440768666
jwst shows only unrelated failures: https://github.com/spacetelescope/RegressionTests/actions/runs/23440788398

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
