### PR TITLE
Allow sregion_to_footprint to accept sregions containing multiple polygons

### DIFF
--- a/changes/543.alignment.rst
+++ b/changes/543.alignment.rst
@@ -1,0 +1,1 @@
+Allow combine_sregions to accept input s_regions with multiple polygons within them, as well as input s_regions with different numbers of vertices

--- a/changes/543.breaking.rst
+++ b/changes/543.breaking.rst
@@ -1,0 +1,1 @@
+Change API of alignment.util.sregion_to_footprint to always return a list of footprints, covering the case where input S_REGION string contains multiple polygons.

--- a/src/stcal/alignment/resample_utils.py
+++ b/src/stcal/alignment/resample_utils.py
@@ -38,18 +38,31 @@ def combine_sregions(sregion_list, det2world, intersect_footprint=None):
     ValueError
         If there is no overlap between the input s_regions and the intersection footprint.
     """
-    footprints = np.array(
-        [
-            util.sregion_to_footprint(sregion) if isinstance(sregion, str) else sregion
-            for sregion in sregion_list
-        ]
-    )
+    footprints = []
+    for sregion in sregion_list:
+        if isinstance(sregion, str):
+            result = util.sregion_to_footprint(sregion)
+            # sregion_to_footprint can return either a single footprint or a list of footprints
+            # depending on if the string contained multiple polygons.
+            if isinstance(result, list):
+                footprints.extend(result)
+            else:
+                footprints.append(result)
+        else:
+            footprints.append(sregion)
 
     # convert from world to pixel coordinates
-    footprints_flat = footprints.reshape(-1, 2)
+    # footprints may have different numbers of vertices, so we flatten, transform, then re-split
+    sizes = [len(fp) for fp in footprints]
+    footprints_flat = np.vstack(footprints)
     world2det = det2world.inverse
     x, y = world2det(footprints_flat[:, 0], footprints_flat[:, 1])
-    footprints_pixels = np.vstack([x, y]).T.reshape(footprints.shape)
+    pixels_flat = np.vstack([x, y]).T
+    footprints_pixels = []
+    idx = 0
+    for size in sizes:
+        footprints_pixels.append(pixels_flat[idx : idx + size])
+        idx += size
 
     # combine footprints with Shapely
     combined_polygons = combine_footprints(footprints_pixels)

--- a/src/stcal/alignment/resample_utils.py
+++ b/src/stcal/alignment/resample_utils.py
@@ -41,13 +41,7 @@ def combine_sregions(sregion_list, det2world, intersect_footprint=None):
     footprints = []
     for sregion in sregion_list:
         if isinstance(sregion, str):
-            result = util.sregion_to_footprint(sregion)
-            # sregion_to_footprint can return either a single footprint or a list of footprints
-            # depending on if the string contained multiple polygons.
-            if isinstance(result, list):
-                footprints.extend(result)
-            else:
-                footprints.append(result)
+            footprints.extend(util.sregion_to_footprint(sregion))
         else:
             footprints.append(sregion)
 

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -323,9 +323,6 @@ def sregion_to_footprint(s_region: str) -> np.ndarray | list[np.ndarray]:
     """
     Parse the s_region string and return the footprint as a list of Nx2 arrays.
 
-    This needs to be a list to account for the case that the input string contains
-    multiple polygons.
-
     Parameters
     ----------
     s_region : str
@@ -334,8 +331,8 @@ def sregion_to_footprint(s_region: str) -> np.ndarray | list[np.ndarray]:
     Returns
     -------
     footprint : np.ndarray or list[np.ndarray]
-        If the S_REGION contains a single polygon, returns a 2D array of shape (N, 2).
-        If the S_REGION contains multiple polygons, returns a list of such arrays.
+        If the input contains a single polygon, returns a 2D array of shape (N, 2).
+        If the input contains multiple polygons, returns a list of such arrays.
     """
     polygons = re.split(r"POLYGON\s+ICRS\s*", s_region, flags=re.IGNORECASE)
     footprints = []

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -319,9 +319,12 @@ def calc_rotation_matrix(roll_ref: float, v3i_yangle: float, vparity: int = 1) -
     return [pc1_1, pc1_2, pc2_1, pc2_2]
 
 
-def sregion_to_footprint(s_region: str) -> np.ndarray:
+def sregion_to_footprint(s_region: str) -> np.ndarray | list[np.ndarray]:
     """
-    Parse the s_region string and return the footprint as an Nx2 array.
+    Parse the s_region string and return the footprint as a list of Nx2 arrays.
+
+    This needs to be a list to account for the case that the input string contains
+    multiple polygons.
 
     Parameters
     ----------
@@ -330,11 +333,21 @@ def sregion_to_footprint(s_region: str) -> np.ndarray:
 
     Returns
     -------
-    footprint : np.ndarray
-        A 2D array of the footprint of the region, shape (N, 2)
+    footprint : np.ndarray or list[np.ndarray]
+        If the S_REGION contains a single polygon, returns a 2D array of shape (N, 2).
+        If the S_REGION contains multiple polygons, returns a list of such arrays.
     """
-    no_prefix = re.sub(r"[a-zA-Z]", "", s_region)
-    return np.array(no_prefix.split(), dtype=float).reshape(-1, 2)
+    polygons = re.split(r"POLYGON\s+ICRS\s*", s_region, flags=re.IGNORECASE)
+    footprints = []
+    for polygon in polygons:
+        polygon = polygon.strip()
+        if not polygon:
+            continue
+        coords = np.array(polygon.split(), dtype=float).reshape(-1, 2)
+        footprints.append(coords)
+    if len(footprints) == 1:
+        return footprints[0]
+    return footprints
 
 
 def _compute_bounding_box_with_offsets(
@@ -492,9 +505,17 @@ def wcs_from_sregions(
         The WCS object corresponding to the combined input footprints.
 
     """
-    footprints = [
-        sregion_to_footprint(s_region) if isinstance(s_region, str) else s_region for s_region in footprints
-    ]
+    parsed_footprints = []
+    for s_region in footprints:
+        if isinstance(s_region, str):
+            result = sregion_to_footprint(s_region)
+            if isinstance(result, list):
+                parsed_footprints.extend(result)
+            else:
+                parsed_footprints.append(result)
+        else:
+            parsed_footprints.append(s_region)
+    footprints = parsed_footprints
     fiducial = _calculate_fiducial(footprints, crval=crval)
     crval = fiducial
     v3yangle = np.deg2rad(ref_wcsinfo["v3yangle"])

--- a/src/stcal/alignment/util.py
+++ b/src/stcal/alignment/util.py
@@ -319,7 +319,7 @@ def calc_rotation_matrix(roll_ref: float, v3i_yangle: float, vparity: int = 1) -
     return [pc1_1, pc1_2, pc2_1, pc2_2]
 
 
-def sregion_to_footprint(s_region: str) -> np.ndarray | list[np.ndarray]:
+def sregion_to_footprint(s_region: str) -> list[np.ndarray]:
     """
     Parse the s_region string and return the footprint as a list of Nx2 arrays.
 
@@ -330,9 +330,9 @@ def sregion_to_footprint(s_region: str) -> np.ndarray | list[np.ndarray]:
 
     Returns
     -------
-    footprint : np.ndarray or list[np.ndarray]
-        If the input contains a single polygon, returns a 2D array of shape (N, 2).
-        If the input contains multiple polygons, returns a list of such arrays.
+    footprints : list[np.ndarray]
+        A list of 2D arrays of shape (N, 2), one per polygon in the S_REGION string.
+        A single-polygon S_REGION returns a list of length one.
     """
     polygons = re.split(r"POLYGON\s+ICRS\s*", s_region, flags=re.IGNORECASE)
     footprints = []
@@ -342,8 +342,6 @@ def sregion_to_footprint(s_region: str) -> np.ndarray | list[np.ndarray]:
             continue
         coords = np.array(polygon.split(), dtype=float).reshape(-1, 2)
         footprints.append(coords)
-    if len(footprints) == 1:
-        return footprints[0]
     return footprints
 
 
@@ -505,11 +503,7 @@ def wcs_from_sregions(
     parsed_footprints = []
     for s_region in footprints:
         if isinstance(s_region, str):
-            result = sregion_to_footprint(s_region)
-            if isinstance(result, list):
-                parsed_footprints.extend(result)
-            else:
-                parsed_footprints.append(result)
+            parsed_footprints.extend(sregion_to_footprint(s_region))
         else:
             parsed_footprints.append(s_region)
     footprints = parsed_footprints

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -29,6 +29,7 @@ def create_astrometric_catalog(
     table_format="ascii.ecsv",
     num_sources=None,
     timeout=TIMEOUT,
+    keep_all_columns=False,
 ):
     """Create an astrometric catalog that covers the inputs' field-of-view.
 
@@ -65,6 +66,9 @@ def create_astrometric_catalog(
     timeout : float
         Maximum time to wait (in seconds) for the catalog service to respond.
 
+    keep_all_columns : bool
+        If True, keep all columns returned by the catalog. If False, only keep
+        columns necessary for tweakreg step.
 
 
     Notes
@@ -81,14 +85,15 @@ def create_astrometric_catalog(
     radius, fiducial = compute_radius(wcs)
 
     # perform query for this field-of-view
-    ref_dict = get_catalog(
+    ref_table = get_catalog(
         fiducial[0], fiducial[1], epoch=epoch, search_radius=radius, catalog=catalog, timeout=timeout
     )
-    if len(ref_dict) == 0:
-        return ref_dict
+    if len(ref_table) == 0:
+        return ref_table
 
-    colnames = ("ra", "dec", "mag", "objID", "epoch")
-    ref_table = ref_dict[colnames]
+    if not keep_all_columns:
+        colnames = ("ra", "dec", "mag", "objID", "epoch")
+        ref_table = ref_table[colnames]
 
     # Add catalog name as meta data
     ref_table.meta["catalog"] = catalog

--- a/src/stcal/tweakreg/astrometric_utils.py
+++ b/src/stcal/tweakreg/astrometric_utils.py
@@ -29,7 +29,6 @@ def create_astrometric_catalog(
     table_format="ascii.ecsv",
     num_sources=None,
     timeout=TIMEOUT,
-    keep_all_columns=False,
 ):
     """Create an astrometric catalog that covers the inputs' field-of-view.
 
@@ -66,9 +65,6 @@ def create_astrometric_catalog(
     timeout : float
         Maximum time to wait (in seconds) for the catalog service to respond.
 
-    keep_all_columns : bool
-        If True, keep all columns returned by the catalog. If False, only keep
-        columns necessary for tweakreg step.
 
 
     Notes
@@ -85,15 +81,14 @@ def create_astrometric_catalog(
     radius, fiducial = compute_radius(wcs)
 
     # perform query for this field-of-view
-    ref_table = get_catalog(
+    ref_dict = get_catalog(
         fiducial[0], fiducial[1], epoch=epoch, search_radius=radius, catalog=catalog, timeout=timeout
     )
-    if len(ref_table) == 0:
-        return ref_table
+    if len(ref_dict) == 0:
+        return ref_dict
 
-    if not keep_all_columns:
-        colnames = ("ra", "dec", "mag", "objID", "epoch")
-        ref_table = ref_table[colnames]
+    colnames = ("ra", "dec", "mag", "objID", "epoch")
+    ref_table = ref_dict[colnames]
 
     # Add catalog name as meta data
     ref_table.meta["catalog"] = catalog

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -176,6 +176,26 @@ def test_sregion_to_footprint():
     assert np.allclose(footprint, expected_footprint)
 
 
+def test_sregion_to_footprint_multi():
+    """Test that a multi-polygon S_REGION returns a list of ndarrays."""
+    s_region = (
+        "POLYGON ICRS  0.000000000 0.000000000 1.000000000 0.000000000 "
+        "1.000000000 1.000000000 0.000000000 1.000000000  "
+        "POLYGON ICRS  2.000000000 2.000000000 3.000000000 2.000000000 "
+        "3.000000000 3.000000000 2.000000000 3.000000000"
+    )
+    result = sregion_to_footprint(s_region)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(r, np.ndarray) for r in result)
+    assert result[0].shape == (4, 2)
+    assert result[1].shape == (4, 2)
+    expected0 = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    expected1 = np.array([[2.0, 2.0], [3.0, 2.0], [3.0, 3.0], [2.0, 3.0]])
+    np.testing.assert_array_equal(result[0], expected0)
+    np.testing.assert_array_equal(result[1], expected1)
+
+
 def test_validate_wcs_list():
     shape = (3, 3)  # in pixels
     fiducial_world = (10, 0)  # in deg

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -172,8 +172,10 @@ def test_sregion_to_footprint():
 
     footprint = sregion_to_footprint(s_region)
 
-    assert footprint.shape == (4, 2)
-    assert np.allclose(footprint, expected_footprint)
+    assert isinstance(footprint, list)
+    assert len(footprint) == 1
+    assert footprint[0].shape == (4, 2)
+    assert np.allclose(footprint[0], expected_footprint)
 
 
 def test_sregion_to_footprint_multi():

--- a/tests/test_combine_sregions.py
+++ b/tests/test_combine_sregions.py
@@ -412,6 +412,43 @@ def test_sregion_no_overlap(complex_footprint_set, det2world):
     assert str(excinfo.value) == "No overlap between input s_regions and intersection footprint"
 
 
+def test_sregion_variable_vertex_counts(det2world):
+    """Test that combine_sregions handles S_REGIONs with different numbers of vertices."""
+    triangle = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 2.0]])
+    pentagon = np.array([[0.5, 0.5], [1.5, 0.5], [2.0, 1.5], [1.0, 2.5], [0.0, 1.5]])
+
+    sregion_list = [_polygons_to_sregion([triangle]), _polygons_to_sregion([pentagon])]
+    combined = combine_sregions(sregion_list, det2world)
+
+    # Both polygons overlap so there should be exactly one combined region
+    assert combined.count("POLYGON ICRS") == 1
+
+
+def test_sregion_multi_polygon_input(det2world):
+    """
+    Test that combine_sregions handles an input S_REGION that contains multiple polygons.
+
+    One input is a multi-polygon S_REGION with two non-overlapping squares.
+    The other input is a single-polygon S_REGION that overlaps with only one of them.
+    The result should have two regions: the union of the overlapping pair, and the untouched square.
+    """
+    square_a = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    square_b = np.array([[3.0, 3.0], [4.0, 3.0], [4.0, 4.0], [3.0, 4.0]])
+    multi_polygon_sregion = _polygons_to_sregion([square_a, square_b])
+
+    overlapping = np.array([[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5]])
+    single_sregion = _polygons_to_sregion([overlapping])
+
+    combined = combine_sregions([multi_polygon_sregion, single_sregion], det2world)
+
+    # Two output regions: union of square_a + overlapping (8 vertices), and square_b (4 vertices)
+    assert combined.count("POLYGON ICRS") == 2
+    sregions_out = [s.strip() for s in combined.split("POLYGON ICRS")][1:]
+    footprints_out = [sregion_to_footprint(s) for s in sregions_out]
+    region_shapes = sorted([fp.shape for fp in footprints_out])
+    assert region_shapes == [(4, 2), (8, 2)]
+
+
 def test_duplicate_tolerance():
     """
     Test duplicated point tolerances.

--- a/tests/test_combine_sregions.py
+++ b/tests/test_combine_sregions.py
@@ -352,7 +352,7 @@ def test_sregion_complex(complex_footprint_set, det2world):
     assert combined_sregion.count("POLYGON ICRS") == 3
     assert combined_sregion.startswith("POLYGON ICRS")
     sregions_out = [s.strip() for s in combined_sregion.split("POLYGON ICRS")][1:]
-    footprints_out = [sregion_to_footprint(sregion) for sregion in sregions_out]
+    footprints_out = [sregion_to_footprint(sregion)[0] for sregion in sregions_out]
 
     # Too tedious to check exact coordinates, so just check the shapes of the regions.
     region_shapes = sorted([region.shape for region in footprints_out])
@@ -444,7 +444,7 @@ def test_sregion_multi_polygon_input(det2world):
     # Two output regions: union of square_a + overlapping (8 vertices), and square_b (4 vertices)
     assert combined.count("POLYGON ICRS") == 2
     sregions_out = [s.strip() for s in combined.split("POLYGON ICRS")][1:]
-    footprints_out = [sregion_to_footprint(s) for s in sregions_out]
+    footprints_out = [sregion_to_footprint(s)[0] for s in sregions_out]
     region_shapes = sorted([fp.shape for fp in footprints_out])
     assert region_shapes == [(4, 2), (8, 2)]
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4349](https://jira.stsci.edu/browse/JP-4349)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

Closes spacetelescope/jwst#10513

<!-- describe the changes comprising this PR here -->

This PR:
- Allows `sregion_to_footprint` to accept as input S_REGIONs that are themselves multiple polygons.  In this case a list of footprint arrays is returned instead of a single footprint array.
- Fixes a bug in `combine_sregions` where it expected all input footprints to have the same number of vertices.

I have also confirmed that the original use-case from the JP ticket passes with this stcal version.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [x] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
