### PR TITLE
[SCSB-237] build Stable ABI3 wheels with `Py_LIMITED_API`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,71 @@
 name: build
 
 on:
+  pull_request:
   release:
     types: [released]
-  pull_request:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   build:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef # v2.6.3
-    with:
-      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
-      targets: |
-        # Linux wheels
-        - cp3*-manylinux_x86_64
-        # MacOS wheels
-        - cp3*-macosx_x86_64
-        # Until we have arm64 runners, we can't automatically test arm64 wheels
-        - cp3*-macosx_arm64
-      sdist: true
-      test_command: python -c "from stcal.ramp_fitting.ols_cas22 import _ramp, _jump, _fit; from stcal.ramp_fitting import slope_fitter"
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3"
+      - if: ${{ runner.os == 'Linux' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        with:
+          package-dir: ./
+          output-dir: dist/
+      - run: pip install build
+      - run: python -m build --sdist
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: dist-${{ runner.os }}-${{ runner.arch }}
+          path: ./dist/
+  publish:
+    if: (github.event_name == 'release') && (github.event.action == 'released')
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    # To add required reviewers before deployment,
+    # edit the protection rules in GitHub Settings:
+    # Settings > Environments > pypi > Add required reviewers
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stcal
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: dist*
+          path: dist/
+          merge-multiple: true
+      - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: "dist/*"
+      # To upload to PyPI without a token, add this workflow file as a Trusted Publisher in the project settings on the PyPI website
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3"
+          pip-install: build
       - if: ${{ runner.os == 'Linux' }}
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
@@ -37,7 +38,6 @@ jobs:
         with:
           package-dir: ./
           output-dir: dist/
-      - run: pip install build
       - run: python -m build --sdist
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,8 @@ skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 ignore-words-list = "nd, ans, LIK, indx, usig, dne"
 
 [tool.cibuildwheel]
-build = "cp311-*"  # build for CPython 3.11 Stable API
-skip = ["cp3??t-*"]  # explicitly skip free-threaded builds
+build = "cp311-*"                                                                                                                     # build for CPython 3.11 Stable API
+skip = ["cp3??t-*"]                                                                                                                   # explicitly skip free-threaded builds
 test-command = "python -c 'from stcal.ramp_fitting.ols_cas22 import _ramp, _jump, _fit; from stcal.ramp_fitting import slope_fitter'"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,9 @@ skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 ignore-words-list = "nd, ans, LIK, indx, usig, dne"
 
 [tool.cibuildwheel]
-build = "cp311-*"   # build for CPython 3.11 Stable API
-skip = ["cp3??t-*"] # explicitly skip free-threaded builds
+build = "cp311-*"  # build for CPython 3.11 Stable API
+skip = ["cp3??t-*"]  # explicitly skip free-threaded builds
+test-command = "python -c 'from stcal.ramp_fitting.ols_cas22 import _ramp, _jump, _fit; from stcal.ramp_fitting import slope_fitter'"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,8 @@ skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 ignore-words-list = "nd, ans, LIK, indx, usig, dne"
 
 [tool.cibuildwheel]
-# Disable free-threading builds on all platforms
-skip = "cp3??t-*"
+build = "cp311-*"  # build for CPython 3.11 Stable API
+skip = ["cp3??t-*"]  # explicitly skip free-threaded builds
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,8 @@ skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 ignore-words-list = "nd, ans, LIK, indx, usig, dne"
 
 [tool.cibuildwheel]
-build = "cp311-*"                                                                                                                     # build for CPython 3.11 Stable API
-skip = ["cp3??t-*"]                                                                                                                   # explicitly skip free-threaded builds
+build = "cp311-*"  # build for CPython 3.11 Stable API
+skip = ["cp3*t-*"]  # explicitly skip free-threaded builds
 test-command = "python -c 'from stcal.ramp_fitting.ols_cas22 import _ramp, _jump, _fit; from stcal.ramp_fitting import slope_fitter'"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,8 @@ skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 ignore-words-list = "nd, ans, LIK, indx, usig, dne"
 
 [tool.cibuildwheel]
-build = "cp311-*"  # build for CPython 3.11 Stable API
-skip = ["cp3??t-*"]  # explicitly skip free-threaded builds
+build = "cp311-*"   # build for CPython 3.11 Stable API
+skip = ["cp3??t-*"] # explicitly skip free-threaded builds
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,8 @@ skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 ignore-words-list = "nd, ans, LIK, indx, usig, dne"
 
 [tool.cibuildwheel]
-build = "cp311-*"  # build for CPython 3.11 Stable API
-skip = ["cp3*t-*"]  # explicitly skip free-threaded builds
+build = "cp311-*"                                                                                                                     # build for CPython 3.11 Stable API
+skip = ["cp3*t-*"]                                                                                                                    # explicitly skip free-threaded builds
 test-command = "python -c 'from stcal.ramp_fitting.ols_cas22 import _ramp, _jump, _fit; from stcal.ramp_fitting import slope_fitter'"
 
 [tool.cibuildwheel.macos]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
+import sysconfig
+
 import numpy as np
 from Cython.Build import cythonize
 from Cython.Compiler import Options
 from setuptools import Extension, setup
+
+FREE_THREADED_PYTHON = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
 
 Options.docstrings = True
 Options.annotate = False
@@ -17,8 +21,9 @@ include_dirs = [np.get_include()]
 # Setup C module macros
 define_macros = [
     ("NUMPY", "1"),
-    ("Py_LIMITED_API", 0x030B0000),  # PY_VERSION_HEX for 3.11
 ]
+if not FREE_THREADED_PYTHON:
+    define_macros.append(("Py_LIMITED_API", 0x030B0000))  # PY_VERSION_HEX for 3.11
 
 # importing these extension modules is tested in `.github/workflows/build.yml`;
 # when adding new modules here, make sure to add them to the `test_command` entry there
@@ -29,7 +34,7 @@ extensions = [
         include_dirs=[np.get_include()],
         language="c++",
         define_macros=define_macros,
-        py_limited_api=True,
+        py_limited_api=not FREE_THREADED_PYTHON,
     ),
     Extension(
         "stcal.ramp_fitting.ols_cas22._jump",
@@ -37,7 +42,7 @@ extensions = [
         include_dirs=[np.get_include()],
         language="c++",
         define_macros=define_macros,
-        py_limited_api=True,
+        py_limited_api=not FREE_THREADED_PYTHON,
     ),
     Extension(
         "stcal.ramp_fitting.ols_cas22._fit",
@@ -45,15 +50,19 @@ extensions = [
         include_dirs=[np.get_include()],
         language="c++",
         define_macros=define_macros,
-        py_limited_api=True,
+        py_limited_api=not FREE_THREADED_PYTHON,
     ),
     Extension(
         "stcal.ramp_fitting.slope_fitter",
         ["src/stcal/ramp_fitting/src/slope_fitter.c"],
         include_dirs=include_dirs,
         define_macros=define_macros,
-        py_limited_api=True,
+        py_limited_api=not FREE_THREADED_PYTHON,
     ),
 ]
 
-setup(ext_modules=cythonize(extensions), options={'bdist_wheel': {'py_limited_api': 'cp311'}})
+SETUPTOOLS_OPTIONS = {}
+if not FREE_THREADED_PYTHON:
+    SETUPTOOLS_OPTIONS["bdist_wheel"] = {"py_limited_api": "cp311"}
+
+setup(ext_modules=cythonize(extensions), options=SETUPTOOLS_OPTIONS)

--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,4 @@ extensions = [
     ),
 ]
 
-setup(ext_modules=cythonize(extensions))
+setup(ext_modules=cythonize(extensions), options={'bdist_wheel': {'py_limited_api': 'cp311'}})

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ package_data = {
 include_dirs = [np.get_include()]
 
 # Setup C module macros
-define_macros = [("NUMPY", "1")]
+define_macros = [
+    ("NUMPY", "1"),
+    ("Py_LIMITED_API", 0x030B0000),  # PY_VERSION_HEX for 3.11
+]
 
 # importing these extension modules is tested in `.github/workflows/build.yml`;
 # when adding new modules here, make sure to add them to the `test_command` entry there
@@ -25,24 +28,31 @@ extensions = [
         ["src/stcal/ramp_fitting/ols_cas22/_ramp.pyx"],
         include_dirs=[np.get_include()],
         language="c++",
+        define_macros=define_macros,
+        py_limited_api=True,
     ),
     Extension(
         "stcal.ramp_fitting.ols_cas22._jump",
         ["src/stcal/ramp_fitting/ols_cas22/_jump.pyx"],
         include_dirs=[np.get_include()],
         language="c++",
+        define_macros=define_macros,
+        py_limited_api=True,
     ),
     Extension(
         "stcal.ramp_fitting.ols_cas22._fit",
         ["src/stcal/ramp_fitting/ols_cas22/_fit.pyx"],
         include_dirs=[np.get_include()],
         language="c++",
+        define_macros=define_macros,
+        py_limited_api=True,
     ),
     Extension(
         "stcal.ramp_fitting.slope_fitter",
         ["src/stcal/ramp_fitting/src/slope_fitter.c"],
         include_dirs=include_dirs,
         define_macros=define_macros,
+        py_limited_api=True,
     ),
 ]
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [SCSB-237](https://jira.stsci.edu/browse/SCSB-237)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

building against the Limited API means we can build just ONE wheel (in this case for Python 3.11) and it should work on all future Python versions: https://docs.python.org/3/c-api/stable.html#limited-c-api

status of this PR: **needs changes to C code to align with Limited API / Stable ABI3**

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
