### PR TITLE
JP-4318: Updating Ramp Fitting Tests for New STCAL Slope Computation.

### DIFF
--- a/changes/550.ramp_fitting.rst
+++ b/changes/550.ramp_fitting.rst
@@ -1,0 +1,1 @@
+Changing the slope computation, removing the use of the Poisson variance as a part of the weight.

--- a/docs/stcal/ramp_fitting/description.rst
+++ b/docs/stcal/ramp_fitting/description.rst
@@ -247,7 +247,12 @@ noise is:
 The slope for an integration depends on the slope and the combined variance of each segment's slope:
 
 .. math::
-   slope_{i} = \frac{ \sum_{s}{ \frac{slope_{s}} {var^C_{s}}}} { \sum_{s}{ \frac{1} {var^C_{s}}}}
+   slope_{i} = \frac{ \sum_{s}{ \frac{slope_{s}} {var^R_{s}}}} { \sum_{s}{ \frac{1} {var^R_{s}}}}
+
+This is equivalent to:
+
+.. math::
+   slope_{i} = (\sum_{s}{ \frac{slope_{s}} {var^R_{s}}}) var^R_{i}
 
 Exposure-level computations
 +++++++++++++++++++++++++++
@@ -273,7 +278,13 @@ The overall slope depends on the slope and the combined variance of the slope of
 segments, so is a sum over integration values computed from the segments:
 
 .. math::
-    slope_{o} = \frac{ \sum_{i}{ \frac{slope_{i}} {var^C_{i}}}} { \sum_{i}{ \frac{1} {var^C_{i}}}}
+    slope_{o} = \frac{ \sum_{i}\sum_s{ \frac{slope_{i,s}} {var^R_{i,s}}}} { \sum_{i}{ \frac{1} {var^R_{i}}}}
+
+where the subscript :math:`i, s` means the segment :math:`s` in integration :math:`i`. This is above
+equation is equivalent to:
+
+.. math::
+    slope_{o} = (\sum_{i}\sum_s{ \frac{slope_{i,s}} {var^R_{i,s}}}) var^R_{o}
 
 
 .. _ramp_error_propagation:

--- a/docs/stcal/ramp_fitting/description.rst
+++ b/docs/stcal/ramp_fitting/description.rst
@@ -238,13 +238,14 @@ The variance of the slope for an integration due to Poisson noise is:
 .. math::
    var^P_{i} = \frac{1}{ \sum_{s} \frac{1}{ var^P_{s}}}
 
-The combined variance of the slope for an integration due to both Poisson and read
-noise is:
+The combined variance of the slope for an integration due to both
+Poisson and read noise is:
 
 .. math::
    var^C_{i} = \frac{1}{ \sum_{s} \frac{1}{ var^R_{s} + var^P_{s}}}
 
-The slope for an integration depends on the slope and the combined variance of each segment's slope:
+The slope for an integration depends on the slope and the read noise variance
+of each segment's slope:
 
 .. math::
    slope_{i} = \frac{ \sum_{s}{ \frac{slope_{s}} {var^R_{s}}}} { \sum_{s}{ \frac{1} {var^R_{s}}}}
@@ -272,10 +273,12 @@ The combined variance of the slope is the sum of the variances:
 .. math::
    var^C_{o} = var^R_{o} + var^P_{o}
 
-The square-root of the combined variance is stored in the ERR array of the output product.
+The square-root of the combined variance is stored in the ERR array of the
+output product.
 
-The overall slope depends on the slope and the combined variance of the slope of each integration's
-segments, so is a sum over integration values computed from the segments:
+The overall slope depends on the slope and the read noise variance of the
+slope of each integration's segments, so is a sum over integration values
+computed from the segments:
 
 .. math::
     slope_{o} = \frac{ \sum_{i}\sum_s{ \frac{slope_{i,s}} {var^R_{i,s}}}} { \sum_{i}{ \frac{1} {var^R_{i}}}}

--- a/docs/stcal/ramp_fitting/description.rst
+++ b/docs/stcal/ramp_fitting/description.rst
@@ -280,7 +280,7 @@ segments, so is a sum over integration values computed from the segments:
 .. math::
     slope_{o} = \frac{ \sum_{i}\sum_s{ \frac{slope_{i,s}} {var^R_{i,s}}}} { \sum_{i}{ \frac{1} {var^R_{i}}}}
 
-where the subscript :math:`i, s` means the segment :math:`s` in integration :math:`i`. This is above
+where the subscript :math:`i, s` means the segment :math:`s` in integration :math:`i`. The above
 equation is equivalent to:
 
 .. math::

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -2825,8 +2825,6 @@ ramp_fit_pixel(
     }
 
     if (!isnan(pr->rate.slope)) {
-        // XXX JP-4318: figure out what to do here
-        // pr->rate.slope = pr->rate.slope / pr->invvar_e_sum;
         pr->rate.slope = pr->rate.slope * pr->rate.var_rnoise;;
     }
 
@@ -3054,7 +3052,6 @@ ramp_fit_pixel_integration_fit_slope(
         }
 
         invvar_e += (1. / current->var_e);
-        // XXX JP-4318
         slope_i_num += (current->slope / current->var_r);
     } /* for loop */
 
@@ -3080,7 +3077,6 @@ ramp_fit_pixel_integration_fit_slope(
     } else {
         var_err = 1. / invvar_e;
 
-        // XXX JP-4318: multiply by var_r
         pr->rateints[integ].slope = slope_i_num * pr->rateints[integ].var_rnoise;
         if (var_err > LARGE_VARIANCE_THRESHOLD) {
             pr->rateints[integ].var_err = 0.;
@@ -3097,7 +3093,6 @@ ramp_fit_pixel_integration_fit_slope(
     }
     pr->rate.var_rnoise += invvar_r;
     pr->invvar_e_sum += invvar_e;
-    // XXX JP-4318: figure out what to do here
     pr->rate.slope += slope_i_num; // 
 
     return ret;
@@ -3192,7 +3187,6 @@ ramp_fit_pixel_integration_fit_slope_seg_len1(
     seg->var_e = seg->var_p + seg->var_r;
 
     if (rd->save_opt) {
-        // XXX JP-4318: should tmp = 1. / seg->var_r;?
         tmp = 1. / seg->var_e;
         seg->weight = tmp * tmp;
     }
@@ -3277,7 +3271,6 @@ ramp_fit_pixel_integration_fit_slope_seg_len2(
     seg->var_r = segment_rnoise_len2(rd, pr);
 
     /* Segment total variance */
-    // seg->var_e = 2. * pr->rnoise * pr->rnoise;  /* XXX Is this right? */
     seg->var_e = seg->var_p + seg->var_r;
 
     if (rd->save_opt) {
@@ -3287,7 +3280,6 @@ ramp_fit_pixel_integration_fit_slope_seg_len2(
         seg->sigyint = seg->sigslope;
 
         /* WEIGHTS */
-        // XXX JP-4318: remove seg->var_r?
         tmp = (seg->var_p + seg->var_r);
         wt = 1. / tmp;
         wt *= wt;
@@ -3446,7 +3438,6 @@ ramp_fit_pixel_integration_fit_slope_seg_default_weighted_seg(
     seg->var_e = seg->var_p + seg->var_r;
 
     if (rd->save_opt) {
-        // XXX JP-4318: should seg->weight = 1. / seg->var_r;
         seg->weight = 1. / seg->var_e;
         seg->weight *= seg->weight;
     }

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -2727,12 +2727,12 @@ py_ramp_data_get_int(
         dbg_ols_print("Rate var_r: %f\n\n", pr->rate.var_rnoise);                          \
     } while (0)
 
-#define DBG_MEDIAN_RATE                                                                    \
-    do {                                                                                   \
-        print_delim();                                                                     \
-        dbg_ols_print("Pixel (%ld, %ld)\n", pr->row, pr->col);                             \
-        dbg_ols_print("Median Rate = %.10f\n", pr->median_rate);                           \
-        print_delim();                                                                     \
+#define DBG_MEDIAN_RATE                                          \
+    do {                                                         \
+        print_delim();                                           \
+        dbg_ols_print("Pixel (%ld, %ld)\n", pr->row, pr->col);   \
+        dbg_ols_print("Median Rate = %.10f\n", pr->median_rate); \
+        print_delim();                                           \
     } while (0)
 
 /*
@@ -2825,7 +2825,8 @@ ramp_fit_pixel(
     }
 
     if (!isnan(pr->rate.slope)) {
-        pr->rate.slope = pr->rate.slope * pr->rate.var_rnoise;; // JP-4318
+        pr->rate.slope = pr->rate.slope * pr->rate.var_rnoise;
+        ; // JP-4318
     }
 
     // DBG_RATE_INFO;  /* XXX */

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -3188,7 +3188,7 @@ ramp_fit_pixel_integration_fit_slope_seg_len1(
     seg->var_e = seg->var_p + seg->var_r;
 
     if (rd->save_opt) {
-        tmp = 1. / seg->var_e;
+        tmp = 1. / seg->var_r;
         seg->weight = tmp * tmp;
     }
 
@@ -3281,9 +3281,8 @@ ramp_fit_pixel_integration_fit_slope_seg_len2(
         seg->sigyint = seg->sigslope;
 
         /* WEIGHTS */
-        tmp = (seg->var_p + seg->var_r);
+        tmp = seg->var_r;
         wt = 1. / tmp;
-        wt *= wt;
         seg->weight = wt;
     }
 
@@ -3439,8 +3438,7 @@ ramp_fit_pixel_integration_fit_slope_seg_default_weighted_seg(
     seg->var_e = seg->var_p + seg->var_r;
 
     if (rd->save_opt) {
-        seg->weight = 1. / seg->var_e;
-        seg->weight *= seg->weight;
+        seg->weight = 1. / seg->var_r;
     }
 }
 

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -3189,7 +3189,7 @@ ramp_fit_pixel_integration_fit_slope_seg_len1(
 
     if (rd->save_opt) {
         tmp = 1. / seg->var_r;
-        seg->weight = tmp * tmp;
+        seg->weight = tmp;
     }
 
     return 0;

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -2727,6 +2727,14 @@ py_ramp_data_get_int(
         dbg_ols_print("Rate var_r: %f\n\n", pr->rate.var_rnoise);                          \
     } while (0)
 
+#define DBG_MEDIAN_RATE                                                                    \
+    do {                                                                                   \
+        print_delim();                                                                     \
+        dbg_ols_print("Pixel (%ld, %ld)\n", pr->row, pr->col);                             \
+        dbg_ols_print("Median Rate = %.10f\n", pr->median_rate);                           \
+        print_delim();                                                                     \
+    } while (0)
+
 /*
  * Ramp fit a pixel ramp.
  * PIXEL RAMP
@@ -2746,14 +2754,8 @@ ramp_fit_pixel(
         ret = 1;
         goto END;
     }
-#if 0
-    if (rd->debug) {
-        print_delim();
-        dbg_ols_print("Pixel (%ld, %ld)\n", pr->row, pr->col);
-        dbg_ols_print("Median Rate = %.10f\n", pr->median_rate);
-        print_delim();
-    }
-#endif
+
+    // DBG_MEDIAN_RATE;
 
     /* Clean up any thing from the last pixel ramp */
     clean_segment_list(pr->nints, pr->segs);
@@ -2823,7 +2825,9 @@ ramp_fit_pixel(
     }
 
     if (!isnan(pr->rate.slope)) {
-        pr->rate.slope = pr->rate.slope / pr->invvar_e_sum;
+        // XXX JP-4318: figure out what to do here
+        // pr->rate.slope = pr->rate.slope / pr->invvar_e_sum;
+        pr->rate.slope = pr->rate.slope * pr->rate.var_rnoise;;
     }
 
     // DBG_RATE_INFO;  /* XXX */
@@ -3050,7 +3054,8 @@ ramp_fit_pixel_integration_fit_slope(
         }
 
         invvar_e += (1. / current->var_e);
-        slope_i_num += (current->slope / current->var_e);
+        // XXX JP-4318
+        slope_i_num += (current->slope / current->var_r);
     } /* for loop */
 
     /* Get rateints computations */
@@ -3075,7 +3080,8 @@ ramp_fit_pixel_integration_fit_slope(
     } else {
         var_err = 1. / invvar_e;
 
-        pr->rateints[integ].slope = slope_i_num * var_err;
+        // XXX JP-4318: multiply by var_r
+        pr->rateints[integ].slope = slope_i_num * pr->rateints[integ].var_rnoise;
         if (var_err > LARGE_VARIANCE_THRESHOLD) {
             pr->rateints[integ].var_err = 0.;
         } else {
@@ -3091,7 +3097,8 @@ ramp_fit_pixel_integration_fit_slope(
     }
     pr->rate.var_rnoise += invvar_r;
     pr->invvar_e_sum += invvar_e;
-    pr->rate.slope += slope_i_num;
+    // XXX JP-4318: figure out what to do here
+    pr->rate.slope += slope_i_num; // 
 
     return ret;
 }
@@ -3185,6 +3192,7 @@ ramp_fit_pixel_integration_fit_slope_seg_len1(
     seg->var_e = seg->var_p + seg->var_r;
 
     if (rd->save_opt) {
+        // XXX JP-4318: should tmp = 1. / seg->var_r;?
         tmp = 1. / seg->var_e;
         seg->weight = tmp * tmp;
     }
@@ -3279,6 +3287,7 @@ ramp_fit_pixel_integration_fit_slope_seg_len2(
         seg->sigyint = seg->sigslope;
 
         /* WEIGHTS */
+        // XXX JP-4318: remove seg->var_r?
         tmp = (seg->var_p + seg->var_r);
         wt = 1. / tmp;
         wt *= wt;
@@ -3437,6 +3446,7 @@ ramp_fit_pixel_integration_fit_slope_seg_default_weighted_seg(
     seg->var_e = seg->var_p + seg->var_r;
 
     if (rd->save_opt) {
+        // XXX JP-4318: should seg->weight = 1. / seg->var_r;
         seg->weight = 1. / seg->var_e;
         seg->weight *= seg->weight;
     }

--- a/src/stcal/ramp_fitting/src/slope_fitter.c
+++ b/src/stcal/ramp_fitting/src/slope_fitter.c
@@ -2825,7 +2825,7 @@ ramp_fit_pixel(
     }
 
     if (!isnan(pr->rate.slope)) {
-        pr->rate.slope = pr->rate.slope * pr->rate.var_rnoise;;
+        pr->rate.slope = pr->rate.slope * pr->rate.var_rnoise;; // JP-4318
     }
 
     // DBG_RATE_INFO;  /* XXX */
@@ -3052,7 +3052,7 @@ ramp_fit_pixel_integration_fit_slope(
         }
 
         invvar_e += (1. / current->var_e);
-        slope_i_num += (current->slope / current->var_r);
+        slope_i_num += (current->slope / current->var_r); // JP-4318
     } /* for loop */
 
     /* Get rateints computations */
@@ -3077,7 +3077,7 @@ ramp_fit_pixel_integration_fit_slope(
     } else {
         var_err = 1. / invvar_e;
 
-        pr->rateints[integ].slope = slope_i_num * pr->rateints[integ].var_rnoise;
+        pr->rateints[integ].slope = slope_i_num * pr->rateints[integ].var_rnoise; // JP-4318
         if (var_err > LARGE_VARIANCE_THRESHOLD) {
             pr->rateints[integ].var_err = 0.;
         } else {
@@ -3093,7 +3093,7 @@ ramp_fit_pixel_integration_fit_slope(
     }
     pr->rate.var_rnoise += invvar_r;
     pr->invvar_e_sum += invvar_e;
-    pr->rate.slope += slope_i_num; // 
+    pr->rate.slope += slope_i_num; // JP-4318
 
     return ret;
 }

--- a/tests/test_ramp_fitting.py
+++ b/tests/test_ramp_fitting.py
@@ -919,7 +919,7 @@ def test_zeroframe(algo):
     # Check slopes information
 
     if algo == DEFAULT_OLS:
-        check = np.array([[48.965397, 18.628912, 47.863224]])
+        check = np.array([[22.07871, 18.628912, 19.89315]])
     else:  # LIKELY
         check = np.array([[22.101093, 18.628912, 18.628912]])
     np.testing.assert_allclose(slopes["slope"], check, tol, tol)
@@ -1392,7 +1392,7 @@ def test_new_saturation(algo):
     # Check slopes information
 
     if algo == DEFAULT_OLS:
-        check = np.array([[2.795187, 2.795632, np.nan]])
+        check = np.array([[2.794969, 2.795479, np.nan]])
     else:  # LIKELY
         check = np.array([[2.794573, 2.793989, np.nan]])
     np.testing.assert_allclose(slopes["slope"], check, tol, tol)
@@ -1422,7 +1422,7 @@ def test_new_saturation(algo):
     # cdata, cdq, cvp, cvr, cerr = cube
 
     if algo == DEFAULT_OLS:
-        check = np.array([[[2.7949152, 2.7956316, np.nan]], [[2.7956493, np.nan, np.nan]]])
+        check = np.array([[[2.7949154, 2.795479, np.nan]], [[2.795479, np.nan, np.nan]]])
     else:  # LIKELY
         check = np.array([[[2.794889, 2.793989, np.nan]], [[2.793989, np.nan, np.nan]]])
     np.testing.assert_allclose(cube["slope"], check, tol, tol)

--- a/tests/test_ramp_fitting_cases.py
+++ b/tests/test_ramp_fitting_cases.py
@@ -68,7 +68,7 @@ def test_pix_0():
 
     # Set truth values for OPTIONAL results:
     # [slope, sigslope, var_poisson, var_rnoise, yint, sigyint, ped, weights]
-    o_true = [1.0117551, 4.874572, 0.0020202, 0.00647973, 15.911023, 27.789335, 13.988245, 13841.038]
+    o_true = [1.0117551, 4.874572, 0.0020202, 0.00647973, 15.911023, 27.789335, 13.988245, 154.32735]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -105,7 +105,7 @@ def test_pix_1():
     p_true = [1.8999999, JUMP | SAT, 1.05057204, 0.03454545, 1.0691562]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.9, 56.870003, 0.03454545, 1.0691562, -3.0, 56.870003, 13.1, 0.82091206]
+    o_true = [1.9, 56.870003, 0.03454545, 1.0691562, -3.0, 56.870003, 13.1, 0.9353173]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -144,7 +144,7 @@ def test_pix_2():
         [14.999998, 51.0, 15.0],  # yint
         [36.709427, 56.870003, 56.870003],  # sigyint
         [14.14999961],  # pedestal
-        [13.091425, 0.84580624, 0.84580624],  # weights
+        [3.741269, 0.935317, 0.935317],  # weights
     ]
 
     assert_pri(p_true, slopes, 0)
@@ -185,7 +185,7 @@ def test_pix_3():
         [14.504965, 15.0],
         [27.842508, 56.870003],
         [13.92515182],
-        [4.2576841e03, 8.458062e-01],
+        [78.56665, 0.935317],
     ]
 
     assert_pri(p_true, slopes, 0)
@@ -217,7 +217,7 @@ def test_pix_4():
     p_true = [1.5, SAT, 1.047105, 0.02727273, 1.0691562]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.5, 0.0, 0.02727273, 1.0691562, 0.0, 0.0, 13.5, 0.8318386]
+    o_true = [1.5, 0.0, 0.02727273, 1.0691562, 0.0, 0.0, 13.5, 0.935317]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -306,7 +306,7 @@ def test_pix_5():
         [13.537246, 2015.0737],
         [35.301933, 67.10882],
         [13.9265975],
-        [78.34764, 855.78046],
+        [9.353172, 32.736103],
     ]
 
     assert_pri(p_true, slopes, 0)
@@ -348,7 +348,7 @@ def test_pix_6():
         [15.0, -143.2391],
         [56.870003, 58.76999],
         [8.8954992],
-        [8.4580624e-01, 2.0433204e03],
+        [0.935317, 52.377766],
     ]
 
     assert_pri(p_true, slopes, 0)
@@ -379,7 +379,7 @@ def test_pix_7():
     p_true = [1.0757396, JUMP, 0.12379601, 0.0025974, 0.01272805]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.0757396, 6.450687, 0.0025974, 0.01272805, 14.504951, 27.842508, 13.92426, 4257.684]
+    o_true = [1.0757396, 6.450687, 0.0025974, 0.01272805, 14.504951, 27.842508, 13.92426, 78.56665]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -410,7 +410,7 @@ def test_pix_8():
     p_true = [0.98561335, JUMP | SAT, 0.1848883, 0.00363636, 0.03054732]
 
     # Set truth values for OPTIONAL results:
-    o_true = [0.98561335, 9.920554, 0.00363636, 0.03054732, 16.508228, 39.383667, 14.014386, 855.78046]
+    o_true = [0.98561335, 9.920554, 0.00363636, 0.03054732, 16.508228, 39.383667, 14.014386, 32.736103]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -450,7 +450,7 @@ def test_pix_9():
         [15.0, 20.119896, 15.0],
         [56.870003, 68.618195, 56.870003],
         [14.0],
-        [0.84580624, 297.23172, 0.84580624],
+        [0.935317, 18.706345, 0.935317],
     ]
 
     assert_pri(p_true, slopes, 0)
@@ -491,7 +491,7 @@ def test_pix_10():
         [15.0, 17.999956, 15.000029],
         [56.870003, 88.40799, 93.73906],
         [14.0],
-        [0.84580624, 13.091425, 297.23172],
+        [0.935317, 3.741269, 18.706345],
     ]
 
     assert_pri(p_true, slopes, 0)
@@ -522,7 +522,7 @@ def test_pix_11():
     p_true = [1.0, SAT, 1.042755, 0.01818182, 1.0691562]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.0, 56.870003, 0.01818182, 1.0691562, 15.0, 56.870003, 14.0, 0.84580624]
+    o_true = [1.0, 56.870003, 0.01818182, 1.0691562, 15.0, 56.870003, 14.0, 0.935317]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -560,7 +560,7 @@ def test_pix_12():
     # slope, sig_slope, var_p, var_r, yint, sig_yint, pedestal, weights
     # slope = group1 / deltatime = 15 / 10 = 1.5
     # sig_slope, yint, sig_yint, and pedestal are all zero, because only 1 good group
-    o_true = [1.5, 0.0, 0.027273, 1.069156, 0.0, 0.0, 13.5, 0.831839]
+    o_true = [1.5, 0.0, 0.027273, 1.069156, 0.0, 0.0, 13.5, 0.935317]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -606,7 +606,7 @@ def test_miri_0():
     p_true = [1.025854, GOOD, 0.12379601, 0.0025974, 0.01272805]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508, 23.974146, 4257.684]
+    o_true = [1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508, 23.974146, 78.56665]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -638,7 +638,7 @@ def test_miri_1():
     p_true = [1.1996487, GOOD, 0.12379601, 0.0025974, 0.01272805]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.1996487, 6.450687, 0.0025974, 0.01272805, 126.110214, 27.842508, 123.800354, 4257.684]
+    o_true = [1.1996487, 6.450687, 0.0025974, 0.01272805, 126.110214, 27.842508, 123.800354, 78.56665]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -670,7 +670,7 @@ def test_miri_2():
     p_true = [1.025854, GOOD, 0.12379601, 0.0025974, 0.01272805]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508, 23.974146, 4257.684]
+    o_true = [1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508, 23.974146, 78.56665]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)
@@ -702,7 +702,7 @@ def test_miri_3():
     p_true = [1.025854, GOOD, 0.12379601, 0.0025974, 0.01272805]
 
     # Set truth values for OPTIONAL results:
-    o_true = [1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508, 23.974146, 4257.684]
+    o_true = [1.025854, 6.450687, 0.0025974, 0.01272805, 26.439266, 27.842508, 23.974146, 78.56665]
 
     assert_pri(p_true, slopes, 0)
     assert_opt(o_true, ols_opt, 0)

--- a/tests/test_ramp_fitting_cases.py
+++ b/tests/test_ramp_fitting_cases.py
@@ -1,5 +1,6 @@
 import inspect
 from pathlib import Path
+import pytest
 
 import numpy as np
 import numpy.testing as npt
@@ -133,7 +134,7 @@ def test_pix_2():
     slopes, cube, ols_opt = ramp_fit_data(ramp_data, save_opt, rnoise, gain, algo, "optimal", ncores)
 
     # Set truth values for PRIMARY results:
-    p_true = [0.84833729, JUMP | SAT, 0.42747884, 0.00454545, 0.1781927]
+    p_true = [0.850000023, JUMP | SAT, 0.42747884, 0.00454545, 0.1781927]
 
     # Set truth values for OPTIONAL results for all segments
     o_true = [
@@ -143,7 +144,7 @@ def test_pix_2():
         [0.26728904, 1.0691562, 1.0691562],  # var_rnoise
         [14.999998, 51.0, 15.0],  # yint
         [36.709427, 56.870003, 56.870003],  # sigyint
-        [14.151663],  # pedestal
+        [14.14999961],  # pedestal
         [13.091425, 0.84580624, 0.84580624],  # weights
     ]
 
@@ -174,7 +175,7 @@ def test_pix_3():
     slopes, cube, ols_opt = ramp_fit_data(ramp_data, save_opt, rnoise, gain, algo, "optimal", ncores)
 
     # Set truth values for PRIMARY results:
-    p_true = [1.0746869, JUMP, 0.12186482, 0.00227273, 0.01257831]
+    p_true = [1.07484829, JUMP, 0.12186482, 0.00227273, 0.01257831]
 
     # Set truth values for OPTIONAL results:
     o_true = [
@@ -184,7 +185,7 @@ def test_pix_3():
         [0.01272805, 1.0691562],
         [14.504965, 15.0],
         [27.842508, 56.870003],
-        [13.925313],
+        [13.92515182],
         [4.2576841e03, 8.458062e-01],
     ]
 
@@ -295,7 +296,7 @@ def test_pix_5():
     slopes, cube, ols_opt = ramp_fit_data(ramp_data, save_opt, rnoise, gain, algo, "optimal", ncores)
 
     # Set truth values for PRIMARY results:
-    p_true = [1.076075, JUMP, 0.16134359, 0.00227273, 0.02375903]
+    p_true = [1.073401, JUMP, 0.16134359, 0.00227273, 0.02375903]
 
     # Set truth values for OPTIONAL results:
     o_true = [
@@ -305,7 +306,7 @@ def test_pix_5():
         [0.10691562, 0.03054732],
         [13.537246, 2015.0737],
         [35.301933, 67.10882],
-        [13.923912],
+        [13.9265975],
         [78.34764, 855.78046],
     ]
 
@@ -337,7 +338,7 @@ def test_pix_6():
     slopes, cube, ols_opt = ramp_fit_data(ramp_data, save_opt, rnoise, gain, algo, "optimal", ncores)
 
     # Set truth values for PRIMARY results:
-    p_true = [6.092052, JUMP, 0.14613187, 0.0025974, 0.01875712]
+    p_true = [6.104500, JUMP, 0.14613187, 0.0025974, 0.01875712]
 
     # Set truth values for OPTIONAL results:
     o_true = [
@@ -347,7 +348,7 @@ def test_pix_6():
         [1.0691562, 0.01909207],
         [15.0, -143.2391],
         [56.870003, 58.76999],
-        [8.907948],
+        [8.8954992],
         [8.4580624e-01, 2.0433204e03],
     ]
 
@@ -533,8 +534,6 @@ def test_pix_12():
     CASE NGROUPS=2: the segment has a good 1st group and a saturated 2nd group,
       so is a single group. Group 1's data will be used in the 'fit'.
     """
-
-    # XXX problem with C
 
     nints, ngroups, nrows, ncols = 1, 2, 1, 2
     gain, rnoise = 5.5, 10.34

--- a/tests/test_ramp_fitting_cases.py
+++ b/tests/test_ramp_fitting_cases.py
@@ -1,6 +1,5 @@
 import inspect
 from pathlib import Path
-import pytest
 
 import numpy as np
 import numpy.testing as npt


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4318](https://jira.stsci.edu/browse/JP-4318)

<!-- describe the changes comprising this PR here -->

This PR addresses using the median rate of a pixel, which is computed across all integrations of a pixel, for the computation of the rate and rateint slopes, using the Poisson variance as part of the weights. This should not happen, since this has the effect of later integrations affecting the slope of earlier integrations. To prevent this the weighting during the computation of rate and rateint slopes use only the read noise variance, rather than a combination of both Poisson and read noise variances.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
