### PR TITLE
Update resampled output image's background level and status

### DIFF
--- a/changes/542.resample.rst
+++ b/changes/542.resample.rst
@@ -1,0 +1,2 @@
+Corrected the "level" and "subtracted" keys in the output model dictionary to
+show correct values for the resampled image.

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -506,6 +506,9 @@ class Resample:
             "start_time": None,
             "end_time": None,
             "duration": 0.0,
+            # background level
+            "level": 0.0,
+            "subtracted": True,
         }
 
         if self._enable_var:

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -507,8 +507,8 @@ class Resample:
             "end_time": None,
             "duration": 0.0,
             # background level
-            "level": 0.0,
-            "subtracted": True,
+            "level": None,
+            "subtracted": False,
         }
 
         if self._enable_var:

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -95,6 +95,8 @@ def test_resample_mostly_defaults(weight_type):
 
     assert resample.output_model["pointings"] == nmodels
     assert resample.output_model["exposure_time"] == ttime
+    assert resample.output_model["level"] == 0.0
+    assert resample.output_model["subtracted"] is True
 
     # next assert assumes constant IVM
     assert np.allclose(

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -95,8 +95,8 @@ def test_resample_mostly_defaults(weight_type):
 
     assert resample.output_model["pointings"] == nmodels
     assert resample.output_model["exposure_time"] == ttime
-    assert resample.output_model["level"] == 0.0
-    assert resample.output_model["subtracted"] is True
+    assert resample.output_model["level"] == None
+    assert resample.output_model["subtracted"] is False
 
     # next assert assumes constant IVM
     assert np.allclose(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [AL-1057](https://jira.stsci.edu/browse/AL-1057)

When attempting to resample (again) an already resampled image, the resulting double-resampled image often has an unexplained background offset compared to expected (single-resampled) image. After analysis, this is caused by resample populating most meta of the output resampled image from an input cal image and not updating background-related fields.

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
