### PR TITLE
Replace resample runtime asserts with explicit errors

### DIFF
--- a/src/stcal/resample/resample.py
+++ b/src/stcal/resample/resample.py
@@ -470,9 +470,12 @@ class Resample:
             A dictionary of data model attributes and values.
 
         """
-        assert self._output_wcs is not None  # noqa: S101
-        assert np.array_equiv(self._output_wcs.array_shape, self._output_array_shape)  # noqa: S101
-        assert self._output_pixel_scale  # noqa: S101
+        if self._output_wcs is None:
+            raise RuntimeError("Output WCS is not configured.")
+        if not np.array_equiv(self._output_wcs.array_shape, self._output_array_shape):
+            raise RuntimeError("Output WCS array shape does not match the configured output shape.")
+        if not self._output_pixel_scale:
+            raise RuntimeError("Output pixel scale is not configured.")
 
         pix_area = self._output_pixel_scale**2
 
@@ -704,8 +707,8 @@ class Resample:
             The ``model`` does not have a required keyword.
 
         """
-        # TODO: do we need this to just raise a custom
-        assert isinstance(model, dict)  # noqa: S101
+        if not isinstance(model, dict):
+            raise TypeError(f"Input model must be a dictionary, got {type(model).__name__}.")
         min_attributes = [
             # arrays:
             "data",
@@ -1330,7 +1333,8 @@ class Resample:
 
     def finalize_time_info(self):
         """Perform final computations for the total time and update relevant fields of the output model."""
-        assert self._n_res_models  # noqa: S101
+        if not self._n_res_models:
+            raise RuntimeError("Cannot finalize exposure times before any models have been resampled.")
         # basic exposure time attributes:
         self._output_model["exposure_time"] = self._total_exposure_time
         self._output_model["start_time"] = min(self._exptime_start)

--- a/tests/test_resample_runtime_validation.py
+++ b/tests/test_resample_runtime_validation.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+import pytest
+
+from stcal.resample.resample import Resample
+
+
+def bare_resampler():
+    return object.__new__(Resample)
+
+
+def test_create_output_model_requires_wcs():
+    resampler = bare_resampler()
+    resampler._output_wcs = None
+    with pytest.raises(RuntimeError, match="Output WCS is not configured"):
+        resampler.create_output_model()
+
+
+def test_create_output_model_requires_consistent_shape():
+    resampler = bare_resampler()
+    resampler._output_wcs = SimpleNamespace(array_shape=(2, 2))
+    resampler._output_array_shape = (3, 3)
+    with pytest.raises(RuntimeError, match="array shape does not match"):
+        resampler.create_output_model()
+
+
+def test_create_output_model_requires_pixel_scale():
+    resampler = bare_resampler()
+    resampler._output_wcs = SimpleNamespace(array_shape=(2, 2))
+    resampler._output_array_shape = (2, 2)
+    resampler._output_pixel_scale = None
+    with pytest.raises(RuntimeError, match="Output pixel scale is not configured"):
+        resampler.create_output_model()
+
+
+def test_validate_input_model_rejects_non_mapping():
+    resampler = bare_resampler()
+    with pytest.raises(TypeError, match="Input model must be a dictionary"):
+        resampler.validate_input_model([])
+
+
+def test_finalize_time_info_requires_resampled_models():
+    resampler = bare_resampler()
+    resampler._n_res_models = 0
+    with pytest.raises(RuntimeError, match="before any models have been resampled"):
+        resampler.finalize_time_info()


### PR DESCRIPTION
Closes #469

## Context

`stcal.resample.Resample` currently uses Python `assert` statements for several production runtime invariants. Assertions are intended primarily as development checks and can be removed entirely when Python is run with optimisation (`python -O`). That means invalid resampling state can bypass these checks depending on interpreter configuration.

## Root cause

Five runtime conditions in `resample.py` are enforced with `assert`:

- an output WCS must exist before an output model is created
- the WCS array shape must match the configured output shape
- an output pixel scale must be available
- input models passed to `validate_input_model` must be dictionaries
- exposure-time finalisation requires at least one successfully resampled model

These are user/runtime state validations rather than internal invariants that should disappear under optimisation.

## Implementation

- replace the output-WCS, output-shape, output-pixel-scale, and no-resampled-model assertions with explicit `RuntimeError`s
- replace the input-model type assertion with an explicit `TypeError`
- provide diagnostic messages describing the failed condition
- add focused regression coverage for all five failure paths

## Impact

This makes resampling failures deterministic under both normal and optimised Python execution and gives callers actionable error messages instead of bare `AssertionError`s. It does not change drizzle calculations, WCS construction, weighting, DQ handling, variance propagation, or any numerical resampling behaviour.

## Validation

- `pytest -q tests/test_resample_runtime_validation.py tests/resample/test_resample.py`
- 68 passed
- focused regression tests re-run successfully on Python 3.13
- Ruff check passed for the modified source and new test file

## Scope

This PR is intentionally limited to replacing the production assertions identified in #469. No resampling algorithm or public numerical result is changed.