### PR TITLE
Fix #501: Use absolute URL for STScI logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 STScI Calibration algorithms and tools.
 
-<img src="docs/_static/stsci_pri_combo_mark_white.png" width="300"/>
+<img src="https://raw.githubusercontent.com/spacetelescope/stcal/main/docs/_static/stsci_pri_combo_mark_white.png" width="300"/>
 
 > [!IMPORTANT]
 > Linux and MacOS platforms are tested and supported. Windows is not currently supported.


### PR DESCRIPTION
The relative-path `img` tag (`docs/_static/stsci_pri_combo_mark_white.png`) renders on GitHub but breaks on PyPI. Switch to an absolute `raw.githubusercontent.com` URL so the brandmark displays on both.

Closes #501.