### PR TITLE
fix ramp fitting memory leak of orig_gdq

### DIFF
--- a/changes/539.ramp_fitting.rst
+++ b/changes/539.ramp_fitting.rst
@@ -1,0 +1,1 @@
+Fix memory leak of orig_gdq.

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -1111,6 +1111,7 @@ clean_ramp_data(struct ramp_data *rd) /* The ramp fitting data structure */
 
     Py_XDECREF(rd->data);
     Py_XDECREF(rd->groupdq);
+    Py_XDECREF(rd->orig_gdq);
     Py_XDECREF(rd->pixeldq);
     Py_XDECREF(rd->zframe);
     Py_XDECREF(rd->dcurrent);

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -1654,7 +1654,8 @@ def test_refcounter():
     assert b_dc == a_dc
 
 
-def test_cext_chargeloss():
+@pytest.mark.parametrize("i", range(10))
+def test_cext_chargeloss(i):
     """
     Testing the recomputation of read noise due to CHARGELOSS.  Wherever
     the CHARGELOSS flag is set, ramp fitting is run using the CHARGELOSS
@@ -1671,7 +1672,7 @@ def test_cext_chargeloss():
 
     The slope should be the same for all pixels.  Variances differ.
     """
-    nints, ngroups, nrows, ncols = 1, 10, 1, 4
+    nints, ngroups, nrows, ncols = 1, 10, 1000, 4000
     rnval, gval = 0.7071, 1.0
     frame_time, nframes, groupgap = 10.6, 1, 0
 


### PR DESCRIPTION
slope_fitter.c increments the reference count for `RampData.orig_gdq`:
https://github.com/spacetelescope/stcal/blob/5ec0ba55235a74a7d233ebfd1645daf2ced10af9/src/stcal/ramp_fitting/src/slope_fitter.c#L2043
but does not decrement the reference during cleanup. The resulting leak can be seen if running `tests/test_ramp_fitting.py::test_cext_chargeloss` 10x times (modifying the test to use a larger number of rows and columns):
<img width="1086" height="350" alt="Screenshot 2026-04-27 at 12 24 23 PM" src="https://github.com/user-attachments/assets/3c07565d-1f87-424a-ab9e-5465ca6918f2" />

This PR adds the missing reference decrement, repeating the above test no longer shows a leak:

<img width="1092" height="365" alt="Screenshot 2026-04-27 at 12 25 25 PM" src="https://github.com/user-attachments/assets/6c58829f-1eb5-4211-9080-66ab3cc1115d" />

Since this doesn't modify code used by roman only jwst regtests were run:
jwst https://github.com/spacetelescope/RegressionTests/actions/runs/25007010730
all passed

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
