### PR TITLE
flag PRs likely to be AI-generated

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,20 @@
+name: quality
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  anti-slop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peakoss/anti-slop@57858eead489d08b255fab2af45a506c2ca6eab2 # v0.3.0
+        with:
+          max-failures: 4
+          close-pr: false
+          lock-pr: false


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->

uses https://github.com/peakoss/anti-slop to flag PRs that look like generated slop

~~I'm testing this on these PRs: https://github.com/spacetelescope/stcal/issues?q=is%3Apr+author%3Asylvesterkaczmarek~~

EDIT: it looks like `sylvesterkaczmarek` doesn't allow pushes to the fork as normal:
```
Changes to push to sylvesterkaczmarek:
  bookmark: fix-linearity-single-resultant [move sideways from 1fff32f08ed6 to 1b916e455081]
git: Enumerating objects: 21, done.
git: Counting objects: 100% (21/21), done.
git: Delta compression using up to 16 threads
git: Compressing objects: 100% (12/12), done.
git: Writing objects: 100% (13/13), 1.96 KiB | 1.96 MiB/s, done.
git: Total 13 (delta 7), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (7/7), completed with 6 local objects.
Warning: The remote rejected the following updates:
  refs/heads/fix-linearity-single-resultant (reason: permission denied)
Hint: Try checking if you have permission to push to all the bookmarks.
Error: Failed to push some bookmarks
```

so we might just have to test this workflow by merging it to `main` with `close-pr: false` `lock-pr: false` and then wait for another generated PR to come in

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
