### PR TITLE
JP-3892: Update Jump Documentation

### DIFF
--- a/changes/562.jump.rst
+++ b/changes/562.jump.rst
@@ -1,0 +1,1 @@
+Updated the jump step documentation and fixed a small bug in computing ``total_sigclip_groups``.

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -21,34 +21,31 @@ in `Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.12
 
 Two-Point Difference Method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The two-point difference method is applied to each integration as follows:
+The two-point difference method is applied as follows:
 
-#. Compute the first differences for each pixel (the difference between
-   adjacent groups)
-#. Compute the clipped median (dropping the largest difference) of the first differences for each pixel.
-   If there are only three first difference values (four groups), no clipping is
-   performed when computing the median.
-#. Use the median to estimate the Poisson noise for each group and combine it
-   with the read noise to arrive at an estimate of the total expected noise for
-   each difference.
-#. Compute the "difference ratio" as the difference between the first differences
-   of each group and the median, divided by the expected noise.
-#. If the largest "difference ratio" is greater than the rejection threshold,
-   flag the group corresponding to that ratio as having a jump.
-#. If a jump is found in a given pixel, iterate the above steps with the
-   jump-impacted group excluded, looking for additional lower-level jumps
-   that still exceed the rejection threshold.
-#. Stop iterating on a given pixel when no new jumps are found or only one
-   difference remains.
-#. If there are only two differences (three groups), the smallest one is compared to the larger
-   one and if the larger one is above a threshold, it is flagged as a jump.
-#. If flagging of the 4 neighbors is requested, then the 4 adjacent pixels will
-   have ramp jumps flagged in the same group as the central pixel as long as it has
-   a jump between the min and max requested levels for this option.
-#. If flagging of groups after a ramp jump is requested, then the groups in the
-   requested time since a detected ramp jump will be flagged as ramp jumps if
-   the ramp jump is above the requested threshold.  Two thresholds and times are
-   possible for this option.
+It is based on two conditions:
+
+A. If ``only_use_ints`` is ``True``, then the number of integrations needs to be
+   greater than ``minimum_sigclip_groups``, which has a default of 100.
+
+B. If ``only_use_ints`` is ``False``, then the total number of available groupsi
+   needs to be greater than ``minimum_sigclip_groups``.
+
+If both A and B are false and there are not enough usable groups in each integration,
+then the jump step is skipped.
+
+The jump step runs using the first differences of groups in integrations runs as follows.
+
+#. If the groups are evenly spaced in time and A or B is true, then do the following.
+    #. If A is true, then use ``astropy.stats.sigma_clip`` across integrations,
+       using ``rejection_threshold`` for jump detection.
+    #. If B is true, then use ``astropy.stats.sigma_clip`` across integrations
+       and groups ``rejection_threshold`` for jump detection.
+#. Else, do the following.
+    #. If the minimum number of usable groups is greater than ``min_diffs_single_pass+1``.
+       The ``+1`` is needed because first differences are used; there 
+       which defaults to 10, then detect jumps in each integration using 4 sigma outliers.
+    #. Else, do an iterative flagging within each integration.
 
 Note that any ramp groups flagged as SATURATED in the input GROUPDQ array
 are not used in any of the above calculations and hence will never be

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -37,15 +37,28 @@ then the jump step is skipped.
 The jump step runs using the first differences of groups in integrations runs as follows.
 
 #. If the groups are evenly spaced in time and A or B is true, then:
+
     #. If A is true, then use ``astropy.stats.sigma_clip`` across integrations,
-       using ``rejection_threshold`` for jump detection.
+       using ``rejection_threshold`` for jump detection. The default value for
+       ``rejection_threshold`` is 4.0.
     #. If B is true, then use ``astropy.stats.sigma_clip`` across integrations
        and groups ``rejection_threshold`` for jump detection.
+
 #. Else:
+
     #. If the minimum number of usable groups is greater than ``min_diffs_single_pass+1``.
        The ``+1`` is needed because first differences are used; ``min_diffs_single_pass``
-       defaults to 10. Then detect jumps in each integration using 4 sigma outliers.
+       defaults to 10. Then detect jumps in each integration using sigma outliers above
+       ``rejection_threshold``.
     #. Else, do an iterative flagging within each integration.
+
+If flagging of the 4 neighbors is requested, then the 4 adjacent pixels will have
+ramp jumps flagged in the same group as the central pixel as long as it has a jump
+between the min and max requested levels for this option.
+
+If flagging of groups after a ramp jump is requested, then the groups in the requested
+time since a detected ramp jump will be flagged as ramp jumps if the ramp jump is above
+the requested threshold. Two thresholds and times are possible for this option.
 
 Note that any ramp groups flagged as SATURATED in the input GROUPDQ array
 are not used in any of the above calculations and hence will never be

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -36,15 +36,15 @@ then the jump step is skipped.
 
 The jump step runs using the first differences of groups in integrations runs as follows.
 
-#. If the groups are evenly spaced in time and A or B is true, then do the following.
+#. If the groups are evenly spaced in time and A or B is true, then:
     #. If A is true, then use ``astropy.stats.sigma_clip`` across integrations,
        using ``rejection_threshold`` for jump detection.
     #. If B is true, then use ``astropy.stats.sigma_clip`` across integrations
        and groups ``rejection_threshold`` for jump detection.
-#. Else, do the following.
+#. Else:
     #. If the minimum number of usable groups is greater than ``min_diffs_single_pass+1``.
-       The ``+1`` is needed because first differences are used; there 
-       which defaults to 10, then detect jumps in each integration using 4 sigma outliers.
+       The ``+1`` is needed because first differences are used; ``min_diffs_single_pass``
+       defaults to 10. Then detect jumps in each integration using 4 sigma outliers.
     #. Else, do an iterative flagging within each integration.
 
 Note that any ramp groups flagged as SATURATED in the input GROUPDQ array

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -9,56 +9,77 @@ any pixels that have non-positive or NaN values in the gain reference file will
 have DQ flags "NO_GAIN_VALUE" and "DO_NOT_USE" set in the output PIXELDQ array.
 The SCI array of the input data is not modified.
 
-Jumps can be detected in two different ways.  The primary way is the two-point
-difference method described below.  The other way is by selecting ``only_use_ints``
-as ``True`` and if there are enough integrations, then ``sigma_clip`` from the
-``astropy.stats`` package will be used to detect jumps.  The ``sigma_clip`` method
-will also be used if the total number of usable groups (number of groups per
-integration multiplied by the number of integrations) is above a minimum threshold.
+Jumps in the ramps of a given pixel are detected using statistics of the
+two-point differences between successive groups. Those statistics either use
+sigma clipping or the method described in
+`Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_.
 
-The current implementation uses the two-point difference method described
-in `Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_.
-
-Two-Point Difference Method
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The two-point difference method is applied as follows:
-
-It is based on two conditions:
+The flow control of the jump step is based on two conditions:
 
 A. If ``only_use_ints`` is ``True``, then the number of integrations needs to be
    greater than ``minimum_sigclip_groups``, which has a default of 100.
 
-B. If ``only_use_ints`` is ``False``, then the total number of available groupsi
+B. If ``only_use_ints`` is ``False``, then the total number of available groups
    needs to be greater than ``minimum_sigclip_groups``.
 
 If both A and B are false and there are not enough usable groups in each integration,
-then the jump step is skipped.
+``minimum_groups`` defaults to 3, then the jump step is skipped.
 
-The jump step runs using the first differences of groups in integrations runs as follows.
+If A is ``True``, then sigma clip across integrations for each group difference
+in the ramp (e.g., sigma clip groups 3-2 for all integrations, then sigma clip
+groups 4-3 for all integrations, etc).
 
-#. If the groups are evenly spaced in time and A or B is true, then:
+If B is ``True``, then sigma clip across all group differences and all integrations
+simultaneously (e.g., treat all group differences within an integration and in other
+integrations equally).
 
-    #. If A is true, then use ``astropy.stats.sigma_clip`` across integrations,
-       using ``rejection_threshold`` for jump detection. The default value for
-       ``rejection_threshold`` is 4.0.
-    #. If B is true, then use ``astropy.stats.sigma_clip`` across integrations
-       and groups ``rejection_threshold`` for jump detection.
+If neither A, nor B, are ``True``, then ``astropy.stats.sigma_clip`` is not used.
+The algorithm detailed below is used on groups within each integration or is used
+over all groups in all integrations.
 
-#. Else:
+If there are at least ``min_diffs_single_pass`` in each integration, then use the
+two-point difference detailed below over the first group differences in each
+integration. This will do a single pass over the first group differences in each
+integration.
 
-    #. If the minimum number of usable groups is greater than ``min_diffs_single_pass+1``.
-       The ``+1`` is needed because first differences are used; ``min_diffs_single_pass``
-       defaults to 10. Then detect jumps in each integration using sigma outliers above
-       ``rejection_threshold``.
-    #. Else, do an iterative flagging within each integration.
+Otherwise, use the two-point difference detailed below looping over all groups
+across all integrations. This will be an iterative approach that loops over all
+first group differences, :math:`(ngroups-1) * nints`, where :math:`ngroups` is
+the number of groups in each integration (the :math:`-1` is used because the
+operations are on the first differences) and :math:`nints` is the number of
+integrations.
 
-If flagging of the 4 neighbors is requested, then the 4 adjacent pixels will have
-ramp jumps flagged in the same group as the central pixel as long as it has a jump
-between the min and max requested levels for this option.
+Two-Point Difference Method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The two-point difference method is applied to each integration as follows:
 
-If flagging of groups after a ramp jump is requested, then the groups in the requested
-time since a detected ramp jump will be flagged as ramp jumps if the ramp jump is above
-the requested threshold. Two thresholds and times are possible for this option.
+#. Compute the first differences for each pixel (the difference between
+   adjacent groups)
+#. Compute the clipped median (dropping the largest difference) of the first
+   differences for each pixel. If there are only three first difference values
+   (four groups), no clipping is performed when computing the median.
+#. Use the median to estimate the Poisson noise for each group and combine it
+   with the read noise to arrive at an estimate of the total expected noise for
+   each difference.
+#. Compute the "difference ratio" as the difference between the first differences
+   of each group and the median, divided by the expected noise.
+#. If the largest "difference ratio" is greater than the rejection threshold,
+   flag the group corresponding to that ratio as having a jump.
+#. If a jump is found in a given pixel, iterate the above steps with the
+   jump-impacted group excluded, looking for additional lower-level jumps
+   that still exceed the rejection threshold.
+#. Stop iterating on a given pixel when no new jumps are found or only one
+   difference remains.
+#. If there are only two differences (three groups), the smallest one is compared
+   to the larger one and if the larger one is above a threshold, it is flagged
+   as a jump.
+#. If flagging of the 4 neighbors is requested, then the 4 adjacent pixels will
+   have ramp jumps flagged in the same group as the central pixel as long as it has
+   a jump between the min and max requested levels for this option.
+#. If flagging of groups after a ramp jump is requested, then the groups in the
+   requested time since a detected ramp jump will be flagged as ramp jumps if
+   the ramp jump is above the requested threshold.  Two thresholds and times are
+   possible for this option.
 
 Note that any ramp groups flagged as SATURATED in the input GROUPDQ array
 are not used in any of the above calculations and hence will never be

--- a/docs/stcal/jump/description.rst
+++ b/docs/stcal/jump/description.rst
@@ -10,48 +10,73 @@ have DQ flags "NO_GAIN_VALUE" and "DO_NOT_USE" set in the output PIXELDQ array.
 The SCI array of the input data is not modified.
 
 Jumps in the ramps of a given pixel are detected using statistics of the
-two-point differences between successive groups. Those statistics either use
-sigma clipping or the method described in
-`Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_.
+two-point differences between successive groups to identify outlying values.
+Depending on the ramp length and parameter configuration one of four different
+methods can be used.
 
-The flow control of the jump step is based on two conditions:
-
-A. If ``only_use_ints`` is ``True``, then the number of integrations needs to be
-   greater than ``minimum_sigclip_groups``, which has a default of 100.
-
-B. If ``only_use_ints`` is ``False``, then the total number of available groups
-   needs to be greater than ``minimum_sigclip_groups``.
-
-If both A and B are false and there are not enough usable groups in each integration,
-``minimum_groups`` defaults to 3, then the jump step is skipped.
-
-If A is ``True``, then sigma clip across integrations for each group difference
+1) Astropy sigma clipping across integrations for each group difference
 in the ramp (e.g., sigma clip groups 3-2 for all integrations, then sigma clip
-groups 4-3 for all integrations, etc).
+groups 4-3 for all integrations, etc).  The appropriate value of sigma to use is
+determined empirically from the ensemble of group differences.
 
-If B is ``True``, then sigma clip across all group differences and all integrations
+2) Astropy sigma clipping across all group differences and all integrations
 simultaneously (e.g., treat all group differences within an integration and in other
-integrations equally).
+integrations equally).  The appropriate value of sigma to use is
+determined empirically from the ensemble of group differences.
 
-If neither A, nor B, are ``True``, then ``astropy.stats.sigma_clip`` is not used.
-The algorithm detailed below is used on groups within each integration or is used
-over all groups in all integrations.
+3) Sigma clipping between all group differences within a given integration using
+a single pass of the method described by 
+`Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_
+(see below).  The appropriate value of sigma to use is determined
+using the estimated read noise plus poisson noise for each pixel.
 
-If there are at least ``min_diffs_single_pass`` in each integration, then use the
-two-point difference detailed below over the first group differences in each
-integration. This will do a single pass over the first group differences in each
-integration.
-
-Otherwise, use the two-point difference detailed below looping over all groups
-across all integrations. This will be an iterative approach that loops over all
+4) Sigma clipping using the
+`Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_
+method in which the median and rejection parameters are iteratively recalculated
+after each group difference is rejected.
+This is an iterative approach that loops over all
 first group differences, :math:`(ngroups-1) * nints`, where :math:`ngroups` is
 the number of groups in each integration (the :math:`-1` is used because the
 operations are on the first differences) and :math:`nints` is the number of
 integrations.
 
-Two-Point Difference Method
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The two-point difference method is applied to each integration as follows:
+Method 1 is used if ``only_use_ints`` is ``True`` and the number of usable integrations
+is greater than ``minimum_sigclip_groups``, which has a default of 100.  This is thus
+the method typically used for many time-series observations.
+
+Method 2 is used if ``only_use_ints`` is ``False`` and the number of usable differences
+across all groups and integrations (i.e., approximately ngroups*nints)
+is greater than ``minimum_sigclip_groups``.  This is not typically used by the default
+pipeline.
+
+Method 3 is used if neither Methods 1 or 2 were selected, but there are a sufficient number
+of usable group differences in each integration (``min_diffs_single_pass`` is 10 by default)
+to find all outliers in a single calculation.  This is the default method used
+by the pipeline for most non-time-series observations in which ngroups is greater than 10.
+
+Method 4 is used if neither Methods 1 or 2 were selected, and there are too few usable
+group differences in each integration to find all outliers at once.
+This method is more robust for short ramps, although the iterative
+rejection increases the step runtime.
+
+In all cases, if flagging of the 4 neighbors is requested, then the 4 adjacent pixels will
+have ramp jumps flagged in the same group as the central pixel as long as it has
+a jump between the min and max requested levels for this option.
+Likewise, if flagging of groups after a ramp jump is requested, then the groups in the
+requested time since a detected ramp jump will be flagged as ramp jumps if
+the ramp jump is above the requested threshold.  Two thresholds and times are
+possible for this option.
+Note that any ramp groups flagged as SATURATED in the input GROUPDQ array
+are not used in any of the above calculations and hence will never be
+marked as containing a jump.
+
+If the ramps are extremely short with the number of usable groups less than
+``minimum_groups`` (default value of 3) no jump detection is performed.
+
+Anderson & Gordon Method
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The full iterative method described by `Anderson & Gordon (2011) <https://ui.adsabs.harvard.edu/abs/2011PASP..123.1237A>`_ is as follows:
 
 #. Compute the first differences for each pixel (the difference between
    adjacent groups)
@@ -73,14 +98,3 @@ The two-point difference method is applied to each integration as follows:
 #. If there are only two differences (three groups), the smallest one is compared
    to the larger one and if the larger one is above a threshold, it is flagged
    as a jump.
-#. If flagging of the 4 neighbors is requested, then the 4 adjacent pixels will
-   have ramp jumps flagged in the same group as the central pixel as long as it has
-   a jump between the min and max requested levels for this option.
-#. If flagging of groups after a ramp jump is requested, then the groups in the
-   requested time since a detected ramp jump will be flagged as ramp jumps if
-   the ramp jump is above the requested threshold.  Two thresholds and times are
-   possible for this option.
-
-Note that any ramp groups flagged as SATURATED in the input GROUPDQ array
-are not used in any of the above calculations and hence will never be
-marked as containing a jump.

--- a/src/stcal/jump/twopoint_difference.py
+++ b/src/stcal/jump/twopoint_difference.py
@@ -663,7 +663,7 @@ def groups_all_set_dnu(nints, ngroups, gdq, twopt_p):
     if twopt_p.only_use_ints:
         total_sigclip_groups = nints
     else:
-        total_sigclip_groups = nints * ngroups - num_flagged_grps
+        total_sigclip_groups = nints * ngroups - total_flagged_grps
 
     min_usable_groups = ngroups - max_flagged_grps
     total_groups = nints * ngroups - total_flagged_grps


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-3892](https://jira.stsci.edu/browse/JP-3892)

<!-- describe the changes comprising this PR here -->

This PR addresses jump step documentation detailing the logical control flow of the step. Also, a small bug was fixed in the computation of `total_sigclip_groups`.

Regression test runs for the bug fix:
jwst:
https://github.com/spacetelescope/RegressionTests/actions/runs/29337654497
romancal:
https://github.com/spacetelescope/RegressionTests/actions/runs/30379195390

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
