### PR TITLE
ignore missing DTypeLike in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,4 +81,5 @@ nitpick_ignore = [
     ("py:class", "stsci.imagestats.ImageStats"),  # intersphinx isn't working here
     ("py:class", "spherical_geometry.polygon.SphericalPolygon"),  # intersphinx isn't working here
     ("py:class", "numpy._typing.DTypeLike"),
+    ("py:class", "numpy._typing._dtype_like.DTypeLike"),
 ]


### PR DESCRIPTION
Docs are failing on main due to what appears to be a change in the class path of DTypeLike in the latest numpy.

We were already ignoring the old warning so this adds another ignore for the new warning (changed by the class path change).

Fixes https://github.com/spacetelescope/stcal/issues/553

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
