### PR TITLE
Perf: speed up LIKELY ramp fitting by avoiding unnecessary allocations

### DIFF
--- a/src/stcal/ramp_fitting/likely_fit.py
+++ b/src/stcal/ramp_fitting/likely_fit.py
@@ -99,7 +99,7 @@ def likely_ramp_fit(ramp_data, readnoise_2d, gain_2d, jump_data=None):
         allrateguesses = np.zeros((nrows, ncols))
 
         for row in range(nrows):
-            d2use = determine_diffs2use(row, diff, gdq)
+            d2use = determine_diffs2use(diff[:, row, :], gdq[:, row, :])
             d2use_copy = d2use.copy()  # Use to flag jumps
             if ramp_data.rejection_threshold is not None:
                 threshold_one_omit = ramp_data.rejection_threshold**2
@@ -447,19 +447,17 @@ def compute_image_info(integ_class, ramp_data):
     return {"slope": slope, "dq": dq, "var_poisson": var_p, "var_rnoise": var_r, "err": err, "chisq": chisq}
 
 
-def determine_diffs2use(row, diffs, gdq):
+def determine_diffs2use(diffs, gdq):
     """
     Compute the diffs2use mask based on DQ flags of a row.
 
     Parameters
     ----------
-    row : int
-        The current row being processed.
     diffs : ndarray
         The group differences of the data array for a given integration and row
         (ngroups-1, ncols).
     gdq : ndarray
-        The group DQ for the current integration.
+        The group DQ for a given integration and row (ngroups, ncols).
 
     Returns
     -------
@@ -467,14 +465,10 @@ def determine_diffs2use(row, diffs, gdq):
         A boolean array defining the segmented ramps for each pixel in a row.
         (ngroups-1, ncols)
     """
-    ngroups, _, ncols = gdq.shape
-    dq = np.zeros(shape=(ngroups, ncols), dtype=np.uint8)
-    dq[:, :] = gdq[:, row, :]
-    d2use_tmp = np.ones(shape=diffs.shape, dtype=np.uint8)
-    d2use = d2use_tmp[:, row]
+    d2use = np.ones(shape=diffs.shape, dtype=np.uint8)
 
-    d2use[dq[1:, :] != 0] = 0
-    d2use[dq[:-1, :] != 0] = 0
+    d2use[gdq[1:, :] != 0] = 0
+    d2use[gdq[:-1, :] != 0] = 0
 
     return d2use
 


### PR DESCRIPTION
This PR makes `determine_diffs2use` much faster; previously it was a substantial proportion of likely ramp fit runtime. The prior implementation took the full diffs cube (nresultants-1, rows, columns) and then allocated a full `ones` array in that shape, and then threw away all but the relevant row. Doing this full-cube allocation once per row was very expensive! `determine_diffs2use` only needs to operate on a single row anyway (interestingly the docstring seems to have been assuming the caller was passing just that row's `diffs` of shape (ngroups-1, ncols), but the implementation assumed the cube).

**On a synthetic 1 x 5 x 4096 x 4096 Roman WFI-sized ramp, `LIKELY` fitting decreased from 34s to 15s on my M3 mac**. Both runs report the same mean fitted rate. See a benchmark script below.

<details><summary> `benchmark.py` </summary>

```python
"""Time one LIKELY fit on synthetic data with realistic Roman WFI dimensions."""
import time
import numpy as np
from stcal.ramp_fitting.likely_fit import likely_ramp_fit
from stcal.ramp_fitting.ramp_fit_class import RampData

SIZE = 4096
RESULTANTS = 5

def main():
    """Construct one detector ramp, fit it, and report wall-clock time."""
    shape = (1, RESULTANTS, SIZE, SIZE)
    levels = np.arange(RESULTANTS, dtype=np.float32)[None, :, None, None]
    data = np.broadcast_to(100 + 20 * levels, shape).copy()
    rng = np.random.default_rng(12345)
    for resultant in range(RESULTANTS):
        noise = rng.standard_normal((SIZE, SIZE), dtype=np.float32)
        noise *= 5
        data[0, resultant] += noise
    del noise
    data[0, RESULTANTS // 2 :, ::64, ::64] += 300  # Sparse cosmic-ray steps.

    ramp = RampData()
    ramp.set_arrays(
        data,
        np.zeros(shape, dtype=np.uint8),
        np.zeros((SIZE, SIZE), dtype=np.uint32),
        np.zeros((SIZE, SIZE), dtype=np.float32),
    )
    ramp.set_meta("WFI", frame_time=3.04, group_time=15.2, groupgap=1, nframes=4)
    ramp.flags_do_not_use = 1
    ramp.flags_saturated = 2
    ramp.flags_jump_det = 4
    readnoise = np.full((SIZE, SIZE), 10, dtype=np.float32)
    gain = np.full((SIZE, SIZE), 2, dtype=np.float32)

    start = time.perf_counter()
    result = likely_ramp_fit(ramp, readnoise, gain)[0]
    elapsed = time.perf_counter() - start

    print(f"Input: 1 integration x {RESULTANTS} resultants x {SIZE} x {SIZE} pixels")
    print(f"LIKELY wall clock: {elapsed:.3f} seconds")
    print(f"Mean fitted rate: {np.nanmean(result['slope']):.9f} DN/s")

if __name__ == "__main__":
    main()
```

</details>

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->

## Tasks

- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stcal/blob/main/changes/README.rst) for instructions)
  - [ ] if your change breaks existing functionality, also add a `changes/<PR#>.breaking.rst` news fragment
- [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stcal@<branch>"`)
  - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
  - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
