### PR TITLE
Handle single-resultant integral non-linearity correction

### DIFF
--- a/src/stcal/linearity/linearity.py
+++ b/src/stcal/linearity/linearity.py
@@ -560,8 +560,9 @@ def linearity_correction_int(
     """
     ngroups, nrows, ncols = data.shape
 
-    # If no inverse linearity coefficients, do simple correction in place
-    if ilin_coeffs is None:
+    # Use the simple correction when inverse coefficients are unavailable or
+    # when there is only one resultant and no slope can be estimated.
+    if ilin_coeffs is None or ngroups == 1:
         for plane in range(ngroups):
             data[plane] = apply_polynomial(data[plane], lin_coeffs, gdq[plane], dqflags)
         return data

--- a/tests/test_linearity_single_resultant.py
+++ b/tests/test_linearity_single_resultant.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from stcal.linearity.linearity import linearity_correction
+
+DQFLAGS = {
+    "GOOD": 0,
+    "DO_NOT_USE": 1,
+    "SATURATED": 2,
+    "DEAD": 1024,
+    "HOT": 2048,
+    "NO_LIN_CORR": 1048576,
+}
+
+
+def test_read_level_correction_single_resultant():
+    """A single resultant uses the classic correction instead of estimating a slope."""
+    nints, ngroups, nrows, ncols = 1, 1, 1, 1
+    data = np.full((nints, ngroups, nrows, ncols), 10.0, dtype=np.float32)
+    gdq = np.zeros_like(data, dtype=np.uint32)
+    pdq = np.zeros((nrows, ncols), dtype=np.uint32)
+    lin_dq = np.zeros((nrows, ncols), dtype=np.uint32)
+
+    lin_coeffs = np.zeros((3, nrows, ncols), dtype=np.float32)
+    lin_coeffs[:, 0, 0] = [0.0, 1.0, 0.01]
+    ilin_coeffs = np.zeros((3, nrows, ncols), dtype=np.float32)
+    ilin_coeffs[:, 0, 0] = [0.0, 1.0, -0.01]
+
+    corrected, _, _ = linearity_correction(
+        data,
+        gdq,
+        pdq,
+        lin_coeffs,
+        lin_dq,
+        DQFLAGS,
+        ilin_coeffs=ilin_coeffs,
+        read_pattern=[[1]],
+        satval=np.full((nrows, ncols), 65000.0, dtype=np.float32),
+    )
+
+    assert corrected[0, 0, 0, 0] == np.float32(11.0)


### PR DESCRIPTION
Closes #545.

## Summary

- handle a single-resultant input by using the existing classic polynomial linearity path
- avoid the read-level slope reconstruction that requires at least two resultants
- preserve the existing integral non-linearity behaviour for multi-resultant inputs
- add a focused regression test for a single-resultant `[[1]]` read pattern

This follows the behaviour agreed in #545 and prevents the current `IndexError` for one-resultant inputs.

## Testing

- core stcal test commands pass on Python 3.11, 3.12, 3.13 and 3.14
- oldest-dependency tests pass
- downstream romancal test command passes
