### PR TITLE
remove incorrect note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ STScI Calibration algorithms and tools.
 <img src="docs/_static/stsci_pri_combo_mark_white.png" width="300"/>
 
 > [!IMPORTANT]
-> STCAL requires Python 3.10 or above and a C compiler for dependencies.
-
-> [!IMPORTANT]
 > Linux and MacOS platforms are tested and supported. Windows is not currently supported.
 
 `STCAL` is intended to be used as a support package for calibration pipeline


### PR DESCRIPTION
Remove the "important" note from the readme that currently incorrectly states that we support 3.10 and that we require a compiler for dependencies (this isn't true if those are installed from wheels).

No regtests will be run.

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
