### PR TITLE
remove unneeded sinscl (only used for sinc kernel)

### DIFF
--- a/src/stcal/outlier_detection/utils.py
+++ b/src/stcal/outlier_detection/utils.py
@@ -292,7 +292,6 @@ def gwcs_blot(
         fillval=fillval,
         iscale=1.0,
         interp="linear",
-        sinscl=1.0,
     )
 
     return outsci


### PR DESCRIPTION
fix devdeps that are failing
https://github.com/spacetelescope/stcal/actions/runs/27922339233/job/82618125434#step:11:537

due to providing sinscl which is removed in drizzle:
https://github.com/spacetelescope/drizzle/pull/220

This parameter is only used for sinc kernel and the test uses linear so the provided value was already ignored.

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
