### PR TITLE
JP-4352: Fix floating point overflow in variance weighting for resampled spectra

### DIFF
--- a/changes/556.resample.rst
+++ b/changes/556.resample.rst
@@ -1,1 +1,1 @@
-Avoid floating point overflow causing exactly zero error and variance images with "ivm" weights for input data in MJy.
+Avoid floating point overflow causing zero-valued error and variance images with "ivm" weights for input data in MJy.

--- a/changes/556.resample.rst
+++ b/changes/556.resample.rst
@@ -1,0 +1,1 @@
+Avoid floating point overflow causing exactly zero error and variance images with "ivm" weights for input data in MJy.

--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -1171,6 +1171,8 @@ class Resample:
             wsum = self._variance_info[varname]["wsum"]
             mask = (var >= 0) & np.isfinite(var) & (weight > 0)
             with warnings.catch_warnings():
+                # Multiplying the weights separately should avoid overflow in
+                # most situations. Catch the warning for extreme cases.
                 warnings.filterwarnings("ignore", "overflow encountered", RuntimeWarning)
                 wsum[mask] = np.nansum([wsum[mask], var[mask] * weight[mask] * weight[mask]], axis=0)
             self._variance_info[varname]["wt"][mask] += weight[mask]
@@ -1205,14 +1207,16 @@ class Resample:
                 scaling = 1.0
             else:
                 if is_imaging_wcs(self.output_wcs):
-                    scaling = self.pixel_scale_ratio**2
+                    scaling = 1.0 / self.pixel_scale_ratio**2
                 else:
-                    scaling = 1.0 / self.pixel_scale_ratio
+                    scaling = self.pixel_scale_ratio
 
             for varname in self.variance_array_names:
                 varwsum = self._variance_info[varname]["wsum"]
                 weight = self._variance_info[varname]["wt"]
-                output_model[varname] = (varwsum / (weight * weight * scaling)).astype(
+                # Divide weights separately instead of multiplying them together
+                # before division to avoid floating point overflow
+                output_model[varname] = (varwsum * scaling / weight / weight).astype(
                     dtype=self.output_array_types[varname]
                 )
             del self._variance_info

--- a/tests/resample/test_resample.py
+++ b/tests/resample/test_resample.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import numpy as np
 import pytest
@@ -326,3 +327,63 @@ def test_resample_photometry(nrcb5_many_fluxes, pscale_ratio, kernel, weight_typ
         wfout = np.nansum(out_wdata[ymin:ymax, xmin:xmax])
 
         assert np.allclose(wfin, wfout, rtol=1.0e-6, atol=0.0)
+
+
+def test_resample_ivm_weight_overflow():
+    crval = (150.0, 2.0)
+    crpix = (500.0, 500.0)
+    shape = (1000, 1000)
+    out_shape = (500, 500)
+    pscale_in = 0.1 / 3600  # Input pixel scale 0.1 arcsec
+    pscale_out = 0.2 / 3600  # Output pixel scale 0.2 arcsec
+
+    # Input flux density and error scaled to MJy
+    # This is a typical level for NIRSpec point sources, which will trigger
+    # floating point overflow if variances are not carefully handled.
+    sb_in = 1e-13
+    sb_err_in = 1e-14
+
+    output_model = make_output_model(
+        crpix=(250, 250),
+        crval=crval,
+        pscale=pscale_out,
+        shape=out_shape,
+    )
+
+    weight_type = "ivm"
+    compute_err = "from_var"
+    resample = Resample(
+        n_input_models=1,
+        output_wcs=output_model,
+        weight_type=weight_type,
+        compute_err=compute_err,
+    )
+
+    im = make_input_model(
+        shape=shape, crpix=tuple(i - 6 for i in crpix), crval=crval, pscale=pscale_in, group_id=1
+    )
+    im["data"][:, :] = sb_in
+    im["err"][:, :] = sb_err_in
+    im["var_poisson"][:, :] = 0
+    im["var_rnoise"][:, :] = sb_err_in**2
+    im["var_flat"][:, :] = 0
+    resample.add_model(im)
+
+    # No overflow warnings issued
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        resample.finalize()
+
+    odata = np.nanmedian(resample.output_model["data"])
+    oerr = np.nanmedian(resample.output_model["err"])
+    ovar = np.nanmedian(resample.output_model["var_rnoise"])
+
+    # Surface brightness should be unchanged with new pixel scale
+    assert np.allclose(odata, sb_in, atol=0, rtol=1e-6)
+
+    # Surface brightness error and variance should have scaled with pixel area.
+    # They are not all zero.
+    assert np.allclose(oerr, sb_err_in * (pscale_in / pscale_out), atol=0, rtol=1e-6)
+    assert not np.allclose(oerr, 0, atol=0, rtol=1e-6)
+    assert np.allclose(ovar, (sb_err_in * pscale_in / pscale_out) ** 2, atol=0, rtol=1e-6)
+    assert not np.allclose(ovar, 0, atol=0, rtol=1e-6)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4352](https://jira.stsci.edu/browse/JP-4352)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->

Fix a floating point overflow problem that typically occurs with NIRSpec point sources and 'ivm' weights.  Typical flux values for point sources in MJy are ~1e-13, error values ~1e-14, and variance values ~1e-28.  The very small variance values can lead to overflow if they are not handled carefully.   This PR fixes one place where variance weights were multiplied together before being divided out, leading to exactly zero error and variance images.  

This regression was introduced in jwst v1.18.0, when the resampling code was refactored and moved from jwst to stcal.  I have added a unit test for data with typical MJy flux scales and verified that it fails without the fix here, so hopefully the regression will not be reintroduced in the future.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
