### PR TITLE
JP-4313: Use explicit read_times in JWST model in ramp fit

### DIFF
--- a/changes/546.ramp_fitting.rst
+++ b/changes/546.ramp_fitting.rst
@@ -1,0 +1,2 @@
+Use explicit read times for likelihood fits with JWST data, if available in the input model.
+This is intended to support new multistripe modes with repeated in-frame reads of the same detector area.

--- a/src/stcal/ramp_fitting/ramp_fit.py
+++ b/src/stcal/ramp_fitting/ramp_fit.py
@@ -98,8 +98,12 @@ def create_ramp_fit_class(model, algorithm, dqflags=None, suppress_one_group=Fal
     )
 
     ramp_data.algorithm = algorithm
-    if hasattr(model.meta.exposure, "read_pattern"):
-        ramp_data.read_pattern = [list(reads) for reads in model.meta.exposure.read_pattern]
+
+    # Set the read pattern from input read times if available
+    read_times = getattr(model.meta.exposure, "read_times", None)
+    if read_times is not None and len(read_times) > 0:
+        log.debug("Using explicit read times")
+        ramp_data.read_pattern = list(read_times)
 
     ramp_data.set_dqflags(dqflags)
     ramp_data.start_row = 0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Toward [JP-4313](https://jira.stsci.edu/browse/JP-4313)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->

For coordination with https://github.com/spacetelescope/jwst/pull/10534:
Use explicit read times for JWST data if available.  This is intended to support new multistripe modes with repeated in-frame reads of the same detector area.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
