### PR TITLE
JP-4347: Vectorize ellipse checks for better snowball performance

### DIFF
--- a/changes/568.jump.rst
+++ b/changes/568.jump.rst
@@ -1,0 +1,1 @@
+Vectorize ellipse checks for faster snowball detection when many jumps are detected.

--- a/src/stcal/jump/jump.py
+++ b/src/stcal/jump/jump.py
@@ -402,16 +402,13 @@ def extend_saturation(cube, grp, sat_ellipses, jump_data, persist_jumps):
     ----------
     cube : ndarray
         Group DQ cube for an integration.
-
     grp : int
         The current group.
-
-    sat_ellipses : list of tuple
-        The saturated ellipse in the format of
-        ``[((cen_x, cen_y), (minor_axis, major_axis), theta_deg), ...]``.
-
+    sat_ellipses : ndarray
+        Saturated ellipses, as a record array with columns
+        ``cen_x, cen_y, minor_axis, major_axis, theta_deg``.
     jump_data : JumpData
-
+        Object containing parameters and methods to detect jumps.
     persist_jumps : ndarray
         3D (nints, nrows, ncols) uint8
 
@@ -426,17 +423,17 @@ def extend_saturation(cube, grp, sat_ellipses, jump_data, persist_jumps):
     ngroups, nrows, ncols = cube.shape
     satcolor = 22  # (0, 0, 22) is a dark blue in RGB
     for ellipse in sat_ellipses:
-        ceny = ellipse[0][0]
-        cenx = ellipse[0][1]
-        minor_axis = min(ellipse[1][1], ellipse[1][0])
+        ceny = ellipse["cen_x"]
+        cenx = ellipse["cen_y"]
+        minor_axis = ellipse["minor_axis"]
 
         if minor_axis > jump_data.min_sat_radius_extend:
-            axis1 = ellipse[1][0] + jump_data.sat_expand
-            axis2 = ellipse[1][1] + jump_data.sat_expand
+            axis1 = ellipse["minor_axis"] + jump_data.sat_expand
+            axis2 = ellipse["major_axis"] + jump_data.sat_expand
             axis1 = min(axis1, jump_data.max_extended_width)
             axis2 = min(axis2, jump_data.max_extended_width)
 
-            alpha = ellipse[2]
+            alpha = ellipse["theta_deg"]
 
             indx, sat_ellipse = ellipse_subim(ceny, cenx, axis1, axis2, alpha, satcolor, (nrows, ncols))
             (iy1, iy2, ix1, ix2) = indx
@@ -449,7 +446,7 @@ def extend_saturation(cube, grp, sat_ellipses, jump_data, persist_jumps):
             for i in range(grp, cube.shape[0]):
                 cube[i][iy1:iy2, ix1:ix2][is_sat] = jump_data.fl_sat
 
-            ax1, ax2 = (ellipse[1][0], ellipse[1][1])
+            ax1, ax2 = (ellipse["minor_axis"], ellipse["major_axis"])
             indx, persist_ellipse = ellipse_subim(ceny, cenx, ax1, ax2, alpha, satcolor, (nrows, ncols))
             (iy1, iy2, ix1, ix2) = indx
 
@@ -531,26 +528,19 @@ def extend_ellipses(
     ----------
     gdq_cube : ndarray
         Group DQ cube for an integration.  Modified in-place.
-
     intg : int
         The current integration.
-
     grp : int
         The current group.
-
-    ellipses : list of tuple
-        Ellipses for events in the format of
-        ``[((cen_x, cen_y), (minor_axis, major_axis), theta_deg), ...]``.
-
+    ellipses : ndarray
+        Event ellipses, as a record array with columns
+        ``cen_x, cen_y, minor_axis, major_axis, theta_deg``.
     jump_data : JumpData
-        Class containing parameters and methods to detect jumps.
-
+        Object containing parameters and methods to detect jumps.
     expansion : float
         The factor that increases the size of the snowball or enclosed ellipse.
-
     expand_by_ratio : bool
         Should the ellipse expansion be used?
-
     num_grps_masked : int
         The number of groups flagged.
 
@@ -558,7 +548,6 @@ def extend_ellipses(
     -------
     gdq_cube : ndarray
         Computed 3-D group DQ array, modified in-place
-
     num_ellipses : int
         The number of ellipses passed in as a parameter.
     """
@@ -568,11 +557,11 @@ def extend_ellipses(
     _, ngroups, nrows, ncols = gdq_cube.shape
     num_ellipses = len(ellipses)
     for ellipse in ellipses:
-        ceny = ellipse[0][0]
-        cenx = ellipse[0][1]
+        ceny = ellipse["cen_x"]
+        cenx = ellipse["cen_y"]
         axes = compute_axes(expand_by_ratio, ellipse, expansion, jump_data)
 
-        alpha = ellipse[2]
+        alpha = ellipse["theta_deg"]
 
         # Get the expanded ellipse in a subimage, along with the
         # indices that place this subimage within the full array.
@@ -630,28 +619,21 @@ def make_snowballs(
     ---------
     gdq : ndarray
         The 4-D group DQ array.
-
     integration : int
         The current integration being used.
-
     group : int
         The current group being used.
-
-    jump_ellipses : list of tuple
-        Ellipses computed based on jump detection in the format of
-        ``[((cen_x, cen_y), (minor_axis, major_axis), theta_deg), ...]``.
-
-    sat_ellipses : list of tuple
+    jump_ellipses : ndarray
+        Ellipses computed based on jump detection, as a record array
+        with columns ``cen_x, cen_y, minor_axis, major_axis, theta_deg``.
+    sat_ellipses : ndarray
         Ellipses computed based on saturation in the same format as
         ``jump_ellipses``.
-
-    next_sat_ellipses : list of tuple
+    next_sat_ellipses : ndarray
         Ellipses computed based on saturation in the next group
         in the same format as ``jump_ellipses``.
-
     jump_data : JumpData
         Class containing parameters and methods to detect jumps.
-
     persist_jumps : ndarray
         Zero array to be filled in.
 
@@ -659,10 +641,8 @@ def make_snowballs(
     -------
     gdq : ndarray
         The 4-D group DQ array.
-
-    snowballs : list
-        List of snowballs found.
-
+    snowballs : list of ndarray
+        List of snowball ellipses found.
     persist_jumps : ndarray
         Filled in array.
     """
@@ -670,25 +650,20 @@ def make_snowballs(
     low_threshold = jump_data.edge_size
     high_threshold = max(0, nrows - jump_data.edge_size)
 
-    # This routine will create a list of snowballs (ellipses) that have the
-    # center of the saturation circle within the enclosing jump rectangle.
-    snowballs = []
-    for jump in jump_ellipses:
-        if near_edge(jump, low_threshold, high_threshold):
-            # if the jump ellipse is near the edge, do not require saturation in the
-            # center of the jump ellipse
-            snowballs.append(jump)
-        else:
-            for sat in sat_ellipses:
-                if point_inside_ellipse(sat[0], jump) and jump not in snowballs:
-                    snowballs.append(jump)
-            if group < ngroups - 1:
-                # Is there saturation inside the jump in the next group?
-                for next_sat in next_sat_ellipses:
-                    if (point_inside_ellipse(next_sat[0], jump)) and jump not in snowballs:
-                        snowballs.append(jump)
+    # Check if the jump is near the edge: in that case, no saturation check needed.
+    is_snowball = near_edge(jump_ellipses, low_threshold, high_threshold)
 
-    # extend the saturated ellipses that are larger than the min_sat_radius
+    # Check if the jump contains any newly saturated ellipses
+    is_snowball |= center_inside_ellipse(sat_ellipses, jump_ellipses)
+
+    # Check if the jump contains any newly saturated ellipses in the next group
+    if group < ngroups - 1:
+        is_snowball |= center_inside_ellipse(next_sat_ellipses, jump_ellipses)
+
+    # If any of these conditions are met, the jump is a snowball.
+    snowballs = jump_ellipses[is_snowball]
+
+    # Extend the saturated ellipses that are larger than the min_sat_radius
     gdq[integration, :, :, :], persist_jumps[integration, :, :] = extend_saturation(
         gdq[integration, :, :, :],
         group,
@@ -700,46 +675,40 @@ def make_snowballs(
     return gdq, snowballs, persist_jumps
 
 
-def point_inside_ellipse(point, ellipse):
+def center_inside_ellipse(inner_ellipse, outer_ellipse):
     """
-    Detect if a point is inside an ellipse.
+    Detect if the center of an ellipse is inside another ellipse.
 
     Parameters
     ----------
-    point : tuple
-        Point of interest in the format of ``(x, y)``.
-
-    ellipse : tuple
-        Ellipse for testing in the format of
-        ``((cen_x, cen_y), (minor_axis, major_axis), theta_deg)``.
+    inner_ellipse : ndarray
+        Inner ellipses of interest. Center point is in ``cen_x, cen_y`` columns.
+    outer_ellipse : ndarray
+        Outer ellipses to test.
 
     Returns
     -------
-    bool
-        Boolean decision if point is in ellipse
+    ndarray of bool
+        Boolean decision if the center of any inner ellipse is in each outer ellipse.
+        1D array; length matches ``outer_ellipse``.
     """
     # https://stackoverflow.com/questions/37031356/check-if-points-are-inside-ellipse-faster-than-contains-point-method
 
-    angle = np.radians(180 - ellipse[2])
+    angle = np.radians(180 - outer_ellipse["theta_deg"])
     cos_angle = np.cos(angle)
     sin_angle = np.sin(angle)
 
-    xc = point[0] - ellipse[0][0]
-    yc = point[1] - ellipse[0][1]
+    xc = np.subtract.outer(inner_ellipse["cen_x"], outer_ellipse["cen_x"])
+    yc = np.subtract.outer(inner_ellipse["cen_y"], outer_ellipse["cen_y"])
 
     xct = xc * cos_angle - yc * sin_angle
     yct = xc * sin_angle + yc * cos_angle
 
-    if ellipse[1][1] >= ellipse[1][0]:
-        semi_major_axis = ellipse[1][1] * 0.5
-        semi_minor_axis = ellipse[1][0] * 0.5
-    else:
-        semi_major_axis = ellipse[1][0] * 0.5
-        semi_minor_axis = ellipse[1][1] * 0.5
+    semi_major_axis = outer_ellipse["major_axis"] / 2
+    semi_minor_axis = outer_ellipse["minor_axis"] / 2
+    rad_cc = (xct / semi_major_axis) ** 2 + (yct / semi_minor_axis) ** 2
 
-    rad_cc = (xct**2 / semi_major_axis**2) + (yct**2 / semi_minor_axis**2)
-
-    return rad_cc <= 1
+    return np.any(rad_cc <= 1, axis=0)
 
 
 def near_edge(jump, low_threshold, high_threshold):
@@ -751,28 +720,26 @@ def near_edge(jump, low_threshold, high_threshold):
 
     Parameters
     ----------
-    jump : tuple
-        Ellipse to check if close to detector edge in the format of
-        ``((cen_x, cen_y), (minor_axis, major_axis), theta_deg)``.
-
+    jump : ndarray
+        Ellipses to check, as a record array with columns
+        ``cen_x, cen_y, minor_axis, major_axis, theta_deg``.
     low_threshold :  int
         Low threshold distance from the edge of the detector where saturated cores are not
         required for snowball detection.
-
     high_threshold : int
         High threshold distance from the edge of the detector where saturated cores are not
         required for snowball detection.
 
     Returns
     -------
-    bool
-        True if ellipse is close to the detector's edge.
+    ndarray of bool
+        True if ellipse is close to the detector's edge. 1D, matching length of ``jump`` array.
     """
     return (
-        jump[0][0] < low_threshold
-        or jump[0][1] < low_threshold
-        or jump[0][0] > high_threshold
-        or jump[0][1] > high_threshold
+        (jump["cen_x"] < low_threshold)
+        | (jump["cen_y"] < low_threshold)
+        | (jump["cen_x"] > high_threshold)
+        | (jump["cen_y"] > high_threshold)
     )
 
 
@@ -973,21 +940,17 @@ def compute_axes(expand_by_ratio, ellipse, expansion, jump_data):
 
     The number of pixels added to both axes is the number of pixels added
     to the minor axis. This prevents very large flagged ellipses with high
-    axis ratio ellipses. The major and minor axis are not always the same
-    index.  Therefore, we have to test to find which is actually the minor axis.
+    axis ratio ellipses.
 
     Parameters
     ----------
     expand_by_ratio : bool
         Should the axes be expanded?
-
-    ellipse : tuple
-        Ellipse to expand in the format of
-        ``((cen_x, cen_y), (minor_axis, major_axis), theta_deg)``.
-
+    ellipse : array
+        Ellipse to expand, as a record array with columns
+        ``cen_x, cen_y, minor_axis, major_axis, theta_deg``.
     expansion : float
         The factor that increases the size of the snowball or enclosed ellipse.
-
     jump_data : JumpData
         Class containing parameters and methods to detect jumps.
 
@@ -997,19 +960,15 @@ def compute_axes(expand_by_ratio, ellipse, expansion, jump_data):
         Expanded and rounded ellipse axes.
     """
     if expand_by_ratio:
-        if ellipse[1][1] < ellipse[1][0]:
-            axis1 = ellipse[1][0] + (expansion - 1.0) * ellipse[1][1]
-            axis2 = ellipse[1][1] * expansion
-        else:
-            axis1 = ellipse[1][0] * expansion
-            axis2 = ellipse[1][1] + (expansion - 1.0) * ellipse[1][0]
+        axis1 = ellipse["minor_axis"] * expansion
+        axis2 = ellipse["major_axis"] + (expansion - 1.0) * ellipse["minor_axis"]
     else:
-        axis1 = ellipse[1][0] + expansion
-        axis2 = ellipse[1][1] + expansion
+        axis1 = ellipse["minor_axis"] + expansion
+        axis2 = ellipse["major_axis"] + expansion
     axis1 = min(axis1, jump_data.max_extended_width)
     axis2 = min(axis2, jump_data.max_extended_width)
 
-    return (round(axis1 / 2), round(axis2 / 2))
+    return round(axis1 / 2), round(axis2 / 2)
 
 
 def get_bigellipses(ratio, intg, grp, gdq, pdq, jump_data, ring_2D_kernel):  # noqa: N803
@@ -1305,14 +1264,11 @@ def _sk_filter_areas(image, threshold):
 
     Returns
     -------
-    list
-        List of found areas. Each area is a rotated rectangular
-        region encoded as is a 3 element list of values.
-        The first element is a tuple of 2 floats encoding the
-        center column and row. Element 2 is a tuple of 2 floats encoding
-        the area minor and major axis full lengths. Element 3 is a float
-        encoding the rotation angle of the area in degrees. Format:
-        ``[((cen_x, cen_y), (minor_axis, major_axis), theta_deg), ...]``
+    ndarray
+        Record array of found areas. Each area is a rotated rectangular
+        region encoded by 5 numbers: center column and row, minor and major
+        full lengths, and the rotation angle of the area in degrees.
+        Column names are: ``cen_x, cen_y, minor_axis, major_axis, theta_deg``.
     """
     lim = skimage.measure.label(image)
     min_areas = []
@@ -1325,6 +1281,17 @@ def _sk_filter_areas(image, threshold):
         w = region.axis_major_length - 1
         h = region.axis_minor_length - 1
         min_areas.append(
-            ((float(region.centroid[1]), float(region.centroid[0])), (h, w), np.degrees(region.orientation))
+            (float(region.centroid[1]), float(region.centroid[0]), h, w, np.degrees(region.orientation))
         )
+
+    min_areas = np.array(
+        min_areas,
+        dtype=[
+            ("cen_x", np.float64),
+            ("cen_y", np.float64),
+            ("minor_axis", np.float64),
+            ("major_axis", np.float64),
+            ("theta_deg", np.float64),
+        ],
+    )
     return min_areas

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -3,12 +3,12 @@ import pytest
 from astropy.io import fits
 
 from stcal.jump.jump import (
+    center_inside_ellipse,
     detect_jumps_data,
     extend_saturation,
     find_ellipses,
     find_faint_extended,
     flag_large_events,
-    point_inside_ellipse,
 )
 from stcal.jump.jump_class import JumpData
 
@@ -27,6 +27,14 @@ SAT = DQFLAGS["SATURATED"]
 JUMP = DQFLAGS["JUMP_DET"]
 NGV = DQFLAGS["NO_GAIN_VALUE"]
 REF = DQFLAGS["REFERENCE_PIXEL"]
+
+ELLIPSE_DTYPE = [
+    ("cen_x", np.float64),
+    ("cen_y", np.float64),
+    ("minor_axis", np.float64),
+    ("major_axis", np.float64),
+    ("theta_deg", np.float64),
+]
 
 
 def create_jump_data(dims, gain, rnoise, tm):
@@ -217,8 +225,8 @@ def test_find_simple_ellipse():
     plane[3, 3] = JUMP
     ellipse = find_ellipses(plane, JUMP, 1)
 
-    assert ellipse[0][2] == pytest.approx(90, 1)  # angle
-    assert ellipse[0][0] == pytest.approx((2.5, 2.0))  # center
+    assert ellipse[0]["theta_deg"] == pytest.approx(90, 1)  # angle
+    assert (ellipse[0]["cen_x"], ellipse[0]["cen_y"]) == pytest.approx((2.5, 2.0))  # center
 
 
 def test_find_ellipse2():
@@ -228,11 +236,11 @@ def test_find_ellipse2():
     plane[3, :] = [0, JUMP, JUMP, JUMP, 0]
     ellipses = find_ellipses(plane, JUMP, 1)
     ellipse = ellipses[0]
-    assert ellipse[0][0] == 2
-    assert ellipse[0][1] == 2
-    assert ellipse[1][0] == pytest.approx(2.266, 1e-3)
-    assert ellipse[1][1] == pytest.approx(2.266, 1e-3)
-    assert ellipse[2] == pytest.approx(-45, 1)
+    assert ellipse["cen_x"] == 2
+    assert ellipse["cen_y"] == 2
+    assert ellipse["minor_axis"] == pytest.approx(2.266, 1e-3)
+    assert ellipse["major_axis"] == pytest.approx(2.266, 1e-3)
+    assert ellipse["theta_deg"] == pytest.approx(-45, 1)
 
 
 def test_extend_saturation_simple():
@@ -488,23 +496,46 @@ def test_find_faint_extended_sigclip():
 @pytest.mark.parametrize(
     ("ellipse", "point"),
     [
-        (((0, 0), (2, 4), -10), (1, 0.6)),
-        (((0, 0), (2, 4), 0), (1, 0.5)),
+        ((0, 0, 2, 4, -10), (1, 0.6)),
+        ((0, 0, 2, 4, 0), (1, 0.5)),
         (
-            ((1111.0001220703125, 870.5000610351562), (10.60660171508789, 10.60660171508789), 45.0),
+            (1111.0001220703125, 870.5000610351562, 10.60660171508789, 10.60660171508789, 45.0),
             (1110.5, 870.5),
         ),
-        (((0, 0), (10, 5), 0), (0, 0)),
-        (((0, 0), (10, 5), 0), (5, 0)),
+        ((0, 0, 5, 10, 0), (0, 0)),
+        ((0, 0, 5, 10, 0), (5, 0)),
     ],
 )
-def test_point_inside_ellipse(ellipse, point):
-    assert point_inside_ellipse(point, ellipse)
+def test_center_inside_ellipse(ellipse, point):
+    inner = np.array([(*point, 0, 0, 0)], dtype=ELLIPSE_DTYPE)
+    outer = np.array([ellipse], dtype=ELLIPSE_DTYPE)
+    assert np.all(center_inside_ellipse(inner, outer))
 
 
 @pytest.mark.parametrize(
     ("ellipse", "point"),
-    [(((0, 0), (2, 4), 0), (3, 0.5)), (((0, 0), (10, 5), 0), (0, 8)), (((0, 0), (10, 5), 0), (8, 0))],
+    [
+        ((0, 0, 2, 4, 0), (3, 0.5)),
+        ((0, 0, 5, 10, 0), (0, 8)),
+        ((0, 0, 5, 10, 0), (8, 0)),
+    ],
 )
-def test_point_outside_ellipse(ellipse, point):
-    assert not point_inside_ellipse(point, ellipse)
+def test_center_outside_ellipse(ellipse, point):
+    inner = np.array([(*point, 0, 0, 0)], dtype=ELLIPSE_DTYPE)
+    outer = np.array([ellipse], dtype=ELLIPSE_DTYPE)
+    assert not np.any(center_inside_ellipse(inner, outer))
+
+
+@pytest.mark.parametrize(
+    ("inner", "expected"),
+    [
+        ([(0, 0, 0, 0, 0)], [True, True]),  # 1 point, in both ellipses
+        ([(1, 0.6, 0, 0, 0), (8, 0, 0, 0, 0)], [True, True]),  # 2 points, 1 in both ellipses
+        ([(0, 8, 0, 0, 0), (3, 0.5, 0, 0, 0)], [False, True]),  # 2 points, 1 in 1 ellipse
+        ([(0, 8, 0, 0, 0), (8, 0, 0, 0, 0)], [False, False]),  # 2 points, none in ellipses
+    ],
+)
+def test_any_center_inside_any_ellipse(inner, expected):
+    inner = np.array(inner, dtype=ELLIPSE_DTYPE)
+    outer = np.array([(0, 0, 2, 4, 0), (0, 0, 5, 10, 00)], dtype=ELLIPSE_DTYPE)
+    assert np.all(center_inside_ellipse(inner, outer) == expected)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Resolves [JP-4347](https://jira.stsci.edu/browse/JP-4347)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

For exposures with many jumps and snowballs, the current `point_inside_ellipse` function gets called many times, inside a nested loop over all jumps and all saturation ellipses in the `make_snowballs` function, called by `flag_large_events`.  For this type of data, it's much faster to vectorize the check over all jumps and ellipses at once.

To enable vectorization, I'm updating the internal ellipse data structure from a list of tuples to a numpy record array.  This allows the ellipse parameters to be accessed by column name (`cen_x, cen_y, minor_axis, major_axis, theta_deg`) instead of index, which should also improve readability.  

I have also updated a couple places where the code compared ellipse axis lengths to determine which one is the major axis.  These checks were necessary with the opencv implementation, but shouldn't be necessary for the scikit-image implementation, since major and minor axes are already distinguished for each ellipse.

For the test data set in the JP ticket (jw02123001001_05101_00001_nrs1_uncal.fits) with 36,543 detected snowballs, on my computer, processing time drops from 303s in the `flag_large_events` function to 84s.  The remainder of the snowball processing time is almost entirely inside the `_sk_filter_areas` function, which uses scikit-image to label and measure ellipse properties. Profiling details for this example are below.

On main:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.030    0.030  318.633  318.633 jwst/jump/jump_step.py:65(process)
        1    0.296    0.296  318.274  318.274 stcal/jump/jump.py:29(detect_jumps_data)
        1    0.293    0.293  303.430  303.430 stcal/jump/jump.py:307(flag_large_events)
       93   14.752    0.159  220.586    2.372 stcal/jump/jump.py:623(make_snowballs)
193057145  205.580    0.000  205.580    0.000 stcal/jump/jump.py:703(point_inside_ellipse)
      279    0.134    0.000   81.328    0.291 stcal/jump/jump.py:596(find_ellipses)
      279    1.530    0.005   81.193    0.291 stcal/jump/jump.py:1294(_sk_filter_areas)
9626406/4184977    1.504    0.000   50.276    0.000 skimage/measure/_regionprops.py:234(wrapper)
```

With this branch:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.026    0.026   99.836   99.836 jwst/jump/jump_step.py:65(process)
        1    0.303    0.303   99.472   99.472 stcal/jump/jump.py:29(detect_jumps_data)
        1    0.247    0.247   84.012   84.012 stcal/jump/jump.py:307(flag_large_events)
      279    0.139    0.000   81.212    0.291 stcal/jump/jump.py:585(find_ellipses)
      279    1.545    0.006   81.073    0.291 stcal/jump/jump.py:1253(_sk_filter_areas)
9626406/4184977    1.491    0.000   49.963    0.000 skimage/measure/_regionprops.py:234(wrapper)
...
       93    0.090    0.001    1.250    0.013 stcal/jump/jump.py:612(make_snowballs)
```

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
